### PR TITLE
Fix: code smell regarding log entries

### DIFF
--- a/src/Altinn.Broker.Application/InitializeFileTransferCommand/InitializeFileTransferCommandHandler.cs
+++ b/src/Altinn.Broker.Application/InitializeFileTransferCommand/InitializeFileTransferCommandHandler.cs
@@ -85,7 +85,7 @@ public class InitializeFileTransferCommandHandler : IHandler<InitializeFileTrans
             Force = false
         }, cancellationToken), fileExpirationTime);
         await _fileTransferRepository.SetFileTransferHangfireJobId(fileTransferId, jobId, cancellationToken);
-        await _eventBus.Publish(AltinnEventType.FileTransferInitialized, request.ResourceId, fileTransferId.ToString(), request.SenderExternalId, cancellationToken);
+        await _eventBus.Publish(AltinnEventType.FileTransferInitialized, resource.Id, fileTransferId.ToString(), request.SenderExternalId, cancellationToken);
 
         return fileTransferId;
     }


### PR DESCRIPTION
Fix i code smell der bruker input var logget. Likt som i correspondence

## Description
Bruk resource.Id istedenfor request.ResourceId i AltinnEventBus

## Related Issue(s)
- [#171 i correspondence](https://github.com/Altinn/altinn-correspondence/issues/171)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
