### PR TITLE
Added/exposed new file metadata fields

### DIFF
--- a/altinn-broker-v1.json
+++ b/altinn-broker-v1.json
@@ -73,6 +73,14 @@
                     }
                 },
                 {
+                    "name": "recipientStatus",
+                    "in": "query",
+                    "style": "form",
+                    "schema": {
+                        "$ref": "#/components/schemas/RecipientFileStatus"
+                    }
+                },
+                {
                     "name": "from",
                     "in": "query",
                     "style": "form",
@@ -470,6 +478,12 @@
               "description": "Checksum for verifying file integrity.",
               "nullable": true
             },
+            "filesize": {
+              "type": "integer",
+              "description": "The total size of the file in bytes",
+              "format": "int64",
+              "nullable": true
+            }
             "fileStatus": {
               "$ref": "#/components/schemas/FileStatus"
             },
@@ -481,6 +495,16 @@
             "fileStatusChanged": {
               "type": "string",
               "description": "Timestamp indicating the last change in file status.",
+              "format": "date-time"
+            },
+            "created": {
+              "type": "string",
+              "description": "Timestamp indicating when the file was created.",
+              "format": "date-time"
+            },
+            "expiryTime": {
+              "type": "string",
+              "description": "Timestamp indicating when the file will expire.",
               "format": "date-time"
             },
             "sender": {
@@ -527,6 +551,11 @@
                     "type": "string",
                     "nullable": true
                 },
+                "filesize": {
+                    "type": "integer",
+                    "format": "int64",
+                    "nullable": true
+                }
                 "fileStatus": {
                     "$ref": "#/components/schemas/FileStatus"
                 },
@@ -538,6 +567,14 @@
                     "type": "string",
                     "format": "date-time",
                     "nullable": false
+                },
+                "created": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "expiryTime": {
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "sender": {
                     "type": "string",

--- a/src/Altinn.Broker.Application/InitializeFileCommand/InitializeFileCommandHandler.cs
+++ b/src/Altinn.Broker.Application/InitializeFileCommand/InitializeFileCommandHandler.cs
@@ -59,7 +59,7 @@ public class InitializeFileCommandHandler : IHandler<InitializeFileCommandReques
         {
             return Errors.ServiceOwnerNotConfigured;
         }
-        var fileId = await _fileRepository.AddFile(serviceOwner, service, request.Filename, request.SendersFileReference, request.SenderExternalId, request.RecipientExternalIds, request.PropertyList, request.Checksum);
+        var fileId = await _fileRepository.AddFile(serviceOwner, service, request.Filename, request.SendersFileReference, request.SenderExternalId, request.RecipientExternalIds, request.PropertyList, request.Checksum, null);
         await _fileStatusRepository.InsertFileStatus(fileId, FileStatus.Initialized);
         var addRecipientEventTasks = request.RecipientExternalIds.Select(recipientId => _actorFileStatusRepository.InsertActorFileStatus(fileId, ActorFileStatus.Initialized, recipientId));
         try

--- a/src/Altinn.Broker.Application/UploadFileCommand/UploadFileCommandHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFileCommand/UploadFileCommandHandler.cs
@@ -55,7 +55,7 @@ public class UploadFileCommandHandler : IHandler<UploadFileCommandRequest, Guid>
 
         await _fileStatusRepository.InsertFileStatus(request.FileId, FileStatus.UploadStarted);
         await _brokerStorageService.UploadFile(serviceOwner, file, request.Filestream);
-        await _fileRepository.SetStorageReference(request.FileId, serviceOwner.StorageProvider.Id, request.FileId.ToString());
+        await _fileRepository.SetStorageDetails(request.FileId, serviceOwner.StorageProvider.Id, request.FileId.ToString(), request.Filestream.Length);
         await _fileStatusRepository.InsertFileStatus(request.FileId, FileStatus.UploadProcessing);
         // TODO, async jobs
         await _fileStatusRepository.InsertFileStatus(request.FileId, FileStatus.Published);

--- a/src/Altinn.Broker.Core/Domain/FileEntity.cs
+++ b/src/Altinn.Broker.Core/Domain/FileEntity.cs
@@ -16,6 +16,7 @@ public class FileEntity
     public StorageProviderEntity StorageProvider { get; set; }
     public string? FileLocation { get; set; }
     public string Filename { get; set; }
+    public long FileSize { get; set; }
     public string? Checksum { get; set; }
     public Dictionary<string, string> PropertyList { get; set; }
 }

--- a/src/Altinn.Broker.Core/Repositories/IFileRepository.cs
+++ b/src/Altinn.Broker.Core/Repositories/IFileRepository.cs
@@ -13,13 +13,15 @@ public interface IFileRepository
         string senderExternalId,
         List<string> recipientIds,
         Dictionary<string, string> propertyList,
-        string? checksum);
+        string? checksum,
+        long? filesize);
     Task<Domain.FileEntity?> GetFile(Guid fileId);
     Task<List<Guid>> GetFilesAssociatedWithActor(FileSearchEntity fileSearch);
     Task<List<Guid>> GetFilesForRecipientWithRecipientStatus(FileSearchEntity fileSearch);
-    Task SetStorageReference(
+    Task SetStorageDetails(
         Guid fileId,
         long storageProviderId,
-        string fileLocation
+        string fileLocation,
+        long fileSize
     );
 }

--- a/src/Altinn.Broker.Persistence/Migrations/V0000__base.sql
+++ b/src/Altinn.Broker.Persistence/Migrations/V0000__base.sql
@@ -76,6 +76,7 @@ CREATE TABLE broker.file (
     created timestamp without time zone NOT NULL,
     filename character varying(500) NOT NULL,
     checksum character varying(500) NULL,
+    filesize bigint,
     sender_actor_id_fk bigint,
     external_file_reference character varying(500) NOT NULL,
     expiration_time timestamp without time zone NOT NULL,

--- a/src/Altinn.Broker.Persistence/Repositories/FileRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileRepository.cs
@@ -120,7 +120,7 @@ public class FileRepository : IFileRepository
         return fileStatuses;
     }
 
-    public async Task<Guid> AddFile(ServiceOwnerEntity serviceOwner, ServiceEntity service, string filename, string sendersFileReference, string senderExternalId, List<string> recipientIds, Dictionary<string, string> propertyList, string? checksum)
+    public async Task<Guid> AddFile(ServiceOwnerEntity serviceOwner, ServiceEntity service, string filename, string sendersFileReference, string senderExternalId, List<string> recipientIds, Dictionary<string, string> propertyList, string? checksum, long? filesize)
     {
         if (serviceOwner.StorageProvider is null)
         {
@@ -142,13 +142,14 @@ public class FileRepository : IFileRepository
 
         var fileId = Guid.NewGuid();
         NpgsqlCommand command = await _connectionProvider.CreateCommand(
-            "INSERT INTO broker.file (file_id_pk, service_id_fk, filename, checksum, external_file_reference, sender_actor_id_fk, created, storage_provider_id_fk, expiration_time) " +
-            "VALUES (@fileId, @serviceId, @filename, @checksum, @externalFileReference, @senderActorId, @created, @storageProviderId, @expirationTime)");
+            "INSERT INTO broker.file (file_id_pk, service_id_fk, filename, checksum, filesize, external_file_reference, sender_actor_id_fk, created, storage_provider_id_fk, expiration_time) " +
+            "VALUES (@fileId, @serviceId, @filename, @checksum, @filesize, @externalFileReference, @senderActorId, @created, @storageProviderId, @expirationTime)");
 
         command.Parameters.AddWithValue("@fileId", fileId);
         command.Parameters.AddWithValue("@serviceId", service.Id);
         command.Parameters.AddWithValue("@filename", filename);
         command.Parameters.AddWithValue("@checksum", checksum is null ? DBNull.Value : checksum);
+        command.Parameters.AddWithValue("@filesize", filesize is null ? DBNull.Value : filesize);
         command.Parameters.AddWithValue("@senderActorId", actorId);
         command.Parameters.AddWithValue("@externalFileReference", sendersFileReference);
         command.Parameters.AddWithValue("@fileStatusId", (int)FileStatus.Initialized); // TODO, remove?
@@ -289,18 +290,20 @@ public class FileRepository : IFileRepository
         }
     }
 
-    public async Task SetStorageReference(Guid fileId, long storageProviderId, string fileLocation)
+    public async Task SetStorageDetails(Guid fileId, long storageProviderId, string fileLocation, long filesize)
     {
         await using (var command = await _connectionProvider.CreateCommand(
             "UPDATE broker.file " +
             "SET " +
                 "file_location = @fileLocation, " +
+                "filesize = @filesize, " +
                 "storage_provider_id_fk = @storageProviderId " +
             "WHERE file_id_pk = @fileId"))
         {
             command.Parameters.AddWithValue("@fileId", fileId);
             command.Parameters.AddWithValue("@storageProviderId", storageProviderId);
             command.Parameters.AddWithValue("@fileLocation", fileLocation);
+            command.Parameters.AddWithValue("@filesize", filesize);
             command.ExecuteNonQuery();
         }
     }

--- a/src/Altinn.Broker/Mappers/FileStatusOverviewExtMapper.cs
+++ b/src/Altinn.Broker/Mappers/FileStatusOverviewExtMapper.cs
@@ -15,6 +15,7 @@ internal static class FileStatusOverviewExtMapper
         return new FileOverviewExt()
         {
             Checksum = file.Checksum,
+            FileSize = file.FileSize,
             FileId = file.FileId,
             FileName = file.Filename,
             FileStatus = MapToExternalEnum(file.FileStatus),
@@ -24,6 +25,7 @@ internal static class FileStatusOverviewExtMapper
             PropertyList = file.PropertyList,
             Recipients = MapToRecipients(file.RecipientCurrentStatuses),
             SendersFileReference = file.SendersFileReference,
+            Created = file.Created,
             ExpirationTime = file.ExpirationTime
         };
     }

--- a/src/Altinn.Broker/Models/FileOverviewExt.cs
+++ b/src/Altinn.Broker/Models/FileOverviewExt.cs
@@ -13,9 +13,11 @@ namespace Altinn.Broker.Models
         public string FileName { get; set; } = string.Empty;
         public string SendersFileReference { get; set; } = string.Empty;
         public string? Checksum { get; set; } = string.Empty;
+        public long FileSize {  get; set; }
         public FileStatusExt FileStatus { get; set; }
         public string FileStatusText { get; set; } = string.Empty;
         public DateTimeOffset FileStatusChanged { get; set; }
+        public DateTimeOffset Created { get; set; }
         public DateTimeOffset ExpirationTime { get; set; }
 
         /// <summary>

--- a/src/Altinn.Broker/Models/FileOverviewExt.cs
+++ b/src/Altinn.Broker/Models/FileOverviewExt.cs
@@ -13,7 +13,7 @@ namespace Altinn.Broker.Models
         public string FileName { get; set; } = string.Empty;
         public string SendersFileReference { get; set; } = string.Empty;
         public string? Checksum { get; set; } = string.Empty;
-        public long FileSize {  get; set; }
+        public long FileSize { get; set; }
         public FileStatusExt FileStatus { get; set; }
         public string FileStatusText { get; set; } = string.Empty;
         public DateTimeOffset FileStatusChanged { get; set; }


### PR DESCRIPTION
## Description
Added/exposed new file metadata fields through API to allow API users insight as well as provide the BrokerBridge / BrokerLegacy solution access to this data.
- Exposed existing field File.Created through FileOverviewExt to allow API users insight into this metadata.
  - File.Created is already used as the fact in the date filtering for file search.
- Added new metadata field FileSize to File entity and database. FileSize is set by the upload process using the actual file stream size.

## Related Issue(s)
- #252 
## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
