### PR TITLE
Use GUID as uinque azure resource name

### DIFF
--- a/Test/Altinn.Broker.Tests/Data/R__Prepare_Test_Data.sql
+++ b/Test/Altinn.Broker.Tests/Data/R__Prepare_Test_Data.sql
@@ -1,5 +1,5 @@
-INSERT INTO broker.resource_owner (resource_owner_id_pk, resource_owner_name, file_time_to_live)
-VALUES ('0192:991825827', 'Digitaliseringsdirektoratet Avd Oslo', '1 Days');
+INSERT INTO broker.resource_owner (resource_owner_id_pk, resource_owner_name, file_time_to_live, resource_group_name)
+VALUES ('0192:991825827', 'Digitaliseringsdirektoratet Avd Oslo', '1 Days', '00010000-0000-0000-0000-00a000000000');
 
 INSERT INTO broker.storage_provider (storage_provider_id_pk, resource_owner_id_fk, created, storage_provider_type, resource_name)
 VALUES (DEFAULT, '0192:991825827', NOW(), 'Altinn3Azure', 'dummy-value');

--- a/src/Altinn.Broker.Core/Domain/ResourceOwnerEntity.cs
+++ b/src/Altinn.Broker.Core/Domain/ResourceOwnerEntity.cs
@@ -6,4 +6,5 @@ public class ResourceOwnerEntity
     public string Name { get; set; }
     public StorageProviderEntity? StorageProvider { get; set; }
     public TimeSpan FileTimeToLive { get; set; }
+    public Guid ResourceGroupName { get; set; }
 }

--- a/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
@@ -29,8 +29,8 @@ public class AzureResourceManagerService : IResourceManager
         new ConcurrentDictionary<string, (DateTime Created, string Token)>();
     private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
     private readonly ILogger<AzureResourceManagerService> _logger;
-    public string GetResourceGroupName(ResourceOwnerEntity resourceOwnerEntity) => $"serviceowner-{_resourceManagerOptions.Environment}-{resourceOwnerEntity.Id.Replace(":", "-")}-rg";
-    public string GetStorageAccountName(ResourceOwnerEntity resourceOwnerEntity) => $"ai{_resourceManagerOptions.Environment.ToLowerInvariant()}{resourceOwnerEntity.Id.Replace(":", "")}sa";
+    public string GetResourceGroupName(ResourceOwnerEntity resourceOwnerEntity) => $"serviceowner-{_resourceManagerOptions.Environment}-{resourceOwnerEntity.ResourceGroupName}-rg";
+    public string GetStorageAccountName(ResourceOwnerEntity resourceOwnerEntity) => $"ai{_resourceManagerOptions.Environment.ToLowerInvariant()}{resourceOwnerEntity.ResourceGroupName}sa";
 
     private SubscriptionResource GetSubscription() => _armClient.GetSubscriptionResource(new ResourceIdentifier($"/subscriptions/{_resourceManagerOptions.SubscriptionId}"));
 

--- a/src/Altinn.Broker.Persistence/Migrations/V0004__add_resourcename.sql
+++ b/src/Altinn.Broker.Persistence/Migrations/V0004__add_resourcename.sql
@@ -1,0 +1,2 @@
+ALTER TABLE broker.resource_owner
+ADD resource_group_name uuid NOT NULL;

--- a/src/Altinn.Broker.Persistence/Repositories/ResourceOwnerRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/ResourceOwnerRepository.cs
@@ -51,12 +51,13 @@ public class ResourceOwnerRepository : IResourceOwnerRepository
         await using var connection = await _connectionProvider.GetConnectionAsync();
 
         await using (var command = await _connectionProvider.CreateCommand(
-            "INSERT INTO broker.resource_owner (resource_owner_id_pk, resource_owner_name, file_time_to_live) " +
-            "VALUES (@sub, @name, @fileTimeToLive)"))
+            "INSERT INTO broker.resource_owner (resource_owner_id_pk, resource_owner_name, file_time_to_live, resource_group_name) " +
+            "VALUES (@sub, @name, @fileTimeToLive, @resourceGroupName)"))
         {
             command.Parameters.AddWithValue("@sub", sub);
             command.Parameters.AddWithValue("@name", name);
             command.Parameters.AddWithValue("@fileTimeToLive", fileTimeToLive);
+            command.Parameters.AddWithValue("@resourceGroupName", Guid.NewGuid());
             var commandText = command.CommandText;
             command.ExecuteNonQuery();
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A guid is generated as a unique name for a customers azure resources. The guid is reused for both the resource group and the storage account. 

## Related Issue(s)
- [#293 ](https://github.com/Altinn/altinn-broker/issues/293)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
