### PR TITLE
Return ProblemDetails for authentication errors

### DIFF
--- a/src/Altinn.Broker.API/Helpers/JWTBearerEventsHelper.cs
+++ b/src/Altinn.Broker.API/Helpers/JWTBearerEventsHelper.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Altinn.Broker.Helpers;
@@ -6,20 +7,28 @@ public class JWTBearerEventsHelper
 {
     public static Task OnAuthenticationFailed(AuthenticationFailedContext context)
     {
-        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-        context.Response.ContentType = "application/json";
+        context.Response.ContentType = "application/problem+json";
         context.Response.Headers.Append("WWW-Authenticate", context.Options.Challenge + " error=\"invalid_token\"");
-        string err = context.Exception.Message;
         if (context.Exception is SecurityTokenInvalidIssuerException)
         {
-            context.Response.StatusCode = StatusCodes.Status403Forbidden;
-            context.Response.ContentType = "application/json";
             var issuer = ((SecurityTokenInvalidIssuerException)context.Exception).InvalidIssuer;
             if (issuer.ToString().Contains("maskinporten.no"))
             {
-                err = "IDX10205: Issuer validation failed. Maskinporten token is not valid. Exchange to Altinn token and try again. Read more at https://docs.altinn.studio/api/scenarios/authentication/#maskinporten-jwt-access-token-input";
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                return context.Response.WriteAsJsonAsync(new ProblemDetails()
+                {
+                    Status = StatusCodes.Status403Forbidden,
+                    Title = "IDX10205: Issuer validation failed",
+                    Detail = "Maskinporten token is not valid. Exchange to Altinn token and try again. Read more at https://docs.altinn.studio/api/scenarios/authentication/#maskinporten-jwt-access-token-input"
+                });
             }
         }
-        return context.Response.WriteAsync(err);
+        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+        return context.Response.WriteAsJsonAsync(new ProblemDetails
+        {
+            Status = StatusCodes.Status401Unauthorized,
+            Title = "Authentication failed",
+            Detail = context.Exception.Message
+        });
     }
 }


### PR DESCRIPTION
## Description
Authentication errors should also return ProblemDetails so that consumers can parse all errors in the same way.

## Related Issue(s)
- #396 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
