### PR TITLE
Updated code better handle malware scan errors so that endusers can b…

### DIFF
--- a/Test/Altinn.Broker.Tests/LegacyFileControllerTests.cs
+++ b/Test/Altinn.Broker.Tests/LegacyFileControllerTests.cs
@@ -96,7 +96,7 @@ public class LegacyFileControllerTests : IClassFixture<CustomWebApplicationFacto
         Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
         Assert.Contains(Guid.Parse(fileId), result);
     }
-    
+
     [Fact]
     public async Task InitializeAndUpload_FailsDueToAntivirus()
     {

--- a/altinn-broker-v1.json
+++ b/altinn-broker-v1.json
@@ -30,10 +30,10 @@
           }
         }
       },
-      "no.altinn.broker.filedeleted": {
+      "no.altinn.broker.filepurged": {
         "post": {
           "requestBody": {
-            "description": "The file has been deleted from Broker",
+            "description": "The file has been purged from Broker",
             "content": {
               "application/cloudevents+json": {
                 "schema": {
@@ -789,7 +789,7 @@
           "Published",
           "Cancelled",
           "AllConfirmedDownloaded",
-          "Deleted",
+          "Purged",
           "Failed"
         ],
         "type": "string"

--- a/src/Altinn.Broker.API/Enums/FileTransferStatusExt.cs
+++ b/src/Altinn.Broker.API/Enums/FileTransferStatusExt.cs
@@ -8,7 +8,7 @@ namespace Altinn.Broker.Enums
         Published,
         Cancelled,
         AllConfirmedDownloaded,
-        Deleted,
+        Purged,
         Failed
     }
 }

--- a/src/Altinn.Broker.API/Mappers/FileStatusOverviewExtMapper.cs
+++ b/src/Altinn.Broker.API/Mappers/FileStatusOverviewExtMapper.cs
@@ -40,7 +40,7 @@ internal static class FileTransferStatusOverviewExtMapper
             FileTransferStatus.Published => FileTransferStatusExt.Published,
             FileTransferStatus.Cancelled => FileTransferStatusExt.Cancelled,
             FileTransferStatus.AllConfirmedDownloaded => FileTransferStatusExt.AllConfirmedDownloaded,
-            FileTransferStatus.Deleted => FileTransferStatusExt.Deleted,
+            FileTransferStatus.Purged => FileTransferStatusExt.Purged,
             FileTransferStatus.Failed => FileTransferStatusExt.Failed,
             _ => throw new InvalidEnumArgumentException()
         };
@@ -60,7 +60,7 @@ internal static class FileTransferStatusOverviewExtMapper
             FileTransferStatus.Published => "Ready for download",
             FileTransferStatus.Cancelled => "FileTransfer cancelled",
             FileTransferStatus.AllConfirmedDownloaded => "All downloaded",
-            FileTransferStatus.Deleted => "FileTransfer has been deleted",
+            FileTransferStatus.Purged => "FileTransfer has been purged",
             FileTransferStatus.Failed => "Upload failed",
             _ => throw new InvalidEnumArgumentException()
         };

--- a/src/Altinn.Broker.API/Mappers/LegacyFileStatusOverviewExtMapper.cs
+++ b/src/Altinn.Broker.API/Mappers/LegacyFileStatusOverviewExtMapper.cs
@@ -21,7 +21,7 @@ internal static class LegacyFileStatusOverviewExtMapper
             FileStatus = MapToExternalEnum(fileTransfer.FileTransferStatusEntity.Status),
             Sender = fileTransfer.Sender.ActorExternalId,
             FileStatusChanged = fileTransfer.FileTransferStatusChanged,
-            FileStatusText = MapToFileStatusText(fileTransfer.FileTransferStatusEntity.Status),
+            FileStatusText = MapToFileStatusText(fileTransfer.FileTransferStatusEntity),
             PropertyList = fileTransfer.PropertyList,
             Recipients = MapToRecipients(fileTransfer.RecipientCurrentStatuses),
             SendersFileReference = fileTransfer.SendersFileTransferReference,
@@ -40,15 +40,15 @@ internal static class LegacyFileStatusOverviewExtMapper
             FileTransferStatus.Published => LegacyFileStatusExt.Published,
             FileTransferStatus.Cancelled => LegacyFileStatusExt.Cancelled,
             FileTransferStatus.AllConfirmedDownloaded => LegacyFileStatusExt.AllConfirmedDownloaded,
-            FileTransferStatus.Deleted => LegacyFileStatusExt.Deleted,
+            FileTransferStatus.Purged => LegacyFileStatusExt.Deleted,
             FileTransferStatus.Failed => LegacyFileStatusExt.Failed,
             _ => throw new InvalidEnumArgumentException()
         };
     }
 
-    internal static string MapToFileStatusText(FileTransferStatus domainEnum)
+    internal static string MapToFileStatusText(FileTransferStatusEntity status)
     {
-        return domainEnum switch
+        return status.Status switch
         {
             FileTransferStatus.Initialized => "Ready for upload",
             FileTransferStatus.UploadStarted => "Upload started",
@@ -56,8 +56,8 @@ internal static class LegacyFileStatusOverviewExtMapper
             FileTransferStatus.Published => "Ready for download",
             FileTransferStatus.Cancelled => "File cancelled",
             FileTransferStatus.AllConfirmedDownloaded => "All downloaded",
-            FileTransferStatus.Deleted => "File has been deleted",
-            FileTransferStatus.Failed => "Upload failed",
+            FileTransferStatus.Purged => "File has been purged",
+            FileTransferStatus.Failed => status.DetailedStatus ?? "Upload failed",
             _ => throw new InvalidEnumArgumentException()
         };
     }

--- a/src/Altinn.Broker.Application/ExpireFileTransferCommand/ExpireFileTransferCommandHandler.cs
+++ b/src/Altinn.Broker.Application/ExpireFileTransferCommand/ExpireFileTransferCommandHandler.cs
@@ -40,13 +40,13 @@ public class ExpireFileTransferCommandHandler : IHandler<ExpireFileTransferComma
         var resource = await GetResource(fileTransfer.ResourceId, cancellationToken);
         var serviceOwner = await GetServiceOwner(resource.ServiceOwnerId);
 
-        if (fileTransfer.FileTransferStatusEntity.Status == Core.Domain.Enums.FileTransferStatus.Deleted)
+        if (fileTransfer.FileTransferStatusEntity.Status == Core.Domain.Enums.FileTransferStatus.Purged)
         {
-            _logger.LogInformation("FileTransfer has already been set to deleted");
+            _logger.LogInformation("FileTransfer has already been set to purged");
         }
-        else
+        else if (!request.DoNotUpdateStatus)
         {
-            await _fileTransferStatusRepository.InsertFileTransferStatus(fileTransfer.FileTransferId, Core.Domain.Enums.FileTransferStatus.Deleted, cancellationToken: cancellationToken);
+            await _fileTransferStatusRepository.InsertFileTransferStatus(fileTransfer.FileTransferId, Core.Domain.Enums.FileTransferStatus.Purged, cancellationToken: cancellationToken);
             await _eventBus.Publish(AltinnEventType.FileDeleted, fileTransfer.ResourceId, fileTransfer.FileTransferId.ToString(), null, cancellationToken);
         }
         if (request.Force || fileTransfer.ExpirationTime < DateTime.UtcNow)
@@ -58,11 +58,10 @@ public class ExpireFileTransferCommandHandler : IHandler<ExpireFileTransferComma
                 _logger.LogError("Recipient {recipientExternalReference} did not download the fileTransfer with id {fileTransferId}", recipient.Actor.ActorExternalId, recipient.FileTransferId.ToString());
                 await _eventBus.Publish(AltinnEventType.FileNeverConfirmedDownloaded, fileTransfer.ResourceId, fileTransfer.FileTransferId.ToString(), recipient.Actor.ActorExternalId, cancellationToken);
             }
-
         }
         else
         {
-            throw new Exception("FileTransfer has not expired, and should not be deleted");
+            throw new Exception("FileTransfer has not expired, and should not be purged");
         }
         return Task.CompletedTask;
     }

--- a/src/Altinn.Broker.Application/ExpireFileTransferCommand/ExpireFileTransferCommandHandler.cs
+++ b/src/Altinn.Broker.Application/ExpireFileTransferCommand/ExpireFileTransferCommandHandler.cs
@@ -47,7 +47,7 @@ public class ExpireFileTransferCommandHandler : IHandler<ExpireFileTransferComma
         else if (!request.DoNotUpdateStatus)
         {
             await _fileTransferStatusRepository.InsertFileTransferStatus(fileTransfer.FileTransferId, Core.Domain.Enums.FileTransferStatus.Purged, cancellationToken: cancellationToken);
-            await _eventBus.Publish(AltinnEventType.FileDeleted, fileTransfer.ResourceId, fileTransfer.FileTransferId.ToString(), null, cancellationToken);
+            await _eventBus.Publish(AltinnEventType.FilePurged, fileTransfer.ResourceId, fileTransfer.FileTransferId.ToString(), null, cancellationToken);
         }
         if (request.Force || fileTransfer.ExpirationTime < DateTime.UtcNow)
         {

--- a/src/Altinn.Broker.Application/ExpireFileTransferCommand/ExpireFileTransferCommandRequest.cs
+++ b/src/Altinn.Broker.Application/ExpireFileTransferCommand/ExpireFileTransferCommandRequest.cs
@@ -4,4 +4,10 @@ public class ExpireFileTransferCommandRequest
 {
     public Guid FileTransferId { get; set; }
     public bool Force { get; set; }
+
+    /// <summary>
+    /// When this is set, the ExpireFileTransferCommandHandler will delete the file from storage, but will refrain from setting the FileTransferStatus to Deleted in FileTransferRepository.
+    /// This is used when MalwareScanResultHandler fails an uploaded file.
+    /// </summary>
+    public bool DoNotUpdateStatus  {get;set; }
 }

--- a/src/Altinn.Broker.Application/ExpireFileTransferCommand/ExpireFileTransferCommandRequest.cs
+++ b/src/Altinn.Broker.Application/ExpireFileTransferCommand/ExpireFileTransferCommandRequest.cs
@@ -6,8 +6,8 @@ public class ExpireFileTransferCommandRequest
     public bool Force { get; set; }
 
     /// <summary>
-    /// When this is set, the ExpireFileTransferCommandHandler will delete the file from storage, but will refrain from setting the FileTransferStatus to Deleted in FileTransferRepository.
+    /// When this is set, the ExpireFileTransferCommandHandler will delete the file from storage, but will refrain from setting the FileTransferStatus to Purged in FileTransferRepository.
     /// This is used when MalwareScanResultHandler fails an uploaded file.
     /// </summary>
-    public bool DoNotUpdateStatus  {get;set; }
+    public bool DoNotUpdateStatus { get; set; }
 }

--- a/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
+++ b/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
@@ -66,7 +66,8 @@ public class MalwareScanningResultHandler : IHandler<ScanResultData, Task>
         _backgroundJobClient.Enqueue<ExpireFileTransferCommandHandler>(handler => handler.Process(new ExpireFileTransferCommandRequest
         {
             FileTransferId = fileTransfer.FileTransferId,
-            Force = true
+            Force = true,
+            DoNotUpdateStatus = true
         }, CancellationToken.None));
         return Task.CompletedTask;
     }

--- a/src/Altinn.Broker.Core/Domain/Enums/FileTransferStatus.cs
+++ b/src/Altinn.Broker.Core/Domain/Enums/FileTransferStatus.cs
@@ -8,6 +8,6 @@ public enum FileTransferStatus
     Published = 3,
     Cancelled = 4,
     AllConfirmedDownloaded = 5,
-    Deleted = 6,
+    Purged = 6,
     Failed = 7
 }

--- a/src/Altinn.Broker.Core/Services/Enums/AltinnEventType.cs
+++ b/src/Altinn.Broker.Core/Services/Enums/AltinnEventType.cs
@@ -8,6 +8,6 @@ public enum AltinnEventType
     UploadFailed,
     DownloadConfirmed,
     AllConfirmedDownloaded,
-    FileDeleted,
+    FilePurged,
     FileNeverConfirmedDownloaded
 }

--- a/src/Altinn.Broker.Persistence/Migrations/V0001__enum_tables.sql
+++ b/src/Altinn.Broker.Persistence/Migrations/V0001__enum_tables.sql
@@ -6,7 +6,7 @@ VALUES
 (3, 'Published'),
 (4, 'Cancelled'),
 (5, 'AllConfirmedDownloaded'),
-(6, 'Deleted'),
+(6, 'Purged'),
 (7, 'Failed');
 
 INSERT INTO broker.actor_file_transfer_status_description (actor_file_transfer_status_description_id_pk, actor_file_transfer_status_description)


### PR DESCRIPTION
…e better informed about their upload results.

#409

<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously uploaded files that have Malware issues would have their final status set to "Purged".
This change will ensure that files with Malware detected will have final status "Failed", with the Failed status and the extended MalwareScan result returned when using the LegacyFileStatus request.

I've also changed the Final status for files that have completed the Broker User Story to "Purged" rather than "Deleted", to communicate that the Altinn Broker system has purged the file from its system.

Added a Unit Test that includes malware result update of file. This creates a somewhat incorrect status history as the file status will be automatically set to published before being Failed, but that should not occur outside of the Unit Tests, and status history is not returned by Legacy requests anyway.

## Related Issue(s)
- #409 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
