### PR TITLE
Limit search result set to 100 and sort by default

### DIFF
--- a/altinn-broker-openapi-v1.json
+++ b/altinn-broker-openapi-v1.json
@@ -202,7 +202,7 @@
           "File"
         ],
         "summary": "List files available for the caller",
-        "description": "This endpoint retrieves a list of files available given for the caller given the query parameters.",
+        "description": "Get files that can be accessed by the caller according to specified filters. Result set is limited to 100 files. If your query returns more than 100 files, you will only receive the 100 first ordered by time created.",
         "operationId": "List files",
         "parameters": [
           {

--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -185,7 +185,7 @@ public class FileTransferController : Controller
     }
 
     /// <summary>
-    /// Get files that can be accessed by the caller according to specified filters. Result set is limited to 100 files.
+    /// Get files that can be accessed by the caller according to specified filters. Result set is limited to 100 files. If your query returns more than 100 files, you will only receive the 100 first ordered by time created.
     /// </summary>
     /// <returns></returns>
     [HttpGet]

--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -185,7 +185,7 @@ public class FileTransferController : Controller
     }
 
     /// <summary>
-    /// Get files that can be accessed by the caller according to specified filters. Result set is limited to 100 files. If your query returns more than 100 files, you will only receive the 100 first ordered by time created.
+    /// Get files that can be accessed by the caller according to specified filters. Result set is limited to 100 files. If your query returns more than 100 files, you will only receive the 100 last created.
     /// </summary>
     /// <returns></returns>
     [HttpGet]

--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
@@ -340,6 +340,8 @@ public class FileTransferRepository : IFileTransferRepository
         {
             commandString.AppendLine("AND f.created < @to");
         }
+        commandString.AppendLine("ORDER BY f.created ASC");
+        commandString.AppendLine("LIMIT 100");
 
         commandString.AppendLine(";");
 
@@ -393,6 +395,8 @@ public class FileTransferRepository : IFileTransferRepository
         {
             commandString.AppendLine("AND f.created < @to");
         }
+        commandString.AppendLine("ORDER BY f.created ASC"); 
+        commandString.AppendLine("LIMIT 100"); 
 
         await using (var command = _dataSource.CreateCommand(
             commandString.ToString()))


### PR DESCRIPTION
## Description
Limit result set to 100, and sort is by time created descending. This way we got a clearly defined search and consumer can use "to" and "from" to paginate.

Not as good pagination as Correspondence, but it is consistent with how Altinn 2 did it so no need for migrators to change. Does Broker need better pagination (already have recipientStatus search)?

## Related Issue(s)
- #527 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
