### PR TITLE
Removed dead auth policy code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Altinn Broker is a Managed File Transfer (MFT) service for secure file transfer 
 
 ## Getting started
 
-Altinn Broker is currently available in Altinn's staging environment at https://platform.tt02.altinn.no. In order to get started integrating to the API, follow our [guide on getting started](https://docs.altinn.studio/broker/user-guides/) and implement according to our [Swagger specification](https://docs.altinn.studio/api/broker/spec/).
+Altinn Broker is currently available in Altinn's staging environment at https://platform.tt02.altinn.no. In order to get started integrating to the API, follow our [guide on getting started](https://docs.altinn.studio/broker/getting-started/) and implement according to our [Swagger specification](https://docs.altinn.studio/api/broker/spec/).
 
 ## Postman
 

--- a/src/Altinn.Broker.Integrations/Altinn/Authorization/XacmlMappers.cs
+++ b/src/Altinn.Broker.Integrations/Altinn/Authorization/XacmlMappers.cs
@@ -50,7 +50,6 @@ public static class XacmlMappers
             Attribute = new List<XacmlJsonAttribute>
                 {
                     DecisionHelper.CreateXacmlJsonAttribute(MatchAttributeIdentifiers.ActionId, actionType, DefaultType, DefaultIssuer, includeResult),
-                    DecisionHelper.CreateXacmlJsonAttribute(MatchAttributeIdentifiers.ActionId, "publish", DefaultType, DefaultIssuer, includeResult) // Permission to publish events is always required
                 }
         };
         return actionAttributes;
@@ -63,7 +62,6 @@ public static class XacmlMappers
         XacmlJsonCategory resourceCategory = new() { Attribute = new List<XacmlJsonAttribute>() };
 
         resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.ResourceId, resourceEntity.Id, DefaultType, DefaultIssuer));
-        resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.AppId, "altinn-broker", DefaultType, DefaultIssuer));
 
         return resourceCategory;
     }


### PR DESCRIPTION
## Description
We previously included "publish" among the actions used in the Policy Decision Point (PDP) request because at that time we forwarded the token to Altinn Events to publsh events on their behalf. If their token could not pass Altinn Events authorization check it would fail during our request processing. Hence we pre-authorized requests to make sure we failed early error message. 
We changed our integration to use altinn:events.publish.admin scope some time ago to avoid forwarding tokens like that. One of the benefits is that we no longer need to pre-authorize.

Also changed the use of the AppId resource attribute.  This attribute is not used like that. So removed.

## Related Issue(s)
- #408 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
