### PR TITLE
Various bug fixes

### DIFF
--- a/Test/Altinn.Broker.Tests/Data/R__Prepare_Test_Data.sql
+++ b/Test/Altinn.Broker.Tests/Data/R__Prepare_Test_Data.sql
@@ -1,5 +1,5 @@
-INSERT INTO broker.service_owner (service_owner_id_pk, service_owner_name, file_transfer_time_to_live, resource_group_name)
-VALUES ('0192:991825827', 'Digitaliseringsdirektoratet Avd Oslo', '1 Days', '00010000-0000-0000-0000-00a000000000');
+INSERT INTO broker.service_owner (service_owner_id_pk, service_owner_name, file_transfer_time_to_live)
+VALUES ('0192:991825827', 'Digitaliseringsdirektoratet Avd Oslo', '1 Days');
 
 INSERT INTO broker.storage_provider (storage_provider_id_pk, service_owner_id_fk, created, storage_provider_type, resource_name)
 VALUES (DEFAULT, '0192:991825827', NOW(), 'Azurite', 'dummy-value');

--- a/src/Altinn.Broker.API/Controllers/MalwareScanResultsController.cs
+++ b/src/Altinn.Broker.API/Controllers/MalwareScanResultsController.cs
@@ -19,24 +19,24 @@ namespace Altinn.Broker.Webhooks.Controllers
     [Route("broker/api/v1/webhooks/malwarescanresults")]
     public class MalwareScanResultsController : Controller
     {
-        private readonly IFileTransferRepository _fileTransferRepository;
-        private readonly IFileTransferStatusRepository _fileTransferStatusRepository;
         private readonly IIdempotencyEventRepository _idempotencyEventRepository;
+        private readonly ILogger<MalwareScanResultsController> _logger;
 
-        public MalwareScanResultsController(IFileTransferRepository fileTransferRepository, IFileTransferStatusRepository fileTransferStatusRepository, IIdempotencyEventRepository idempotencyEventRepository)
+        public MalwareScanResultsController(IIdempotencyEventRepository idempotencyEventRepository, ILogger<MalwareScanResultsController> logger)
         {
-            _fileTransferRepository = fileTransferRepository;
-            _fileTransferStatusRepository = fileTransferStatusRepository;
             _idempotencyEventRepository = idempotencyEventRepository;
+            _logger = logger;
         }
 
         [HttpPost]
+        [Consumes("application/json")]
         public async Task<ActionResult> ProcessMalwareScanResult([FromServices] MalwareScanningResultHandler handler, CancellationToken cancellationToken)
         {
-            BinaryData events = BinaryData.FromStreamAsync(this.Request.Body).Result;
+            BinaryData events = await BinaryData.FromStreamAsync(this.Request.Body);
             EventGridEvent[] eventGridEvents = EventGridEvent.ParseMany(events);
             foreach (EventGridEvent eventGridEvent in eventGridEvents)
             {
+                _logger.LogInformation("Got malware scan event of type {EventType} with data: {eventData}", eventGridEvent.EventType, eventGridEvent.Data.ToString());
                 if (eventGridEvent.TryGetSystemEventData(out object eventData))
                 {
                     if (eventData is SubscriptionValidationEventData subscriptionValidationEventData)

--- a/src/Altinn.Broker.Application/UploadFileCommand/UploadFileCommandHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFileCommand/UploadFileCommandHandler.cs
@@ -98,7 +98,6 @@ public class UploadFileCommandHandler : IHandler<UploadFileCommandRequest, Guid>
             await _fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.Published);
             await _eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, cancellationToken);
         }
-        await _fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.Published, cancellationToken: cancellationToken);
         return fileTransfer.FileTransferId;
     }
 }

--- a/src/Altinn.Broker.Core/Domain/ServiceOwnerEntity.cs
+++ b/src/Altinn.Broker.Core/Domain/ServiceOwnerEntity.cs
@@ -6,5 +6,4 @@ public class ServiceOwnerEntity
     public string Name { get; set; }
     public StorageProviderEntity? StorageProvider { get; set; }
     public TimeSpan FileTransferTimeToLive { get; set; }
-    public Guid ResourceGroupName { get; set; }
 }

--- a/src/Altinn.Broker.Core/Services/IResourceManager.cs
+++ b/src/Altinn.Broker.Core/Services/IResourceManager.cs
@@ -13,8 +13,4 @@ public interface IResourceManager
     Task Deploy(ServiceOwnerEntity serviceOwnerEntity, CancellationToken cancellationToken);
 
     Task<string> GetStorageConnectionString(ServiceOwnerEntity serviceOwnerEntity);
-
-    string GetResourceGroupName(ServiceOwnerEntity serviceOwnerEntity);
-
-    string GetStorageAccountName(ServiceOwnerEntity serviceOwnerEntity);
 }

--- a/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerOptions.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerOptions.cs
@@ -13,4 +13,6 @@ public class AzureResourceManagerOptions
     public string? ClientId { get; set; }
     public string? ClientSecret { get; set; }
     public string? SubscriptionId { get; set; }
+    public string? ApplicationResourceGroupName { get; set; }
+    public string? MalwareScanEventGridTopicName { get; set; }
 }

--- a/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
@@ -30,7 +30,7 @@ public class AzureResourceManagerService : IResourceManager
     private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
     private readonly ILogger<AzureResourceManagerService> _logger;
     public string GetResourceGroupName(ServiceOwnerEntity serviceOwnerEntity) => $"serviceowner-{_resourceManagerOptions.Environment}-{serviceOwnerEntity.ResourceGroupName}-rg";
-    public string GetStorageAccountName(ServiceOwnerEntity serviceOwnerEntity) => $"ai{_resourceManagerOptions.Environment.ToLowerInvariant()}{serviceOwnerEntity.ResourceGroupName}sa";
+    public string GetStorageAccountName(ServiceOwnerEntity serviceOwnerEntity) => $"ai{_resourceManagerOptions.Environment.ToLowerInvariant()}{serviceOwnerEntity.ResourceGroupName.ToString().Split("-").First()}sa";
 
     private SubscriptionResource GetSubscription() => _armClient.GetSubscriptionResource(new ResourceIdentifier($"/subscriptions/{_resourceManagerOptions.SubscriptionId}"));
 

--- a/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
@@ -21,8 +21,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-using Polly;
-
 namespace Altinn.Broker.Integrations.Azure;
 public class AzureResourceManagerService : IResourceManager
 {

--- a/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
@@ -97,7 +97,7 @@ public class AzureResourceManagerService : IResourceManager
         var tokenRequestContext = new TokenRequestContext(new[] { "https://management.azure.com/.default" });
         var token = await _credentials.GetTokenAsync(tokenRequestContext, cancellationToken);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
-        var endpoint = $"https://management.azure.com/subscriptions/{_resourceManagerOptions.SubscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/aibrokerba8u7c40sa/providers/Microsoft.Security/defenderForStorageSettings/current?api-version=2022-12-01-preview";
+        var endpoint = $"https://management.azure.com/subscriptions/{_resourceManagerOptions.SubscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{storageAccountName}/providers/Microsoft.Security/defenderForStorageSettings/current?api-version=2022-12-01-preview";
         var requestBody = new MalwareScanConfiguration()
         {
             Properties = new Properties()

--- a/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
@@ -88,7 +88,7 @@ public class AzureResourceManagerService : IResourceManager
         }
 
         await _serviceOwnerRepository.InitializeStorageProvider(serviceOwnerEntity.Id, storageAccountName, StorageProviderType.Altinn3Azure);
-       _logger.LogInformation($"Storage account {storageAccountName} created");
+        _logger.LogInformation($"Storage account {storageAccountName} created");
     }
 
     private async Task EnableMicrosoftDefender(string resourceGroupName, string storageAccountName, CancellationToken cancellationToken)

--- a/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
@@ -29,7 +29,7 @@ public class AzureResourceManagerService : IResourceManager
         new ConcurrentDictionary<string, (DateTime Created, string Token)>();
     private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
     private readonly ILogger<AzureResourceManagerService> _logger;
-    public string GetResourceGroupName(ServiceOwnerEntity serviceOwnerEntity) => $"serviceowner-{_resourceManagerOptions.Environment}-{serviceOwnerEntity.ResourceGroupName}-rg";
+    public string GetResourceGroupName(ServiceOwnerEntity serviceOwnerEntity) => $"serviceowner-{_resourceManagerOptions.Environment}-{serviceOwnerEntity.Id.Split(":")[1]}-rg";
     public string GetStorageAccountName(ServiceOwnerEntity serviceOwnerEntity) => $"ai{_resourceManagerOptions.Environment.ToLowerInvariant()}{serviceOwnerEntity.ResourceGroupName.ToString().Split("-").First()}sa";
 
     private SubscriptionResource GetSubscription() => _armClient.GetSubscriptionResource(new ResourceIdentifier($"/subscriptions/{_resourceManagerOptions.SubscriptionId}"));

--- a/src/Altinn.Broker.Integrations/Azure/BlobService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/BlobService.cs
@@ -21,7 +21,13 @@ public class BlobService : IFileStore
 
     private BlobClient GetBlobClient(Guid fileId, string connectionString)
     {
-        var blobServiceClient = new BlobServiceClient(connectionString);
+        var blobServiceClient = new BlobServiceClient(connectionString, new BlobClientOptions()
+        {
+            Retry =
+            {
+                NetworkTimeout = TimeSpan.MaxValue,
+            }
+        });
         var containerClient = blobServiceClient.GetBlobContainerClient("brokerfiles");
         BlobClient blobClient = containerClient.GetBlobClient(fileId.ToString());
         return blobClient;
@@ -59,7 +65,7 @@ public class BlobService : IFileStore
                 {
                     LeaseId = blobLease.LeaseId
                 },
-                TransferValidation = new UploadTransferValidationOptions { ChecksumAlgorithm = StorageChecksumAlgorithm.MD5 },
+                TransferValidation = new UploadTransferValidationOptions { ChecksumAlgorithm = StorageChecksumAlgorithm.MD5 }
             };
             var blobMetadata = await blobClient.UploadAsync(stream, options, cancellationToken);
             var metadata = blobMetadata.Value;

--- a/src/Altinn.Broker.Integrations/Azure/BlobService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/BlobService.cs
@@ -25,7 +25,7 @@ public class BlobService : IFileStore
         {
             Retry =
             {
-                NetworkTimeout = TimeSpan.MaxValue,
+                NetworkTimeout = TimeSpan.FromHours(1),
             }
         });
         var containerClient = blobServiceClient.GetBlobContainerClient("brokerfiles");

--- a/src/Altinn.Broker.Integrations/Azure/MalwareScanConfiguration.cs
+++ b/src/Altinn.Broker.Integrations/Azure/MalwareScanConfiguration.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Altinn.Broker.Integrations.Azure;
+ 
+internal class MalwareScanConfiguration
+{
+    public Properties Properties { get; set; }
+    public string Scope { get; set; }
+}
+
+internal class MalwareScanning
+{
+    public OnUpload OnUpload { get; set; }
+    public string ScanResultsEventGridTopicResourceId { get; set; }
+}
+
+internal class OnUpload
+{
+    public bool IsEnabled { get; set; }
+    public int CapGBPerMonth { get; set; }
+}
+
+internal class Properties
+{
+    public bool IsEnabled { get; set; }
+    public MalwareScanning MalwareScanning { get; set; }
+    public SensitiveDataDiscovery SensitiveDataDiscovery { get; set; }
+    public bool OverrideSubscriptionLevelSettings { get; set; }
+}
+
+internal class SensitiveDataDiscovery
+{
+    public bool IsEnabled { get; set; }
+}
+

--- a/src/Altinn.Broker.Integrations/Azure/MalwareScanConfiguration.cs
+++ b/src/Altinn.Broker.Integrations/Azure/MalwareScanConfiguration.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace Altinn.Broker.Integrations.Azure;
- 
+
 internal class MalwareScanConfiguration
 {
     public Properties Properties { get; set; }

--- a/src/Altinn.Broker.Persistence/Migrations/V0004__add_resourcename.sql
+++ b/src/Altinn.Broker.Persistence/Migrations/V0004__add_resourcename.sql
@@ -1,2 +1,0 @@
-ALTER TABLE broker.service_owner
-ADD resource_group_name uuid NOT NULL;

--- a/src/Altinn.Broker.Persistence/Repositories/ServiceOwnerRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/ServiceOwnerRepository.cs
@@ -52,13 +52,12 @@ public class ServiceOwnerRepository : IServiceOwnerRepository
         await using var connection = await _connectionProvider.GetConnectionAsync();
 
         await using (var command = await _connectionProvider.CreateCommand(
-            "INSERT INTO broker.service_owner (service_owner_id_pk, service_owner_name, file_transfer_time_to_live, resource_group_name) " +
-            "VALUES (@sub, @name, @fileTimeToLive, @resourceGroupName)"))
+            "INSERT INTO broker.service_owner (service_owner_id_pk, service_owner_name, file_transfer_time_to_live) " +
+            "VALUES (@sub, @name, @fileTimeToLive)"))
         {
             command.Parameters.AddWithValue("@sub", sub);
             command.Parameters.AddWithValue("@name", name);
             command.Parameters.AddWithValue("@fileTimeToLive", fileTimeToLive);
-            command.Parameters.AddWithValue("@resourceGroupName", Guid.NewGuid());
             var commandText = command.CommandText;
             command.ExecuteNonQuery();
         }

--- a/src/Altinn.Broker.Persistence/Repositories/ServiceOwnerRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/ServiceOwnerRepository.cs
@@ -16,7 +16,7 @@ public class ServiceOwnerRepository : IServiceOwnerRepository
     public async Task<ServiceOwnerEntity?> GetServiceOwner(string serviceOwnerId)
     {
         using var command = await _connectionProvider.CreateCommand(
-            "SELECT service_owner_id_pk, service_owner_name, file_transfer_time_to_live, resource_group_name, " +
+            "SELECT service_owner_id_pk, service_owner_name, file_transfer_time_to_live, " +
             "storage_provider_id_pk, created, resource_name, storage_provider_type " +
             "FROM broker.service_owner " +
             "LEFT JOIN broker.storage_provider sp on sp.service_owner_id_fk = service_owner_id_pk " +
@@ -33,7 +33,6 @@ public class ServiceOwnerRepository : IServiceOwnerRepository
                 Id = reader.GetString(reader.GetOrdinal("service_owner_id_pk")),
                 Name = reader.GetString(reader.GetOrdinal("service_owner_name")),
                 FileTransferTimeToLive = reader.GetTimeSpan(reader.GetOrdinal("file_transfer_time_to_live")),
-                ResourceGroupName = reader.GetGuid(reader.GetOrdinal("resource_group_name")),
                 StorageProvider = reader.IsDBNull(reader.GetOrdinal("storage_provider_id_pk")) ? null : new StorageProviderEntity()
                 {
                     Created = reader.GetDateTime(reader.GetOrdinal("created")),


### PR DESCRIPTION
## Description
Fix of three small bugs:
1) We did not add a subscription to Microsoft Defender when we deployed storage accounts through the service owner endpoint. As this endpoint/flow is now part of final delivery we need to ensure this works without any manual fixes.
2) Default file transfer timeout for the Azure Storage account client SDK was five minutes. Extended this to one hour for now, but will test with higher before final merge. There should not be a limit at all if it is possible I think.
3) Storage account name became too long. Turns out storage account names can only be 24 characters long. Changed from using Guid to randomly generating an 8-character long lowercase alphanumeric string. Also changed back to using organization number in resource group name for simplicity for maintainers (no need to map more id's than necessary) and because resource group names are not global hence do not have the same issue as storage accounts.


## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
