### PR TITLE
Updated to include webhook subscription

### DIFF
--- a/Test/Altinn.Broker.Tests/Altinn.Broker.Tests.csproj
+++ b/Test/Altinn.Broker.Tests/Altinn.Broker.Tests.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Data\*.json">
+    <Content Include="..\..\Test\Altinn.Broker.Tests\Data\*.json">
     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Test/Altinn.Broker.Tests/Altinn.Broker.Tests.csproj
+++ b/Test/Altinn.Broker.Tests/Altinn.Broker.Tests.csproj
@@ -23,4 +23,11 @@
   <ItemGroup>
 	  <ProjectReference Include="..\..\src\Altinn.Broker\Altinn.Broker.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Data\*.json">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/Test/Altinn.Broker.Tests/Data/MalwareScanResult_Malicious.json
+++ b/Test/Altinn.Broker.Tests/Data/MalwareScanResult_Malicious.json
@@ -1,6 +1,6 @@
 {
   "data": {
-      "blobUri": "https://aitest0192991825827sa.blob.core.windows.net/brokerfiles/EICAR antivirus test file.txt",
+      "blobUri": "https://aitest0192991825827sa.blob.core.windows.net/brokerfiles/--FILEID--",
       "correlationId": "2ee9f258-c96a-4982-9e6e-16b8485d71da",
       "eTag": "0x8DBF7C56A86430D",
       "scanFinishedTimeUtc": "2023-12-08T08:12:31.9933275Z",
@@ -17,6 +17,6 @@
   "eventType": "Microsoft.Security.MalwareScanningResult",
   "id": "2ee9f258-c96a-4982-9e6e-16b8485d71da",
   "metadataVersion": "1",
-  "subject": "storageAccounts/aitest0192991825827sa/containers/brokerfiles/blobs/EICAR antivirus test file.txt",
+  "subject": "storageAccounts/aitest0192991825827sa/containers/brokerfiles/blobs/--FILEID--",
   "topic": "/subscriptions/81cc3a6b-dfdf-49c7-96f0-3efddb159356/resourceGroups/serviceowner-test-0192-991825827-rg/providers/Microsoft.EventGrid/topics/test-broker-defenderresults"
 }

--- a/Test/Altinn.Broker.Tests/Data/MalwareScanResult_NoThreatFound.json
+++ b/Test/Altinn.Broker.Tests/Data/MalwareScanResult_NoThreatFound.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "blobUri": "https://aitest0192991825827sa.blob.core.windows.net/brokerfiles/emptydoctest.txt",
+        "blobUri": "https://aitest0192991825827sa.blob.core.windows.net/brokerfiles/--FILEID--",
         "correlationId": "21c48159-e5ef-4376-ba96-4f8d6e0f1c7f",
         "eTag": "0x8DBF7C550ADB6E7",
         "scanFinishedTimeUtc": "2023-12-08T08:11:44.9457492Z",
@@ -12,6 +12,6 @@
     "eventType": "Microsoft.Security.MalwareScanningResult",
     "id": "21c48159-e5ef-4376-ba96-4f8d6e0f1c7f",
     "metadataVersion": "1",
-    "subject": "storageAccounts/aitest0192991825827sa/containers/brokerfiles/blobs/emptydoctest.txt",
+    "subject": "storageAccounts/aitest0192991825827sa/containers/brokerfiles/blobs/--FILEID--",
     "topic": "/subscriptions/81cc3a6b-dfdf-49c7-96f0-3efddb159356/resourceGroups/serviceowner-test-0192-991825827-rg/providers/Microsoft.EventGrid/topics/test-broker-defenderresults"
 }

--- a/Test/Altinn.Broker.Tests/Data/WebHookSubscriptionValidationTest.json
+++ b/Test/Altinn.Broker.Tests/Data/WebHookSubscriptionValidationTest.json
@@ -1,0 +1,13 @@
+[{
+    "id": "2d1781af-3a4c-4d7c-bd0c-e34b19da4e66",
+    "topic": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "subject": "",
+    "data": {
+      "validationCode": "512d38b6-c7b8-40c8-89fe-f46f9e9622b6",
+      "validationUrl": "https://www.contoso.com/"
+    },
+    "eventType": "Microsoft.EventGrid.SubscriptionValidationEvent",
+    "eventTime": "2018-01-25T22:12:19.4556811Z",
+    "metadataVersion": "1",
+    "dataVersion": "1"
+}]

--- a/Test/Altinn.Broker.Tests/MalwareScanResultControllerTests.cs
+++ b/Test/Altinn.Broker.Tests/MalwareScanResultControllerTests.cs
@@ -108,4 +108,15 @@ public class MalwareScanReulstControllerTests : IClassFixture<CustomWebApplicati
         Assert.NotNull(scannedFile);
         Assert.True(scannedFile.FileStatus == FileStatusExt.Failed);
     }
+
+    [Fact]
+    public async Task MalwareScanWebhookSubscription_OK()
+    {
+        // Webhook
+        string jsonBody = "[{\"id\":\"2d1781af-3a4c-4d7c-bd0c-e34b19da4e66\",\"topic\":\"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",\"subject\":\"\",\"data\":{\"validationCode\":\"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\",\"validationUrl\":\"https://www.contoso.com/\"},\"eventType\":\"Microsoft.EventGrid.SubscriptionValidationEvent\",\"eventTime\":\"2018-01-25T22:12:19.4556811Z\",\"metadataVersion\":\"1\",\"dataVersion\":\"1\"}]";
+        var result = await _webhookClient.PostAsync("broker/api/v1/webhooks/malwarescanresults", new StringContent(jsonBody, Encoding.UTF8, "application/json"));
+        string rs = result.Content.ReadAsStringAsync().Result;
+        Assert.Equal(System.Net.HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal("{\"validationResponse\":\"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\"}", rs);
+    }
 }

--- a/Test/Altinn.Broker.Tests/MalwareScanResultControllerTests.cs
+++ b/Test/Altinn.Broker.Tests/MalwareScanResultControllerTests.cs
@@ -62,8 +62,9 @@ public class MalwareScanReulstControllerTests : IClassFixture<CustomWebApplicati
             Assert.True(uploadResponse.IsSuccessStatusCode);
         }
 
-        // Webhook
-        string jsonBody = "{\"data\":{\"blobUri\":\"https://aitest0192991825827sa.blob.core.windows.net/brokerfiles/" + fileId + "\",\"correlationId\":\"21c48159-e5ef-4376-ba96-4f8d6e0f1c7f\",\"eTag\":\"0x8DBF7C550ADB6E7\",\"scanFinishedTimeUtc\":\"2023-12-08T08:11:44.9457492Z\",\"scanResultDetails\":null,\"scanResultType\":\"No threats found\"},\"dataVersion\":\"1.0\",\"eventTime\":\"2023-12-08T08:11:44.9464641Z\",\"eventType\":\"Microsoft.Security.MalwareScanningResult\",\"id\":\"21c48159-e5ef-4376-ba96-4f8d6e0f1c7f\",\"metadataVersion\":\"1\",\"subject\":\"storageAccounts/aitest0192991825827sa/containers/brokerfiles/blobs/emptydoctest.txt\",\"topic\":\"/subscriptions/81cc3a6b-dfdf-49c7-96f0-3efddb159356/resourceGroups/serviceowner-test-0192-991825827-rg/providers/Microsoft.EventGrid/topics/test-broker-defenderresults\"}";
+        // Webhook        
+        string jsonBody = File.ReadAllText("Data/MalwareScanResult_NoThreatFound.json");
+        jsonBody = jsonBody.Replace("--FILEID--", fileId);
         var result = await _webhookClient.PostAsync("broker/api/v1/webhooks/malwarescanresults", new StringContent(jsonBody, Encoding.UTF8, "application/json"));
 
         Assert.Equal(System.Net.HttpStatusCode.OK, result.StatusCode);
@@ -97,7 +98,8 @@ public class MalwareScanReulstControllerTests : IClassFixture<CustomWebApplicati
         Assert.True(fileAfterUpload.FileStatus == FileStatusExt.Published); // When running integration test this happens instantly as of now.
 
         // Webhook
-        string jsonBody = "{\"data\":{\"blobUri\":\"https://aitest0192991825827sa.blob.core.windows.net/brokerfiles/" + fileId + "\",\"correlationId\":\"2ee9f258-c96a-4982-9e6e-16b8485d71da\",\"eTag\":\"0x8DBF7C56A86430D\",\"scanFinishedTimeUtc\":\"2023-12-08T08:12:31.9933275Z\",\"scanResultDetails\":{\"malwareNamesFound\":[\"Virus:DOS/EICAR_Test_File\"],\"sha256\":\"275A021BBFB6489E54D471899F7DB9D1663FC695EC2FE2A2C4538AABF651FD0F\"},\"scanResultType\":\"Malicious\"},\"dataVersion\":\"1.0\",\"eventTime\":\"2023-12-08T08:12:31.9939079Z\",\"eventType\":\"Microsoft.Security.MalwareScanningResult\",\"id\":\"2ee9f258-c96a-4982-9e6e-16b8485d71da\",\"metadataVersion\":\"1\",\"subject\":\"storageAccounts/aitest0192991825827sa/containers/brokerfiles/blobs/EICAR antivirus test file.txt\",\"topic\":\"/subscriptions/81cc3a6b-dfdf-49c7-96f0-3efddb159356/resourceGroups/serviceowner-test-0192-991825827-rg/providers/Microsoft.EventGrid/topics/test-broker-defenderresults\"}";
+        string jsonBody = File.ReadAllText("Data/MalwareScanResult_Malicious.json");
+        jsonBody = jsonBody.Replace("--FILEID--", fileId);
         var result = await _webhookClient.PostAsync("broker/api/v1/webhooks/malwarescanresults", new StringContent(jsonBody, Encoding.UTF8, "application/json"));
 
         Assert.Equal(System.Net.HttpStatusCode.OK, result.StatusCode);
@@ -113,7 +115,7 @@ public class MalwareScanReulstControllerTests : IClassFixture<CustomWebApplicati
     public async Task MalwareScanWebhookSubscription_OK()
     {
         // Webhook
-        string jsonBody = "[{\"id\":\"2d1781af-3a4c-4d7c-bd0c-e34b19da4e66\",\"topic\":\"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",\"subject\":\"\",\"data\":{\"validationCode\":\"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\",\"validationUrl\":\"https://www.contoso.com/\"},\"eventType\":\"Microsoft.EventGrid.SubscriptionValidationEvent\",\"eventTime\":\"2018-01-25T22:12:19.4556811Z\",\"metadataVersion\":\"1\",\"dataVersion\":\"1\"}]";
+        string jsonBody = File.ReadAllText("Data/WebHookSubscriptionValidationTest.json");
         var result = await _webhookClient.PostAsync("broker/api/v1/webhooks/malwarescanresults", new StringContent(jsonBody, Encoding.UTF8, "application/json"));
         string rs = result.Content.ReadAsStringAsync().Result;
         Assert.Equal(System.Net.HttpStatusCode.OK, result.StatusCode);

--- a/Test/Altinn.Broker.Tests/MalwareScanResultControllerTests.cs
+++ b/Test/Altinn.Broker.Tests/MalwareScanResultControllerTests.cs
@@ -117,7 +117,7 @@ public class MalwareScanReulstControllerTests : IClassFixture<CustomWebApplicati
         // Webhook
         string jsonBody = File.ReadAllText("Data/WebHookSubscriptionValidationTest.json");
         var result = await _webhookClient.PostAsync("broker/api/v1/webhooks/malwarescanresults", new StringContent(jsonBody, Encoding.UTF8, "application/json"));
-        string rs = result.Content.ReadAsStringAsync().Result;
+        string rs = await result.Content.ReadAsStringAsync();
         Assert.Equal(System.Net.HttpStatusCode.OK, result.StatusCode);
         Assert.Equal("{\"validationResponse\":\"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\"}", rs);
     }

--- a/Test/Altinn.Broker.Tests/MalwareScanResultControllerTests.cs
+++ b/Test/Altinn.Broker.Tests/MalwareScanResultControllerTests.cs
@@ -59,7 +59,8 @@ public class MalwareScanReulstControllerTests : IClassFixture<CustomWebApplicati
         {
             content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
             var uploadResponse = await _senderClient.PostAsync($"broker/api/v1/file/{fileId}/upload", content);
-            Assert.True(uploadResponse.IsSuccessStatusCode);
+            string response = await uploadResponse.Content.ReadAsStringAsync();
+            Assert.True(uploadResponse.IsSuccessStatusCode, "Response: " + response);
         }
 
         // Webhook        

--- a/src/Altinn.Broker/Altinn.Broker.csproj
+++ b/src/Altinn.Broker/Altinn.Broker.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.4" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="2.16.0" />

--- a/src/Altinn.Broker/Altinn.Broker.csproj
+++ b/src/Altinn.Broker/Altinn.Broker.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.6" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.8.0" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.4" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.3.0" />     
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />

--- a/src/Altinn.Broker/Altinn.Broker.csproj
+++ b/src/Altinn.Broker/Altinn.Broker.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -23,6 +23,7 @@
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.21.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.Broker/Controllers/MalwareScanResultsController.cs
+++ b/src/Altinn.Broker/Controllers/MalwareScanResultsController.cs
@@ -1,11 +1,17 @@
 using System.Net;
+using System.Text.Json.Serialization;
 
 using Altinn.Broker.Core.Repositories;
 using Altinn.Broker.Webhooks.Models;
 
+using Azure.Messaging.EventGrid;
+using Azure.Messaging.EventGrid.SystemEvents;
+
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+
+using Newtonsoft.Json;
 
 namespace Altinn.Broker.Webhooks.Controllers
 {
@@ -22,35 +28,51 @@ namespace Altinn.Broker.Webhooks.Controllers
             _fileStatusRepository = fileStatusRepository;
         }
 
-        /// <summary>
-        /// Used to receive Malware Scan Results from Azure Defender.
-        /// </summary>
-        /// <returns>Should always return 200 OK when file status has been updated by Scan Result</returns>
         [HttpPost]
-        public ActionResult ProcessMalwareScanResults(EventMessage eventMessage)
-        {
-            this.Response.StatusCode = (int)HttpStatusCode.OK;
-            string blobUri = eventMessage.Data.BlobUri;
-            string fileIdFromUri = blobUri.Split("/").Last();
-
-            string result = eventMessage.Data.ScanResultType;
-            Guid fileId = Guid.Parse(fileIdFromUri);
-
-            if (fileId == Guid.Empty)
+        public ActionResult ProcessMalwareScanResult()
+        {            
+            BinaryData events = BinaryData.FromStreamAsync(this.Request.Body).Result;
+            EventGridEvent[] eventGridEvents = EventGridEvent.ParseMany(events);
+            foreach(EventGridEvent eventGridEvent in eventGridEvents)
             {
-                return NotFound();
+                if(eventGridEvent.TryGetSystemEventData(out object eventData))
+                {
+                    if(eventData is SubscriptionValidationEventData subscriptionValidationEventData)
+                    {
+                        // TODO: validate that eventGridEvent WebHook subscription is actually from an Altinn Azure Defender EventGrid
+                        var responseData = new
+                        {
+                            ValidationResponse = subscriptionValidationEventData.ValidationCode
+                        };
+                        return new OkObjectResult(responseData);
+                    }
+                }
+                else if (eventGridEvent.EventType == "Microsoft.Security.MalwareScanningResult")
+                {
+                    string jsonString = eventGridEvent.Data.ToString();
+                    ScanResultData result = JsonConvert.DeserializeObject<ScanResultData>(jsonString);
+                    string fileIdFromUri = result.BlobUri.Split("/")
+                                                         .Last() ?? Guid.Empty.ToString();
+                    Guid fileId = Guid.Parse(fileIdFromUri);                    
+                    if (fileId == Guid.Empty)
+                    {
+                        return NotFound();
+                    }
+
+                    if (result.ScanResultType.Equals("malicious", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        _fileStatusRepository.InsertFileStatus(fileId, Core.Domain.Enums.FileStatus.Failed);
+                        return Ok();
+                    }
+                    else
+                    {
+                        _fileStatusRepository.InsertFileStatus(fileId, Core.Domain.Enums.FileStatus.Published);
+                        return Ok();
+                    }
+                }
             }
 
-            if (result.Equals("malicious", StringComparison.InvariantCultureIgnoreCase))
-            {
-                _fileStatusRepository.InsertFileStatus(fileId, Core.Domain.Enums.FileStatus.Failed);
-                return Ok();
-            }
-            else
-            {
-                _fileStatusRepository.InsertFileStatus(fileId, Core.Domain.Enums.FileStatus.Published);
-                return Ok();
-            }
+            return Ok();
         }
     }
 }

--- a/src/Altinn.Broker/Controllers/MalwareScanResultsController.cs
+++ b/src/Altinn.Broker/Controllers/MalwareScanResultsController.cs
@@ -30,14 +30,14 @@ namespace Altinn.Broker.Webhooks.Controllers
 
         [HttpPost]
         public ActionResult ProcessMalwareScanResult()
-        {            
+        {
             BinaryData events = BinaryData.FromStreamAsync(this.Request.Body).Result;
             EventGridEvent[] eventGridEvents = EventGridEvent.ParseMany(events);
-            foreach(EventGridEvent eventGridEvent in eventGridEvents)
+            foreach (EventGridEvent eventGridEvent in eventGridEvents)
             {
-                if(eventGridEvent.TryGetSystemEventData(out object eventData))
+                if (eventGridEvent.TryGetSystemEventData(out object eventData))
                 {
-                    if(eventData is SubscriptionValidationEventData subscriptionValidationEventData)
+                    if (eventData is SubscriptionValidationEventData subscriptionValidationEventData)
                     {
                         // TODO: validate that eventGridEvent WebHook subscription is actually from an Altinn Azure Defender EventGrid
                         var responseData = new
@@ -53,7 +53,7 @@ namespace Altinn.Broker.Webhooks.Controllers
                     ScanResultData result = JsonConvert.DeserializeObject<ScanResultData>(jsonString);
                     string fileIdFromUri = result.BlobUri.Split("/")
                                                          .Last() ?? Guid.Empty.ToString();
-                    Guid fileId = Guid.Parse(fileIdFromUri);                    
+                    Guid fileId = Guid.Parse(fileIdFromUri);
                     if (fileId == Guid.Empty)
                     {
                         return NotFound();


### PR DESCRIPTION
Updated Webhook for malware scanning to include handling of subscription.

## Description
The existing webhook functionality only handled the actual update of file status based on malware scan result.
This update will handle subscription requests so that Azure can actually connect to the webhook.

## Related Issue(s)
- #220

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
