### PR TITLE
Improved custom dimensions in logs

### DIFF
--- a/src/Altinn.Broker.Application/Altinn.Broker.Application.csproj
+++ b/src/Altinn.Broker.Application/Altinn.Broker.Application.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="OneOf" Version="3.0.263" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.Broker.Persistence/Altinn.Broker.Persistence.csproj
+++ b/src/Altinn.Broker.Persistence/Altinn.Broker.Persistence.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.8" />
     <PackageReference Include="Microsoft.Azure.Management.Storage" Version="25.0.0" />
     <PackageReference Include="Npgsql" Version="8.0.2" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
   </ItemGroup>
   


### PR DESCRIPTION
## Description
Make sure all custom data is added to the log context as soon as possible so that subsequent log entries will be searchable.
Example of how it can be used:
```
traces 
| extend fileTransferId = customDimensions.fileTransferId
| where fileTransferId == '1d970eec-c9d9-4c94-8a63-fea392b3aa38'
```

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
