### PR TITLE
Always exchange to Altinn token when communicating with Altinn platform

### DIFF
--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -49,6 +49,10 @@ var containerAppEnvVars = [
     name: 'MaskinportenSettings__Scope'
     value: 'altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin'
   }
+  { 
+    name: 'MaskinportenSettings__ExhangeToAltinnToken'
+    value: 'true'
+  }
   { name: 'MaskinportenSettings__EncodedJwk', secretRef: 'maskinporten-jwk' }
 ]
 resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {

--- a/src/Altinn.Broker.API/appsettings.Development.json
+++ b/src/Altinn.Broker.API/appsettings.Development.json
@@ -23,9 +23,10 @@
     "PlatformSubscriptionKey": ""
   },
   "MaskinportenSettings": {
-    "Environment": "ver2",
+    "Environment": "test",
     "ClientId": "",
     "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin",
-    "EncodedJwk": ""
+    "EncodedJwk": "",
+    "ExhangeToAltinnToken": true
   }
 }

--- a/src/Altinn.Broker.Integrations/DependencyInjection.cs
+++ b/src/Altinn.Broker.Integrations/DependencyInjection.cs
@@ -40,16 +40,16 @@ public static class DependencyInjection
         else
         {
             services.RegisterMaskinportenClientDefinition<SettingsJwkClientDefinition>(typeof(IEventBus).FullName, maskinportenSettings);
-            services.AddHttpClient<IEventBus, AltinnEventBus>((client) => client.BaseAddress = new Uri(altinnOptions!.PlatformGatewayUrl))
-                .AddMaskinportenHttpMessageHandler<SettingsJwkClientDefinition, IEventBus>(x => x.ClientSettings.ExhangeToAltinnToken = true);
+            services.AddHttpClient<IEventBus, AltinnEventBus>((client) => client.BaseAddress = new Uri(altinnOptions.PlatformGatewayUrl))
+                .AddMaskinportenHttpMessageHandler<SettingsJwkClientDefinition, IEventBus>();
 
             services.RegisterMaskinportenClientDefinition<SettingsJwkClientDefinition>(typeof(IAltinnRegisterService).FullName, maskinportenSettings);
-            services.AddHttpClient<IAltinnRegisterService, AltinnRegisterService>((client) => client.BaseAddress = new Uri(altinnOptions!.PlatformGatewayUrl))
-                .AddMaskinportenHttpMessageHandler<SettingsJwkClientDefinition, IAltinnRegisterService>(x => x.ClientSettings.ExhangeToAltinnToken = true);
+            services.AddHttpClient<IAltinnRegisterService, AltinnRegisterService>((client) => client.BaseAddress = new Uri(altinnOptions.PlatformGatewayUrl))
+                .AddMaskinportenHttpMessageHandler<SettingsJwkClientDefinition, IAltinnRegisterService>();
 
             services.RegisterMaskinportenClientDefinition<SettingsJwkClientDefinition>(typeof(IAuthorizationService).FullName, maskinportenSettings);
-            services.AddHttpClient<IAuthorizationService, AltinnAuthorizationService>((client) => client.BaseAddress = new Uri(altinnOptions!.PlatformGatewayUrl))
-                    .AddMaskinportenHttpMessageHandler<SettingsJwkClientDefinition, IAuthorizationService>(x => x.ClientSettings.ExhangeToAltinnToken = false);
+            services.AddHttpClient<IAuthorizationService, AltinnAuthorizationService>((client) => client.BaseAddress = new Uri(altinnOptions.PlatformGatewayUrl))
+                    .AddMaskinportenHttpMessageHandler<SettingsJwkClientDefinition, IAuthorizationService>();
         }
     }
 }


### PR DESCRIPTION
## Description
We previously used Maskinporten token to Altinn Authorization, but that is no longer the case. Hence we move exhangeToAltinnToken to "global" configuration for our Altinn services.

There seems to have been an issue with cache invalidation where the authorization token, which was Maskinporten only, was not renewed as expected. Reading through the library, it does not seem like how we used the library (doing both Maskinporten and Altinn token at the same time) was the expected way to use it. Nor is it the way forward for us either.

## Related Issue(s)
- #507 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
