### PR TITLE
Checksum validation

### DIFF
--- a/Test/Altinn.Broker.Tests/FileControllerTests.cs
+++ b/Test/Altinn.Broker.Tests/FileControllerTests.cs
@@ -246,7 +246,7 @@ public class FileControllerTests : IClassFixture<CustomWebApplicationFactory>
         Assert.NotNull(parsedError);
         Assert.Equal(Errors.NoAccessToResource.Message, parsedError.Detail);
     }
-    
+
     [Fact]
     public async Task UploadFile_ChecksumCorrect_Succeeds()
     {

--- a/src/Altinn.Broker.API/Models/FileInitializeExt.cs
+++ b/src/Altinn.Broker.API/Models/FileInitializeExt.cs
@@ -81,6 +81,10 @@ namespace Altinn.Broker.Models
             {
                 return new ValidationResult("The checksum, if used, must be a MD5 hash with a length of 32 characters");
             }
+            if (stringValue.ToLowerInvariant() != stringValue)
+            {
+                return new ValidationResult("The checksum, if used, must be a MD5 hash in lower case");
+            }
             return ValidationResult.Success;
         }
     }

--- a/src/Altinn.Broker.Application/Altinn.Broker.Application.csproj
+++ b/src/Altinn.Broker.Application/Altinn.Broker.Application.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Hangfire.Core" Version="1.8.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />

--- a/src/Altinn.Broker.Application/Errors.cs
+++ b/src/Altinn.Broker.Application/Errors.cs
@@ -15,4 +15,6 @@ public static class Errors
     public static Error ResourceNotConfigured = new Error(7, "Resource needs to be configured to use the broker API", HttpStatusCode.Unauthorized);
     public static Error NoAccessToResource = new Error(8, "You must use a bearer token that represents a system user with access to the resource in the Resource Rights Registry", HttpStatusCode.Unauthorized);
     public static Error FileNotAvailable = new Error(9, "The requested file is not ready for download. See file status.", HttpStatusCode.Forbidden);
+    public static Error UploadFailed = new Error(10, "Error occurred while uploading file. See /details for more information.", HttpStatusCode.InternalServerError);
+    public static Error ChecksumMismatch = new Error(12, "The checksum of uploaded file did not match the checksum specified in initialize call.", HttpStatusCode.BadRequest);
 }

--- a/src/Altinn.Broker.Core/Repositories/IFileRepository.cs
+++ b/src/Altinn.Broker.Core/Repositories/IFileRepository.cs
@@ -19,6 +19,7 @@ public interface IFileRepository
     Task<List<Guid>> GetFilesAssociatedWithActor(FileSearchEntity fileSearch);
     Task<List<Guid>> GetFilesForRecipientWithRecipientStatus(FileSearchEntity fileSearch);
     Task<List<Guid>> LegacyGetFilesForRecipientsWithRecipientStatus(LegacyFileSearchEntity fileSearch);
+    Task SetChecksum(Guid fileId, string checksum);
     Task SetStorageDetails(
         Guid fileId,
         long storageProviderId,

--- a/src/Altinn.Broker.Core/Repositories/IFileStore.cs
+++ b/src/Altinn.Broker.Core/Repositories/IFileStore.cs
@@ -3,7 +3,7 @@ namespace Altinn.Broker.Repositories
     public interface IFileStore
     {
         Task<Stream> GetFileStream(Guid fileId, string connectionString);
-        Task UploadFile(Stream filestream, Guid fileId, string connectionString);
+        Task<string> UploadFile(Stream filestream, Guid fileId, string connectionString);
         Task DeleteFile(Guid fileId, string connectionString);
     }
 }

--- a/src/Altinn.Broker.Core/Services/IBrokerStorageService.cs
+++ b/src/Altinn.Broker.Core/Services/IBrokerStorageService.cs
@@ -8,10 +8,10 @@ public interface IBrokerStorageService
     /// <summary>
     /// Looks up the correct storage account to use for service owner and upload the file
     /// </summary>
-    /// <param name="resourceOwnerEntity"></param>
-    /// <param name="stream"></param>
-    /// <returns></returns>
-    Task UploadFile(ResourceOwnerEntity resourceOwnerEntity, FileEntity fileEntity, Stream stream);
+    /// <param name="resourceOwnerEntity">The resource owner entity.</param>
+    /// <param name="stream">The stream to upload.</param>
+    /// <returns>A string containing the MD5 checksum</returns>
+    Task<string> UploadFile(ResourceOwnerEntity resourceOwnerEntity, FileEntity fileEntity, Stream stream);
 
     Task<Stream> DownloadFile(ResourceOwnerEntity resourceOwnerEntity, FileEntity file);
     Task DeleteFile(ResourceOwnerEntity resourceOwnerEntity, FileEntity fileEntity);

--- a/src/Altinn.Broker.Integrations/Azure/AzureBrokerStorageService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureBrokerStorageService.cs
@@ -21,10 +21,10 @@ public class AzureBrokerStorageService : IBrokerStorageService
         _logger = logger;
     }
 
-    public async Task UploadFile(ResourceOwnerEntity resourceOwnerEntity, FileEntity fileEntity, Stream stream)
+    public async Task<string> UploadFile(ResourceOwnerEntity resourceOwnerEntity, FileEntity fileEntity, Stream stream)
     {
         var connectionString = await GetConnectionString(resourceOwnerEntity);
-        await _fileStore.UploadFile(stream, fileEntity.FileId, connectionString);
+        return await _fileStore.UploadFile(stream, fileEntity.FileId, connectionString);
     }
 
     public async Task<Stream> DownloadFile(ResourceOwnerEntity resourceOwnerEntity, FileEntity fileEntity)

--- a/src/Altinn.Broker.Persistence/Altinn.Broker.Persistence.csproj
+++ b/src/Altinn.Broker.Persistence/Altinn.Broker.Persistence.csproj
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="Migrations\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.5" />

--- a/src/Altinn.Broker.Persistence/Repositories/FileRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileRepository.cs
@@ -470,4 +470,18 @@ public class FileRepository : IFileRepository
             throw;
         }
     }
+
+    public async Task SetChecksum(Guid fileId, string checksum)
+    {
+        await using (var command = await _connectionProvider.CreateCommand(
+            "UPDATE broker.file " +
+            "SET " +
+                "checksum = @checksum " +
+            "WHERE file_id_pk = @fileId"))
+        {
+            command.Parameters.AddWithValue("@fileId", fileId);
+            command.Parameters.AddWithValue("@checksum", checksum);
+            command.ExecuteNonQuery();
+        }
+    }
 }


### PR DESCRIPTION
## Description
We should verify the integrity of uploaded files using a checksum. If no checksum is given, we should store the checksum regardless to enable recipients to verify that file has not been tampered with while at rest.

## Related Issue(s)
- #271 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
