### PR TITLE
Added simple authorization for the Hangfire dashboard

### DIFF
--- a/Test/Altinn.Broker.Tests/Data/R__Prepare_Test_Data.sql
+++ b/Test/Altinn.Broker.Tests/Data/R__Prepare_Test_Data.sql
@@ -5,4 +5,4 @@ INSERT INTO broker.storage_provider (storage_provider_id_pk, service_owner_id_fk
 VALUES (DEFAULT, '0192:991825827', NOW(), 'Altinn3Azure', 'dummy-value');
 
 INSERT INTO broker.file (file_id_pk, service_owner_id_fk, filename, checksum, sender_actor_id_fk, external_file_reference, created, storage_provider_id_fk, file_location, expiration_time)
-VALUES ('ed76ce89-3768-481a-bca1-4e4262d9098b', '0192:991825827', 'filename.txt', NULL, 1, 'external_reference', NOW(), 1, 'https://blob-storage-example', NOW() + INTERVAL '1 DAY')
+VALUES ('ed76ce89-3768-481a-bca1-4e4262d9098b', '0192:991825827', 'filename.txt', NULL, 1, 'external_reference', NOW(), 1, 'https://blob-storage-example', NOW() + INTERVAL '1 Days');

--- a/src/Altinn.Broker.Application/DependencyInjection.cs
+++ b/src/Altinn.Broker.Application/DependencyInjection.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Broker.Application.DownloadFileQuery;
+﻿using Altinn.Broker.Application.DeleteFileCommand;
+using Altinn.Broker.Application.DownloadFileQuery;
 using Altinn.Broker.Application.GetFileDetailsQuery;
 using Altinn.Broker.Application.GetFileOverviewQuery;
 using Altinn.Broker.Application.InitializeFileCommand;
@@ -17,5 +18,6 @@ public static class DependencyInjection
         services.AddScoped<GetFileDetailsQueryHandler>();
         services.AddScoped<DownloadFileQueryHandler>();
         services.AddScoped<ConfirmDownloadCommandHandler>();
+        services.AddScoped<DeleteFileCommandHandler>();
     }
 }

--- a/src/Altinn.Broker.Integrations/Altinn.Broker.Integrations.csproj
+++ b/src/Altinn.Broker.Integrations/Altinn.Broker.Integrations.csproj
@@ -11,7 +11,10 @@
     <PackageReference Include="Azure.ResourceManager" Version="1.9.0" />
     <PackageReference Include="Azure.ResourceManager.Storage" Version="1.2.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.6" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.6" />
     <PackageReference Include="Microsoft.Azure.Management.Storage" Version="25.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.Broker.Integrations/Altinn.Broker.Integrations.csproj
+++ b/src/Altinn.Broker.Integrations/Altinn.Broker.Integrations.csproj
@@ -13,12 +13,14 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.6" />
     <PackageReference Include="Hangfire.Core" Version="1.8.6" />
+    <PackageReference Include="Hangfire.PostgreSql" Version="1.20.4" />
     <PackageReference Include="Microsoft.Azure.Management.Storage" Version="25.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Altinn.Broker.Core\Altinn.Broker.Core.csproj" />
+    <ProjectReference Include="..\Altinn.Broker.Persistence\Altinn.Broker.Persistence.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Altinn.Broker.Integrations/Hangfire/DependencyInjection.cs
+++ b/src/Altinn.Broker.Integrations/Hangfire/DependencyInjection.cs
@@ -1,0 +1,40 @@
+﻿using Altinn.Broker.Persistence.Options;
+
+using Hangfire;
+using Hangfire.PostgreSql;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Altinn.Broker.Integrations.Hangfire;
+public static class DependencyInjection
+{
+    public static void ConfigureHangfireDashboard(this WebApplication app, IConfiguration config)
+    {
+        if (app.Environment.IsDevelopment())
+        {
+            app.UseHangfireDashboard();
+        }
+        else
+        {
+            var hangfireAuthOptions = new HangfireAuthorizationOptions();
+            config.GetSection(nameof(HangfireAuthorizationOptions)).Bind(hangfireAuthOptions);
+            app.UseHangfireDashboard("/hangfire", new DashboardOptions
+            {
+                Authorization = new[] { new HangfireMaintainerAuthorizationFilter(hangfireAuthOptions) }
+            });
+        }
+    }
+
+    public static void ConfigureHangfire(this IServiceCollection services, IConfiguration config)
+    {
+        var databaseOptions = new DatabaseOptions() { ConnectionString = "" };
+        config.GetSection(nameof(DatabaseOptions)).Bind(databaseOptions);
+        services.AddHangfire(config =>
+            config.UsePostgreSqlStorage(c => c.UseNpgsqlConnection(databaseOptions.ConnectionString))
+        );
+        services.AddHangfireServer();
+    }
+}

--- a/src/Altinn.Broker.Integrations/Hangfire/HangfireAuthorizationOptions.cs
+++ b/src/Altinn.Broker.Integrations/Hangfire/HangfireAuthorizationOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Altinn.Broker.Integrations.Hangfire;
+public class HangfireAuthorizationOptions
+{
+    public string TenantId { get; set; }
+    public string GroupId { get; set; }
+    public string Audience { get; set; }
+
+}

--- a/src/Altinn.Broker.Integrations/Hangfire/HangfireMaintainerAuthorizationFilter.cs
+++ b/src/Altinn.Broker.Integrations/Hangfire/HangfireMaintainerAuthorizationFilter.cs
@@ -21,7 +21,7 @@ public class HangfireMaintainerAuthorizationFilter : IDashboardAuthorizationFilt
     {
         _tenantId = hangfireAuthOptions.TenantId;
         _permittedGroup = hangfireAuthOptions.GroupId;
-        _configManager = new ConfigurationManager<OpenIdConnectConfiguration>($"https://login.microsoftonline.com/{tenantId}/v2.0/.well-known/openid-configuration", new OpenIdConnectConfigurationRetriever());
+        _configManager = new ConfigurationManager<OpenIdConnectConfiguration>($"https://login.microsoftonline.com/{_tenantId}/v2.0/.well-known/openid-configuration", new OpenIdConnectConfigurationRetriever());
         _jwtValidationParameters = new TokenValidationParameters
         {
             RequireExpirationTime = true,

--- a/src/Altinn.Broker.Integrations/Hangfire/HangfireMaintainerAuthorizationFilter.cs
+++ b/src/Altinn.Broker.Integrations/Hangfire/HangfireMaintainerAuthorizationFilter.cs
@@ -1,0 +1,57 @@
+﻿using System.IdentityModel.Tokens.Jwt;
+
+using Hangfire.Dashboard;
+
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Altinn.Broker.Integrations.Hangfire;
+
+public class HangfireMaintainerAuthorizationFilter : IDashboardAuthorizationFilter
+{
+    private static readonly string HangFireCookieName = "hangfire-dashboard";
+    private string _tenantId;
+    private string _permittedGroup;
+    private ConfigurationManager<OpenIdConnectConfiguration> _configManager;
+    private TokenValidationParameters _jwtValidationParameters;
+    private JwtSecurityTokenHandler _jwtSecurityTokenHandler = new JwtSecurityTokenHandler();
+
+    public HangfireMaintainerAuthorizationFilter(HangfireAuthorizationOptions hangfireAuthOptions)
+    {
+        _tenantId = hangfireAuthOptions.TenantId;
+        _permittedGroup = hangfireAuthOptions.GroupId;
+        _configManager = new ConfigurationManager<OpenIdConnectConfiguration>($"https://login.microsoftonline.com/{tenantId}/v2.0/.well-known/openid-configuration", new OpenIdConnectConfigurationRetriever());
+        _jwtValidationParameters = new TokenValidationParameters
+        {
+            RequireExpirationTime = true,
+            RequireSignedTokens = true,
+            ValidateAudience = true,
+            ValidateIssuer = true,
+            ValidAudience = hangfireAuthOptions.Audience,
+            ValidIssuer = $"https://sts.windows.net/{_tenantId}/",
+            ValidateLifetime = true,
+            ConfigurationManager = _configManager
+        };
+    }
+
+    public bool Authorize(DashboardContext context)
+    {
+        var httpContext = context.GetHttpContext();
+        var accessToken = httpContext.Request.Cookies[HangFireCookieName];
+        if (string.IsNullOrWhiteSpace(accessToken))
+        {
+            return false;
+        }
+        try
+        {
+            _jwtSecurityTokenHandler.ValidateToken(accessToken, _jwtValidationParameters, out var validatedToken);
+            var token = _jwtSecurityTokenHandler.ReadToken(accessToken) as JwtSecurityToken;
+            return token?.Claims.Any(claim => claim.Type == "groups" && claim.Value == _permittedGroup) ?? false;
+        }
+        catch (Exception e)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Altinn.Broker/Middlewares/RequestLoggingMiddleware.cs
+++ b/src/Altinn.Broker/Middlewares/RequestLoggingMiddleware.cs
@@ -17,7 +17,8 @@
 
         private static readonly string[] IgnoredPaths =
         {
-            "/health"
+            "/health",
+            "/hangfire"
         };
 
         public async Task Invoke(HttpContext httpContext)
@@ -25,7 +26,7 @@
             // Log request
             var requestMethod = httpContext.Request.Method;
             var requestPath = httpContext.Request.PathBase.Add(httpContext.Request.Path).ToString();
-            if (!IgnoredPaths.Contains(requestPath.ToLowerInvariant()))
+            if (!IgnoredPaths.Any(path => requestPath.ToLowerInvariant().StartsWith(path)))
             {
                 _logger.LogInformation(
                     "Request for method {RequestMethod} at {RequestPath}",
@@ -38,7 +39,7 @@
 
             // Log response
             var statusCode = httpContext.Response.StatusCode;
-            if (!IgnoredPaths.Contains(requestPath.ToLowerInvariant()))
+            if (!IgnoredPaths.Any(path => requestPath.ToLowerInvariant().StartsWith(path)))
             {
                 if (statusCode >= 200 && statusCode < 400)
                 {

--- a/src/Altinn.Broker/Program.cs
+++ b/src/Altinn.Broker/Program.cs
@@ -9,9 +9,6 @@ using Altinn.Broker.Models.Maskinporten;
 using Altinn.Broker.Persistence;
 using Altinn.Broker.Persistence.Options;
 
-using Hangfire;
-using Hangfire.PostgreSql;
-
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http.Features;
@@ -76,12 +73,7 @@ static void BuildAndRun(string[] args)
 
     app.MapControllers();
 
-    var hangfireAuthOptions = new HangfireAuthorizationOptions();
-    builder.Configuration.GetSection(nameof(HangfireAuthorizationOptions)).Bind(hangfireAuthOptions);    
-    app.UseHangfireDashboard("/hangfire", new DashboardOptions
-    {
-        Authorization = new[] { new HangfireMaintainerAuthorizationFilter(hangfireAuthOptions.TenantId, hangfireAuthOptions.GroupId) }
-    });
+    app.ConfigureHangfireDashboard(builder.Configuration);
 
     app.Run();
 }
@@ -106,12 +98,7 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
 
     services.AddHttpClient();
 
-    var databaseOptions = new DatabaseOptions() { ConnectionString = "" };
-    config.GetSection(nameof(DatabaseOptions)).Bind(databaseOptions);
-    services.AddHangfire(config =>
-        config.UsePostgreSqlStorage(c => c.UseNpgsqlConnection(databaseOptions.ConnectionString))
-    );
-    services.AddHangfireServer();
+    services.ConfigureHangfire(config);
 
     services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(options =>
     {

--- a/src/Altinn.Broker/Program.cs
+++ b/src/Altinn.Broker/Program.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using Altinn.Broker.Application;
 using Altinn.Broker.Integrations;
 using Altinn.Broker.Integrations.Azure;
+using Altinn.Broker.Integrations.Hangfire;
 using Altinn.Broker.Middlewares;
 using Altinn.Broker.Models.Maskinporten;
 using Altinn.Broker.Persistence;
@@ -74,7 +75,13 @@ static void BuildAndRun(string[] args)
     app.UseAuthorization();
 
     app.MapControllers();
-    app.UseHangfireDashboard();
+
+    var hangfireAuthOptions = new HangfireAuthorizationOptions();
+    builder.Configuration.GetSection(nameof(HangfireAuthorizationOptions)).Bind(hangfireAuthOptions);    
+    app.UseHangfireDashboard("/hangfire", new DashboardOptions
+    {
+        Authorization = new[] { new HangfireMaintainerAuthorizationFilter(hangfireAuthOptions.TenantId, hangfireAuthOptions.GroupId) }
+    });
 
     app.Run();
 }


### PR DESCRIPTION
## Description
Added simple auth for Hangfire dashboard so that we can use it when deployed for monitoring background jobs. It is not a very elegant, but we probably won't go in there often so the ~30second process to get access is acceptable.
The process is described in altinn-broker-infra repository.

<img width="962" alt="image" src="https://github.com/Altinn/altinn-broker/assets/36594318/275a47c8-79be-4608-a009-3f5f8d15f5fa">


## Related Issue(s)
- #222 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
