### PR TITLE
Log custom properties

### DIFF
--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -74,6 +74,7 @@ public class FileTransferController : Controller
         CancellationToken cancellationToken
     )
     {
+        LogContextHelpers.EnrichLogsWithFileTransferId(fileTransferId);
         LogContextHelpers.EnrichLogsWithToken(token);
         _logger.LogInformation("Uploading file for file transfer {fileTransferId}", fileTransferId.ToString());
         Request.EnableBuffering();
@@ -144,6 +145,7 @@ public class FileTransferController : Controller
         [FromServices] GetFileTransferOverviewQueryHandler handler,
         CancellationToken cancellationToken)
     {
+        LogContextHelpers.EnrichLogsWithFileTransferId(fileTransferId);
         LogContextHelpers.EnrichLogsWithToken(token);
         _logger.LogInformation("Getting filetransfer overview for {fileTransferId}", fileTransferId.ToString());
         var queryResult = await handler.Process(new GetFileTransferOverviewQueryRequest()
@@ -170,6 +172,7 @@ public class FileTransferController : Controller
         [FromServices] GetFileTransferDetailsQueryHandler handler,
         CancellationToken cancellationToken)
     {
+        LogContextHelpers.EnrichLogsWithFileTransferId(fileTransferId);
         LogContextHelpers.EnrichLogsWithToken(token);
         _logger.LogInformation("Getting fileTransfer details for {fileTransferId}", fileTransferId.ToString());
         var queryResult = await handler.Process(new GetFileTransferDetailsQueryRequest()
@@ -230,6 +233,7 @@ public class FileTransferController : Controller
         [FromServices] DownloadFileQueryHandler handler,
          CancellationToken cancellationToken)
     {
+        LogContextHelpers.EnrichLogsWithFileTransferId(fileTransferId);
         LogContextHelpers.EnrichLogsWithToken(token);
         _logger.LogInformation("Downloading file for file transfer {fileTransferId}", fileTransferId.ToString());
         var queryResult = await handler.Process(new DownloadFileQueryRequest()
@@ -256,6 +260,7 @@ public class FileTransferController : Controller
         [FromServices] ConfirmDownloadCommandHandler handler,
         CancellationToken cancellationToken)
     {
+        LogContextHelpers.EnrichLogsWithFileTransferId(fileTransferId);
         LogContextHelpers.EnrichLogsWithToken(token);
         _logger.LogInformation("Confirming download for fileTransfer {fileTransferId}", fileTransferId.ToString());
         var requestData = new ConfirmDownloadCommandRequest()

--- a/src/Altinn.Broker.API/Helpers/LogContextHelpers.cs
+++ b/src/Altinn.Broker.API/Helpers/LogContextHelpers.cs
@@ -36,4 +36,9 @@ public static class LogContextHelpers
     {
         LogContext.PushProperty("fileTransferId", fileTransferId);
     }   
+
+    public static void EnrichLogsWithResourceId(string resourceId)
+    {
+        LogContext.PushProperty("resourceId", resourceId);
+    }
 }

--- a/src/Altinn.Broker.API/Helpers/LogContextHelpers.cs
+++ b/src/Altinn.Broker.API/Helpers/LogContextHelpers.cs
@@ -31,4 +31,9 @@ public static class LogContextHelpers
         LogContext.PushProperty("scope", token.Scope);
         LogContext.PushProperty("clientId", token.ClientId);
     }
+
+    public static void EnrichLogsWithFileTransferId(Guid fileTransferId)
+    {
+        LogContext.PushProperty("fileTransferId", fileTransferId);
+    }   
 }

--- a/src/Altinn.Broker.Application/ExpireFileTransferCommand/ExpireFileTransferCommandHandler.cs
+++ b/src/Altinn.Broker.Application/ExpireFileTransferCommand/ExpireFileTransferCommandHandler.cs
@@ -10,6 +10,8 @@ using Microsoft.Extensions.Logging;
 
 using OneOf;
 
+using Serilog.Context;
+
 namespace Altinn.Broker.Application.ExpireFileTransferCommand;
 public class ExpireFileTransferCommandHandler : IHandler<ExpireFileTransferCommandRequest, Task>
 {
@@ -35,6 +37,7 @@ public class ExpireFileTransferCommandHandler : IHandler<ExpireFileTransferComma
     [AutomaticRetry(Attempts = 0)]
     public async Task<OneOf<Task, Error>> Process(ExpireFileTransferCommandRequest request, CancellationToken cancellationToken)
     {
+        LogContext.PushProperty("fileTransferId", request.FileTransferId);
         _logger.LogInformation("Deleting file transfer with id {fileTransferId}", request.FileTransferId.ToString());
         var fileTransfer = await GetFileTransferAsync(request.FileTransferId, cancellationToken);
         var resource = await GetResource(fileTransfer.ResourceId, cancellationToken);

--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
@@ -118,6 +118,7 @@ public class FileTransferRepository : IFileTransferRepository
 
     private static void EnrichLogs(FileTransferEntity fileTransferEntity)
     {
+        LogContext.PushProperty("resourceId", fileTransferEntity.ResourceId);
         LogContext.PushProperty("fileTransferId", fileTransferEntity.FileTransferId);
         LogContext.PushProperty("resourceId", fileTransferEntity.ResourceId);
         LogContext.PushProperty("sender", fileTransferEntity.Sender);


### PR DESCRIPTION
## Description
Log custom properties so that we can make queries like the following in app insights:

Gets log entries associated with the given file transfer id.
`AppTraces
| where Properties.fileTransferId == "a062e0b9-4400-4a6a-89c6-ff1780992240"
`



Gets log entries associated with the given resource:
`AppTraces
| where Properties.resourceId == "altinn-broker-test-resource"
`


## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
