### PR TITLE
Download and ConfirmDownload

### DIFF
--- a/Test/Altinn.Broker.Tests/LegacyFileControllerTests.cs
+++ b/Test/Altinn.Broker.Tests/LegacyFileControllerTests.cs
@@ -270,7 +270,7 @@ public class LegacyFileControllerTests : IClassFixture<CustomWebApplicationFacto
         // Assert
         Assert.Equal(System.Net.HttpStatusCode.NotFound, getResponse.StatusCode);
     }
-    
+
     [Fact]
     public async Task Download_DownloadFile_Success()
     {
@@ -300,7 +300,7 @@ public class LegacyFileControllerTests : IClassFixture<CustomWebApplicationFacto
         // Assert
         Assert.Equal(uploadedFileBytes, downloadedFileBytes);
     }
-    
+
     [Fact]
     public async Task Download_ConfirmDownloaded_Success()
     {

--- a/Test/Altinn.Broker.Tests/LegacyFileControllerTests.cs
+++ b/Test/Altinn.Broker.Tests/LegacyFileControllerTests.cs
@@ -298,6 +298,7 @@ public class LegacyFileControllerTests : IClassFixture<CustomWebApplicationFacto
         var downloadedFileBytes = await downloadedFile.Content.ReadAsByteArrayAsync();
 
         // Assert
+        Assert.True(downloadedFileBytes?.Length > 0);
         Assert.Equal(uploadedFileBytes, downloadedFileBytes);
     }
 

--- a/src/Altinn.Broker.Application/ConfirmDownloadCommand/ConfirmDownloadCommandHandler.cs
+++ b/src/Altinn.Broker.Application/ConfirmDownloadCommand/ConfirmDownloadCommandHandler.cs
@@ -38,7 +38,7 @@ public class ConfirmDownloadCommandHandler : IHandler<ConfirmDownloadCommandRequ
         {
             return Errors.FileNotFound;
         }
-        var hasAccess = await _resourceRightsRepository.CheckUserAccess(file.ResourceId, request.Token.ClientId, ResourceAccessLevel.Read);
+        var hasAccess = await _resourceRightsRepository.CheckUserAccess(file.ResourceId, request.Token.ClientId, ResourceAccessLevel.Read, request.IsLegacy);
         if (!hasAccess)
         {
             return Errors.FileNotFound;

--- a/src/Altinn.Broker.Application/ConfirmDownloadCommand/ConfirmDownloadCommandRequest.cs
+++ b/src/Altinn.Broker.Application/ConfirmDownloadCommand/ConfirmDownloadCommandRequest.cs
@@ -6,4 +6,5 @@ public class ConfirmDownloadCommandRequest
 {
     public CallerIdentity Token { get; set; }
     public Guid FileId { get; set; }
+    public bool IsLegacy { get; set; }
 }

--- a/src/Altinn.Broker.Application/DownloadFileQuery/DownloadFileQueryHandler.cs
+++ b/src/Altinn.Broker.Application/DownloadFileQuery/DownloadFileQueryHandler.cs
@@ -43,7 +43,7 @@ public class DownloadFileQueryHandler : IHandler<DownloadFileQueryRequest, Downl
         {
             return Errors.NoFileUploaded;
         }
-        var hasAccess = await _resourceRightsRepository.CheckUserAccess(file.ResourceId, request.Token.ClientId, ResourceAccessLevel.Read);
+        var hasAccess = await _resourceRightsRepository.CheckUserAccess(file.ResourceId, request.Token.ClientId, ResourceAccessLevel.Read, request.IsLegacy);
         if (!hasAccess)
         {
             return Errors.NoAccessToResource;

--- a/src/Altinn.Broker.Application/DownloadFileQuery/DownloadFileQueryRequest.cs
+++ b/src/Altinn.Broker.Application/DownloadFileQuery/DownloadFileQueryRequest.cs
@@ -6,4 +6,5 @@ public class DownloadFileQueryRequest
 {
     public CallerIdentity Token { get; set; }
     public Guid FileId { get; set; }
+    public bool IsLegacy { get; set; }
 }


### PR DESCRIPTION
Implements the BrokerBridge Legacy for Download and ConfirmDownload

## Description
Added Download and ConfirmDownload operations to LegacyFileController.
Re-using existing Broker code to download and confirm downloaded files. 

## Related Issue(s)
- #255 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [xx] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
