### PR TITLE
Expanded GetFiles / File Search with RecipientFileStatus

### DIFF
--- a/Test/Altinn.Broker.Tests/FileControllerTests.cs
+++ b/Test/Altinn.Broker.Tests/FileControllerTests.cs
@@ -235,4 +235,60 @@ public class FileControllerTests : IClassFixture<CustomWebApplicationFactory>
         // Assert
         Assert.Contains(fileId, contentstring);
     }
+
+    [Fact]
+    public async Task Search_SearchFileWith_RecipientStatus_Success()
+    {
+        // Arrange
+        string status = "Published";
+        string recipientStatus = "Initialized";       
+        var initializeFileResponse = await _senderClient.PostAsJsonAsync("broker/api/v1/file", FileInitializeExtTestFactory.BasicFile());        
+        var fileId = await initializeFileResponse.Content.ReadAsStringAsync();
+        var initializedFile = await _senderClient.GetFromJsonAsync<FileOverviewExt>($"broker/api/v1/file/{fileId}", _responseSerializerOptions);
+        Assert.NotNull(initializedFile);
+        var uploadedFileBytes = Encoding.UTF8.GetBytes("This is the contents of the uploaded file");
+        using (var content = new ByteArrayContent(uploadedFileBytes))
+        {
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            var uploadResponse = await _senderClient.PostAsync($"broker/api/v1/file/{fileId}/upload", content);
+            Assert.True(uploadResponse.IsSuccessStatusCode);
+        }
+        var uploadedFile = await _senderClient.GetFromJsonAsync<FileOverviewExt>($"broker/api/v1/file/{fileId}", _responseSerializerOptions);
+
+        // Act        
+        var searchResult = await _recipientClient.GetAsync($"broker/api/v1/file?status={status}&recipientStatus={recipientStatus}");
+        string contentstring = await searchResult.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Contains(fileId, contentstring);
+    }
+
+    [Fact]
+    public async Task Search_SearchFileWith_RecipientStatus_NotFound()
+    {
+        // Arrange
+        string status = "Published";
+        string recipientStatus = "DownloadConfirmed";
+        DateTimeOffset dateTimeFrom = DateTime.Now.AddMinutes(-2);
+        var initializeFileResponse = await _senderClient.PostAsJsonAsync("broker/api/v1/file", FileInitializeExtTestFactory.BasicFile());
+        DateTimeOffset dateTimeTo = DateTime.Now.AddMinutes(2);
+        var fileId = await initializeFileResponse.Content.ReadAsStringAsync();
+        var initializedFile = await _senderClient.GetFromJsonAsync<FileOverviewExt>($"broker/api/v1/file/{fileId}", _responseSerializerOptions);
+        Assert.NotNull(initializedFile);
+        var uploadedFileBytes = Encoding.UTF8.GetBytes("This is the contents of the uploaded file");
+        using (var content = new ByteArrayContent(uploadedFileBytes))
+        {
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            var uploadResponse = await _senderClient.PostAsync($"broker/api/v1/file/{fileId}/upload", content);
+            Assert.True(uploadResponse.IsSuccessStatusCode);
+        }
+        var uploadedFile = await _senderClient.GetFromJsonAsync<FileOverviewExt>($"broker/api/v1/file/{fileId}", _responseSerializerOptions);
+
+        // Act        
+        var searchResult = await _recipientClient.GetAsync($"broker/api/v1/file?status={status}&recipientStatus={recipientStatus}");
+        string contentstring = await searchResult.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.DoesNotContain(fileId, contentstring);
+    }
 }

--- a/Test/Altinn.Broker.Tests/FileControllerTests.cs
+++ b/Test/Altinn.Broker.Tests/FileControllerTests.cs
@@ -241,8 +241,8 @@ public class FileControllerTests : IClassFixture<CustomWebApplicationFactory>
     {
         // Arrange
         string status = "Published";
-        string recipientStatus = "Initialized";       
-        var initializeFileResponse = await _senderClient.PostAsJsonAsync("broker/api/v1/file", FileInitializeExtTestFactory.BasicFile());        
+        string recipientStatus = "Initialized";
+        var initializeFileResponse = await _senderClient.PostAsJsonAsync("broker/api/v1/file", FileInitializeExtTestFactory.BasicFile());
         var fileId = await initializeFileResponse.Content.ReadAsStringAsync();
         var initializedFile = await _senderClient.GetFromJsonAsync<FileOverviewExt>($"broker/api/v1/file/{fileId}", _responseSerializerOptions);
         Assert.NotNull(initializedFile);
@@ -255,7 +255,7 @@ public class FileControllerTests : IClassFixture<CustomWebApplicationFactory>
         }
         var uploadedFile = await _senderClient.GetFromJsonAsync<FileOverviewExt>($"broker/api/v1/file/{fileId}", _responseSerializerOptions);
 
-        // Act        
+        // Act
         var searchResult = await _recipientClient.GetAsync($"broker/api/v1/file?status={status}&recipientStatus={recipientStatus}");
         string contentstring = await searchResult.Content.ReadAsStringAsync();
 
@@ -284,7 +284,7 @@ public class FileControllerTests : IClassFixture<CustomWebApplicationFactory>
         }
         var uploadedFile = await _senderClient.GetFromJsonAsync<FileOverviewExt>($"broker/api/v1/file/{fileId}", _responseSerializerOptions);
 
-        // Act        
+        // Act
         var searchResult = await _recipientClient.GetAsync($"broker/api/v1/file?status={status}&recipientStatus={recipientStatus}");
         string contentstring = await searchResult.Content.ReadAsStringAsync();
 

--- a/src/Altinn.Broker.Application/GetFilesQuery/GetFilesQueryHandler.cs
+++ b/src/Altinn.Broker.Application/GetFilesQuery/GetFilesQueryHandler.cs
@@ -36,7 +36,7 @@ public class GetFilesQueryHandler : IHandler<GetFilesQueryRequest, List<Guid>>
         {
             return new List<Guid>();
         }
-        
+
         FileSearchEntity fileSearchEntity = new()
         {
             Actor = callingActor,
@@ -61,6 +61,6 @@ public class GetFilesQueryHandler : IHandler<GetFilesQueryRequest, List<Guid>>
         else
         {
             return await _fileRepository.GetFilesAssociatedWithActor(fileSearchEntity);
-        }        
+        }
     }
 }

--- a/src/Altinn.Broker.Application/GetFilesQuery/GetFilesQueryHandler.cs
+++ b/src/Altinn.Broker.Application/GetFilesQuery/GetFilesQueryHandler.cs
@@ -1,5 +1,6 @@
 using Altinn.Broker.Core.Application;
 using Altinn.Broker.Core.Domain;
+using Altinn.Broker.Core.Domain.Enums;
 using Altinn.Broker.Core.Repositories;
 
 using Microsoft.Extensions.Logging;
@@ -35,7 +36,7 @@ public class GetFilesQueryHandler : IHandler<GetFilesQueryRequest, List<Guid>>
         {
             return new List<Guid>();
         }
-
+        
         FileSearchEntity fileSearchEntity = new()
         {
             Actor = callingActor,
@@ -52,7 +53,14 @@ public class GetFilesQueryHandler : IHandler<GetFilesQueryRequest, List<Guid>>
             fileSearchEntity.To = new DateTimeOffset(request.To.Value.UtcDateTime, TimeSpan.Zero);
         }
 
-        var files = await _fileRepository.GetFilesAssociatedWithActor(fileSearchEntity);
-        return files;
+        if (request.RecipientStatus.HasValue)
+        {
+            fileSearchEntity.RecipientStatus = request.RecipientStatus;
+            return await _fileRepository.GetFilesForRecipientWithRecipientStatus(fileSearchEntity);
+        }
+        else
+        {
+            return await _fileRepository.GetFilesAssociatedWithActor(fileSearchEntity);
+        }        
     }
 }

--- a/src/Altinn.Broker.Application/GetFilesQuery/GetFilesQueryRequest.cs
+++ b/src/Altinn.Broker.Application/GetFilesQuery/GetFilesQueryRequest.cs
@@ -7,6 +7,7 @@ public class GetFilesQueryRequest
     public string Consumer { get; set; }
     public string Supplier { get; set; }
     public FileStatus? Status { get; set; }
+    public ActorFileStatus? RecipientStatus { get; set; }
     public DateTimeOffset? From { get; set; }
     public DateTimeOffset? To { get; set; }
 }

--- a/src/Altinn.Broker.Core/Domain/FileSearchEntity.cs
+++ b/src/Altinn.Broker.Core/Domain/FileSearchEntity.cs
@@ -6,6 +6,7 @@ public class FileSearchEntity
 {
     public ActorEntity Actor { get; set; }
     public FileStatus? Status { get; set; }
+    public ActorFileStatus? RecipientStatus { get; set; }
     public DateTimeOffset? From { get; set; }
     public DateTimeOffset? To { get; set; }
 }

--- a/src/Altinn.Broker.Core/Repositories/IFileRepository.cs
+++ b/src/Altinn.Broker.Core/Repositories/IFileRepository.cs
@@ -15,6 +15,7 @@ public interface IFileRepository
         string? checksum);
     Task<Domain.FileEntity?> GetFile(Guid fileId);
     Task<List<Guid>> GetFilesAssociatedWithActor(FileSearchEntity fileSearch);
+    Task<List<Guid>> GetFilesForRecipientWithRecipientStatus(FileSearchEntity fileSearch);
     Task SetStorageReference(
         Guid fileId,
         long storageProviderId,

--- a/src/Altinn.Broker.Persistence/Repositories/FileRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileRepository.cs
@@ -168,7 +168,7 @@ public class FileRepository : IFileRepository
         commandString.AppendLine("SELECT DISTINCT afs.file_id_fk, 'Recipient'");
         commandString.AppendLine("FROM broker.actor_file_status afs ");
         commandString.AppendLine("INNER JOIN broker.file f on f.file_id_pk = afs.file_id_fk");
-        commandString.AppendLine("INNER JOIN LATERAL (SELECT fs.file_status_description_id_fk FROM broker.file_status fs where fs.file_id_fk = f.file_id_pk ORDER BY fs.file_status_id_pk desc LIMIT 1 ) AS filestatus ON true");        
+        commandString.AppendLine("INNER JOIN LATERAL (SELECT fs.file_status_description_id_fk FROM broker.file_status fs where fs.file_id_fk = f.file_id_pk ORDER BY fs.file_status_id_pk desc LIMIT 1 ) AS filestatus ON true");
         commandString.AppendLine("WHERE afs.actor_id_fk = @actorId");
         if (fileSearch.Status.HasValue)
         {
@@ -266,7 +266,7 @@ public class FileRepository : IFileRepository
         StringBuilder commandString = new StringBuilder();
         commandString.AppendLine("SELECT DISTINCT f.file_id_pk");
         commandString.AppendLine("FROM broker.file f");
-        commandString.AppendLine("INNER JOIN LATERAL (SELECT afs.actor_file_status_id_fk FROM broker.actor_file_status afs WHERE afs.file_id_fk = f.file_id_pk AND afs.actor_id_fk = @recipientId ORDER BY afs.actor_file_status_id_fk desc LIMIT 1) AS recipientfilestatus ON true");        
+        commandString.AppendLine("INNER JOIN LATERAL (SELECT afs.actor_file_status_id_fk FROM broker.actor_file_status afs WHERE afs.file_id_fk = f.file_id_pk AND afs.actor_id_fk = @recipientId ORDER BY afs.actor_file_status_id_fk desc LIMIT 1) AS recipientfilestatus ON true");
         commandString.AppendLine("INNER JOIN LATERAL (SELECT fs.file_status_description_id_fk FROM broker.file_status fs where fs.file_id_fk = f.file_id_pk ORDER BY fs.file_status_id_pk desc LIMIT 1 ) AS filestatus ON true");
         commandString.AppendLine("WHERE actor_file_status_id_fk = @recipientFileStatus");
         if (fileSearch.Status.HasValue)

--- a/src/Altinn.Broker.Persistence/Repositories/FileRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileRepository.cs
@@ -168,7 +168,7 @@ public class FileRepository : IFileRepository
         commandString.AppendLine("SELECT DISTINCT afs.file_id_fk, 'Recipient'");
         commandString.AppendLine("FROM broker.actor_file_status afs ");
         commandString.AppendLine("INNER JOIN broker.file f on f.file_id_pk = afs.file_id_fk");
-        commandString.AppendLine("INNER JOIN LATERAL (SELECT fs.file_status_description_id_fk FROM broker.file_status fs where fs.file_id_fk = f.file_id_pk ORDER BY fs.file_status_id_pk desc LIMIT 1 ) AS filestatus ON true");
+        commandString.AppendLine("INNER JOIN LATERAL (SELECT fs.file_status_description_id_fk FROM broker.file_status fs where fs.file_id_fk = f.file_id_pk ORDER BY fs.file_status_id_pk desc LIMIT 1 ) AS filestatus ON true");        
         commandString.AppendLine("WHERE afs.actor_id_fk = @actorId");
         if (fileSearch.Status.HasValue)
         {
@@ -247,6 +247,57 @@ public class FileRepository : IFileRepository
                 command.Parameters.AddWithValue("@To", fileSearch.To);
             if (fileSearch.Status.HasValue)
                 command.Parameters.AddWithValue("@fileStatus", (int)fileSearch.Status);
+
+            var files = new List<Guid>();
+            using (var reader = await command.ExecuteReaderAsync())
+            {
+                while (await reader.ReadAsync())
+                {
+                    var fileId = reader.GetGuid(0);
+                    files.Add(fileId);
+                }
+            }
+            return files;
+        }
+    }
+
+    public async Task<List<Guid>> GetFilesForRecipientWithRecipientStatus(FileSearchEntity fileSearch)
+    {
+        StringBuilder commandString = new StringBuilder();
+        commandString.AppendLine("SELECT DISTINCT f.file_id_pk");
+        commandString.AppendLine("FROM broker.file f");
+        commandString.AppendLine("INNER JOIN LATERAL (SELECT afs.actor_file_status_id_fk FROM broker.actor_file_status afs WHERE afs.file_id_fk = f.file_id_pk AND afs.actor_id_fk = @recipientId ORDER BY afs.actor_file_status_id_fk desc LIMIT 1) AS recipientfilestatus ON true");        
+        commandString.AppendLine("INNER JOIN LATERAL (SELECT fs.file_status_description_id_fk FROM broker.file_status fs where fs.file_id_fk = f.file_id_pk ORDER BY fs.file_status_id_pk desc LIMIT 1 ) AS filestatus ON true");
+        commandString.AppendLine("WHERE actor_file_status_id_fk = @recipientFileStatus");
+        if (fileSearch.Status.HasValue)
+        {
+            commandString.AppendLine("AND file_status_description_id_fk = @fileStatus");
+        }
+        if (fileSearch.From.HasValue && fileSearch.To.HasValue)
+        {
+            commandString.AppendLine("AND f.created between @from AND @to");
+        }
+        else if (fileSearch.From.HasValue)
+        {
+            commandString.AppendLine("AND f.created > @from");
+        }
+        else if (fileSearch.To.HasValue)
+        {
+            commandString.AppendLine("AND f.created < @to");
+        }
+
+        await using (var command = await _connectionProvider.CreateCommand(
+            commandString.ToString()))
+        {
+            command.Parameters.AddWithValue("@recipientId", fileSearch.Actor.ActorId);
+            if (fileSearch.From.HasValue)
+                command.Parameters.AddWithValue("@From", fileSearch.From);
+            if (fileSearch.To.HasValue)
+                command.Parameters.AddWithValue("@To", fileSearch.To);
+            if (fileSearch.Status.HasValue)
+                command.Parameters.AddWithValue("@fileStatus", (int)fileSearch.Status);
+            if (fileSearch.RecipientStatus.HasValue)
+                command.Parameters.AddWithValue("@recipientFileStatus", (int)fileSearch.RecipientStatus);
 
             var files = new List<Guid>();
             using (var reader = await command.ExecuteReaderAsync())

--- a/src/Altinn.Broker/Controllers/FileController.cs
+++ b/src/Altinn.Broker/Controllers/FileController.cs
@@ -184,9 +184,10 @@ namespace Altinn.Broker.Controllers
         /// </summary>
         /// <returns></returns>
         [HttpGet]
-        [Authorize(Policy = "Sender")]
+        [Authorize(Policy = "SenderOrRecipient")]
         public async Task<ActionResult<List<Guid>>> GetFiles(
             [FromQuery] FileStatusExt? status,
+            [FromQuery] RecipientFileStatusExt? recipientStatus,
             [FromQuery] DateTimeOffset? from,
             [FromQuery] DateTimeOffset? to,
             [ModelBinder(typeof(MaskinportenModelBinder))] MaskinportenToken token,
@@ -199,6 +200,7 @@ namespace Altinn.Broker.Controllers
                 Consumer = token.Consumer,
                 Supplier = token.Supplier,
                 Status = status is not null ? (FileStatus)status : null,
+                RecipientStatus = recipientStatus is not null ? (ActorFileStatus)recipientStatus : null,
                 From = from,
                 To = to
             });

--- a/src/Altinn.Broker/Controllers/LegacyFileController.cs
+++ b/src/Altinn.Broker/Controllers/LegacyFileController.cs
@@ -100,6 +100,7 @@ namespace Altinn.Broker.Controllers
         [HttpGet]
         public async Task<ActionResult<List<Guid>>> GetFiles(
             [FromQuery] FileStatusExt? status,
+            [FromQuery] RecipientFileStatusExt? recipientStatus,
             [FromQuery] DateTimeOffset? from,
             [FromQuery] DateTimeOffset? to,
             [ModelBinder(typeof(MaskinportenModelBinder))] MaskinportenToken token,

--- a/src/Altinn.Broker/Program.cs
+++ b/src/Altinn.Broker/Program.cs
@@ -141,8 +141,9 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
 
     services.AddAuthorization(options =>
     {
-        options.AddPolicy("Sender", policy => policy.RequireClaim("scope", ["altinn:broker.write"]));
+        options.AddPolicy("Sender", policy => policy.RequireClaim("scope", ["altinn:broker.write", "altinn:broker.write altinn:broker.read"]));
         options.AddPolicy("Recipient", policy => policy.RequireClaim("scope", ["altinn:broker.read", "altinn:broker.write altinn:broker.read"]));
+        options.AddPolicy("SenderOrRecipient", policy => policy.RequireClaim("scope", ["altinn:broker.read", "altinn:broker.write", "altinn:broker.write altinn:broker.read"]));
         options.AddPolicy("Legacy", policy => policy.RequireClaim("scope", ["altinn:broker.legacy"]));
     });
 


### PR DESCRIPTION
## Description
- Expanded GetFiles / File Search to be able to use RecipientFileStatus s as a search parameter.
- Added new policy for GetFiles to allow it to be used by both Senders and Recipients.
- Updated most policies to be able to handle tokens containing multiple scopes

## Related Issue(s)
- #245 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
