### PR TITLE
Updated LegacyFileController to receive FileTransferStatus

### DIFF
--- a/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
+++ b/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
@@ -141,6 +141,7 @@ namespace Altinn.Broker.Controllers
         /// <returns></returns>
         [HttpGet]
         public async Task<ActionResult<List<Guid>>> GetFiles(
+            [FromQuery] FileTransferStatusExt? status,
             [FromQuery] RecipientFileTransferStatusExt? recipientStatus,
             [FromQuery] DateTimeOffset? from,
             [FromQuery] DateTimeOffset? to,
@@ -174,7 +175,8 @@ namespace Altinn.Broker.Controllers
             {
                 Token = legacyToken ?? token,
                 ResourceId = resourceId ?? string.Empty,
-                RecipientStatus = recipientStatus is not null ? (ActorFileTransferStatus)recipientStatus : null,
+                RecipientFileTransferStatus = recipientStatus is not null ? (ActorFileTransferStatus)recipientStatus : null,
+                FileTransferStatus = status is not null ? (FileTransferStatus)status : null,
                 OnBehalfOfConsumer = onBehalfOfConsumer,
                 From = from,
                 To = to,

--- a/src/Altinn.Broker.Application/GetFileTransfersQuery/LegacyGetFilesQueryHandler.cs
+++ b/src/Altinn.Broker.Application/GetFileTransfersQuery/LegacyGetFilesQueryHandler.cs
@@ -68,9 +68,14 @@ public class LegacyGetFilesQueryHandler : IHandler<LegacyGetFilesQueryRequest, L
             fileSearch.To = new DateTimeOffset(request.To.Value.UtcDateTime, TimeSpan.Zero);
         }
 
-        if (request.RecipientStatus.HasValue)
+        if (request.RecipientFileTransferStatus.HasValue)
         {
-            fileSearch.RecipientStatus = request.RecipientStatus;
+            fileSearch.RecipientFileTransferStatus = request.RecipientFileTransferStatus;
+        }
+
+        if (request.FileTransferStatus.HasValue)
+        {
+            fileSearch.FileTransferStatus = request.FileTransferStatus;
         }
 
         return await _fileTransferRepository.LegacyGetFilesForRecipientsWithRecipientStatus(fileSearch, cancellationToken);

--- a/src/Altinn.Broker.Application/GetFileTransfersQuery/LegacyGetFilesQueryRequest.cs
+++ b/src/Altinn.Broker.Application/GetFileTransfersQuery/LegacyGetFilesQueryRequest.cs
@@ -7,7 +7,8 @@ public class LegacyGetFilesQueryRequest
 {
     public CallerIdentity Token { get; set; }
     public string? ResourceId { get; set; }
-    public ActorFileTransferStatus? RecipientStatus { get; set; }
+    public FileTransferStatus? FileTransferStatus { get; set; }
+    public ActorFileTransferStatus? RecipientFileTransferStatus { get; set; }
     public DateTimeOffset? From { get; set; }
     public DateTimeOffset? To { get; set; }
     public string[]? Recipients { get; set; }

--- a/src/Altinn.Broker.Core/Domain/LegacyFileSearchEntity.cs
+++ b/src/Altinn.Broker.Core/Domain/LegacyFileSearchEntity.cs
@@ -6,7 +6,8 @@ public class LegacyFileSearchEntity
 {
     public ActorEntity? Actor { get; set; }
     public List<ActorEntity>? Actors { get; set; }
-    public ActorFileTransferStatus? RecipientStatus { get; set; }
+    public ActorFileTransferStatus? RecipientFileTransferStatus { get; set; }
+    public FileTransferStatus? FileTransferStatus { get; set; }
     public DateTimeOffset? From { get; set; }
     public DateTimeOffset? To { get; set; }
     public string? ResourceId { get; set; }

--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
@@ -233,9 +233,13 @@ public class FileTransferRepository : IFileTransferRepository
         {
             commandString.AppendLine("AND resource_id = @resourceId");
         }
-        if (fileTransferSearch.RecipientStatus.HasValue)
+        if (fileTransferSearch.RecipientFileTransferStatus.HasValue)
         {
             commandString.AppendLine("AND actor_file_transfer_status_id_fk = @recipientFileTransferStatus");
+        }
+        if (fileTransferSearch.FileTransferStatus.HasValue)
+        {
+            commandString.AppendLine("AND filetransferstatus.file_transfer_status_description_id_fk = @fileTransferStatus");
         }
 
         commandString.AppendLine(";");
@@ -257,8 +261,10 @@ public class FileTransferRepository : IFileTransferRepository
                 command.Parameters.AddWithValue("@From", fileTransferSearch.From);
             if (fileTransferSearch.To.HasValue)
                 command.Parameters.AddWithValue("@To", fileTransferSearch.To);
-            if (fileTransferSearch.RecipientStatus.HasValue)
-                command.Parameters.AddWithValue("@recipientFileTransferStatus", (int)fileTransferSearch.RecipientStatus);
+            if (fileTransferSearch.RecipientFileTransferStatus.HasValue)
+                command.Parameters.AddWithValue("@recipientFileTransferStatus", (int)fileTransferSearch.RecipientFileTransferStatus);
+            if (fileTransferSearch.FileTransferStatus.HasValue)
+                command.Parameters.AddWithValue("@fileTransferStatus", (int)fileTransferSearch.FileTransferStatus);
 
             var fileTransfers = new List<Guid>();
             await using (var reader = await command.ExecuteReaderAsync(cancellationToken))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
LegacyFileController should receive a FileTransferStatus value in its request.
Technically this should always be status "Published" received from Altinn 2, but we will keep it as a variable.
We mistakenly removed this property in the initial checkin.

## Related Issue(s)
- #251 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
