### PR TITLE
Tag image with Git tag so that specific versions can be deployed

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -6,6 +6,7 @@ on:
       - "test/k6/**"
       - ".github/**"
   workflow_dispatch:
+
 jobs:
   build-test-analyze:
     name: Build and push
@@ -22,5 +23,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push image to registry
         run: |
-              docker build . --tag ghcr.io/altinn/altinn-broker:latest
-              docker push ghcr.io/altinn/altinn-broker:latest
+              # Construct the image tag using the Git hash
+              IMAGE_TAG="ghcr.io/altinn/altinn-broker:${{ github.sha }}"
+              
+              docker build . --tag $IMAGE_TAG
+              docker push $IMAGE_TAG


### PR DESCRIPTION
## Description
Tag image with Git tag so that specific versions can be deployed. Necessary to avoid container's restarting and pulling an image that has not been through the release process yet (where related infrastructure and migrations are provisioned).

See related issue.

## Related Issue(s)
- Altinn/Altinn-broker-infra#6

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
