### PR TITLE
fix endless loop and add max attempt

### DIFF
--- a/.github/tools/revisionVerifier.sh
+++ b/.github/tools/revisionVerifier.sh
@@ -31,6 +31,10 @@ verify_revision() {
   if [[ $health_state == "Healthy" && ($running_state == "Running" || $running_state == "RunningAtMaxScale") ]]; then
     return 0  # OK!
   else
+    if [[ $running_state == "Failed"]]; then
+      echo "Revision $revision_name failed. Exiting script."
+      exit 1
+    fi 
     return 1  # Not OK!
   fi
 }
@@ -46,5 +50,8 @@ while true; do
     echo "Attempt $attempt: Waiting for revision $revision_name ..."
     sleep 10 # Sleep for 10 seconds
     attempt=$((attempt+1))
+    if [[ $attempt -gt 25 ]]; then
+      echo "Revision $revision_name did not start in time. Exiting script."
+      exit 1
   fi
 done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
revision verifier had an endless loop. Now it will exit if a revision reaches a failed state, or if it attemps 25 times. 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
