### PR TITLE
Bugfix: skipping default logic should only happen when authenticate fails 

### DIFF
--- a/src/Altinn.Broker.API/Helpers/JWTBearerEventsHelper.cs
+++ b/src/Altinn.Broker.API/Helpers/JWTBearerEventsHelper.cs
@@ -8,7 +8,7 @@ public class JWTBearerEventsHelper
     {
         context.Response.StatusCode = StatusCodes.Status401Unauthorized;
         context.Response.ContentType = "application/json";
-        context.Response.Headers.Append("WWW-Authenticate", context.Options.Challenge + " error=\"invalid_token\", error_description=\"" + context.Exception.Message + "\"");
+        context.Response.Headers.Append("WWW-Authenticate", context.Options.Challenge + " error=\"invalid_token\"");
         string err = "";
         if (context.Exception is SecurityTokenInvalidIssuerException)
         {
@@ -20,6 +20,7 @@ public class JWTBearerEventsHelper
                 err = "IDX10205: Issuer validation failed. Maskinporten token is not valid. Exchange to Altinn token and try again. Read more at https://docs.altinn.studio/api/scenarios/authentication/#maskinporten-jwt-access-token-input";
             }
         }
+
         return context.Response.WriteAsync(err);
     }
 }

--- a/src/Altinn.Broker.API/Helpers/JWTBearerEventsHelper.cs
+++ b/src/Altinn.Broker.API/Helpers/JWTBearerEventsHelper.cs
@@ -20,7 +20,6 @@ public class JWTBearerEventsHelper
                 err = "IDX10205: Issuer validation failed. Maskinporten token is not valid. Exchange to Altinn token and try again. Read more at https://docs.altinn.studio/api/scenarios/authentication/#maskinporten-jwt-access-token-input";
             }
         }
-
         return context.Response.WriteAsync(err);
     }
 }

--- a/src/Altinn.Broker.API/Helpers/JWTBearerEventsHelper.cs
+++ b/src/Altinn.Broker.API/Helpers/JWTBearerEventsHelper.cs
@@ -9,7 +9,7 @@ public class JWTBearerEventsHelper
         context.Response.StatusCode = StatusCodes.Status401Unauthorized;
         context.Response.ContentType = "application/json";
         context.Response.Headers.Append("WWW-Authenticate", context.Options.Challenge + " error=\"invalid_token\"");
-        string err = "";
+        string err = context.Exception.Message;
         if (context.Exception is SecurityTokenInvalidIssuerException)
         {
             context.Response.StatusCode = StatusCodes.Status403Forbidden;

--- a/src/Altinn.Broker.API/Program.cs
+++ b/src/Altinn.Broker.API/Program.cs
@@ -130,7 +130,10 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
                 OnAuthenticationFailed = context => JWTBearerEventsHelper.OnAuthenticationFailed(context),
                 OnChallenge = c =>
                 {
-                    c.HandleResponse();
+                    if (c.AuthenticateFailure != null)
+                    {
+                        c.HandleResponse();
+                    }
                     return Task.CompletedTask;
                 }
             };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
skipping default logic should only happen when authenticate fails 


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
