### PR TITLE
Fix + Change to primary constructor

### DIFF
--- a/src/Altinn.Broker.API/Altinn.Broker.API.csproj
+++ b/src/Altinn.Broker.API/Altinn.Broker.API.csproj
@@ -7,25 +7,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="9.1.0" />
+    <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="9.2.0" />
     <PackageReference Include="Altinn.Common.PEP" Version="4.0.0" />
-    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.14" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.8.1.1" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.9" />     
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="2.20.0" />
-    <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="3.1.0" />
+    <PackageReference Include="Serilog" Version="4.0.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.24.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.3" />
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.25.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.Broker.API/Configuration/Constants.cs
+++ b/src/Altinn.Broker.API/Configuration/Constants.cs
@@ -1,0 +1,6 @@
+﻿namespace Altinn.Broker.API.Configuration;
+
+public static class Constants
+{
+    public const string OrgNumberPattern = @"^\d{4}:\d{9}$";
+}

--- a/src/Altinn.Broker.API/Controllers/HealthController.cs
+++ b/src/Altinn.Broker.API/Controllers/HealthController.cs
@@ -14,23 +14,16 @@ namespace Altinn.Broker.Controllers;
 
 [ApiController]
 [Route("health")]
-public class HealthController : ControllerBase
+public class HealthController(NpgsqlDataSource databaseConnectionProvider, IOptions<AzureResourceManagerOptions> azureResourceManagerOptions) : ControllerBase
 {
-    private readonly NpgsqlDataSource _databaseConnectionProvider;
-    private readonly AzureResourceManagerOptions _azureResourceManagerOptions;
-
-    public HealthController(NpgsqlDataSource databaseConnectionProvider, IOptions<AzureResourceManagerOptions> azureResourceManagerOptions)
-    {
-        _databaseConnectionProvider = databaseConnectionProvider;
-        _azureResourceManagerOptions = azureResourceManagerOptions.Value;
-    }
+    private readonly AzureResourceManagerOptions _azureResourceManagerOptions = azureResourceManagerOptions.Value;
 
     [HttpGet]
     public async Task<ActionResult> HealthCheckAsync()
     {
         try
         {
-            using var command = _databaseConnectionProvider.CreateCommand("SELECT COUNT(*) FROM broker.file_transfer_status_description");
+            using var command = databaseConnectionProvider.CreateCommand("SELECT COUNT(*) FROM broker.file_transfer_status_description");
             var count = (long)(command.ExecuteScalar() ?? 0);
             if (count == 0)
             {

--- a/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
+++ b/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
@@ -142,24 +142,12 @@ public class LegacyFileController(ILogger<LegacyFileController> logger) : Contro
         var organizationNumberPattern = new Regex(Constants.OrgNumberPattern);
         if (recipients?.Length > 0)
         {
-            var invalidRecipients = recipients.Where(r => !organizationNumberPattern.IsMatch(r)).ToList();
-
-            if (invalidRecipients.Any())
-            {
-                return BadRequest($"Invalid recipient format");
-            }
-
             var recipientsString = string.Join(',', recipients);
-            logger.LogInformation("Getting files with status {status} created {from} to {to} for recipients {recipients}",
-                recipientStatus?.ToString(), from?.ToString(), to?.ToString(), recipientsString.SanitizeForLogs());
+            logger.LogInformation("Getting files with status {status} created {from} to {to} for recipients {recipients}", recipientStatus?.ToString(), from?.ToString(), to?.ToString(), recipientsString.SanitizeForLogs());
         }
-        else if (onBehalfOfConsumer is not null)
+        else
         {
-            if (!organizationNumberPattern.IsMatch(onBehalfOfConsumer))
-            {
-                return BadRequest($"Invalid onBehalfOfConsumer format");
-            }
-            logger.LogInformation("Getting files with status {status} created {from} to {to} for consumer {consumer}", recipientStatus?.ToString(), from?.ToString(), to?.ToString(), onBehalfOfConsumer);
+            logger.LogInformation("Getting files with status {status} created {from} to {to} for consumer {consumer}", recipientStatus?.ToString(), from?.ToString(), to?.ToString(), onBehalfOfConsumer.SanitizeForLogs());
         }
 
         var queryResult = await handler.Process(new LegacyGetFilesRequest()

--- a/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
+++ b/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
@@ -10,6 +10,7 @@ using Altinn.Broker.Application.InitializeFileTransfer;
 using Altinn.Broker.Application.UploadFile;
 using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Domain.Enums;
+using Altinn.Broker.Core.Helpers;
 using Altinn.Broker.Enums;
 using Altinn.Broker.Helpers;
 using Altinn.Broker.Mappers;
@@ -150,7 +151,7 @@ public class LegacyFileController(ILogger<LegacyFileController> logger) : Contro
 
             var recipientsString = string.Join(',', recipients);
             logger.LogInformation("Getting files with status {status} created {from} to {to} for recipients {recipients}",
-                recipientStatus?.ToString(), from?.ToString(), to?.ToString(), recipientsString);
+                recipientStatus?.ToString(), from?.ToString(), to?.ToString(), recipientsString.SanitizeForLogs());
         }
         else if (onBehalfOfConsumer is not null)
         {

--- a/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
+++ b/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
@@ -26,14 +26,8 @@ namespace Altinn.Broker.Controllers;
 [Route("broker/api/legacy/v1/file")]
 [Authorize(AuthenticationSchemes = AuthorizationConstants.Legacy)]
 [Authorize(Policy = AuthorizationConstants.Legacy)]
-public class LegacyFileController : Controller
+public class LegacyFileController(ILogger<LegacyFileController> logger) : Controller
 {
-    private readonly ILogger<LegacyFileController> _logger;
-
-    public LegacyFileController(ILogger<LegacyFileController> logger)
-    {
-        _logger = logger;
-    }
 
     /// <summary>
     /// Initialize a file upload
@@ -46,7 +40,7 @@ public class LegacyFileController : Controller
 
         LogContextHelpers.EnrichLogsWithLegacyInitializeFile(initializeExt);
         LogContextHelpers.EnrichLogsWithToken(legacyToken);
-        _logger.LogInformation("Legacy - Initializing file");
+        logger.LogInformation("Legacy - Initializing file");
         var commandRequest = LegacyInitializeFileMapper.MapToRequest(initializeExt, token);
         var commandResult = await handler.Process(commandRequest, cancellationToken);
         return commandResult.Match(
@@ -73,7 +67,7 @@ public class LegacyFileController : Controller
         CallerIdentity legacyToken = CreateLegacyToken(onBehalfOfConsumer, token);
 
         LogContextHelpers.EnrichLogsWithToken(legacyToken);
-        _logger.LogInformation("Legacy - Uploading file for file transfer {fileId}", fileTransferId.ToString());
+        logger.LogInformation("Legacy - Uploading file for file transfer {fileId}", fileTransferId.ToString());
         Request.EnableBuffering();
         var commandResult = await handler.Process(new UploadFileRequest()
         {
@@ -104,7 +98,7 @@ public class LegacyFileController : Controller
         CallerIdentity legacyToken = CreateLegacyToken(onBehalfOfConsumer, token);
 
         LogContextHelpers.EnrichLogsWithToken(legacyToken);
-        _logger.LogInformation("Legacy - Getting file overview for {fileId}", fileId.ToString());
+        logger.LogInformation("Legacy - Getting file overview for {fileId}", fileId.ToString());
         var queryResult = await handler.Process(new GetFileTransferOverviewRequest()
         {
             FileTransferId = fileId,
@@ -146,11 +140,11 @@ public class LegacyFileController : Controller
         if (recipients?.Length > 0)
         {
             recipientsString = string.Join(',', recipients);
-            _logger.LogInformation("Getting files with status {status} created {from} to {to} for recipients {recipients}", recipientStatus?.ToString(), from?.ToString(), to?.ToString(), recipientsString);
+            logger.LogInformation("Getting files with status {status} created {from} to {to} for recipients {recipients}", recipientStatus?.ToString(), from?.ToString(), to?.ToString(), recipientsString);
         }
         else
         {
-            _logger.LogInformation("Getting files with status {status} created {from} to {to} for consumer {consumer}", recipientStatus?.ToString(), from?.ToString(), to?.ToString(), onBehalfOfConsumer);
+            logger.LogInformation("Getting files with status {status} created {from} to {to} for consumer {consumer}", recipientStatus?.ToString(), from?.ToString(), to?.ToString(), onBehalfOfConsumer);
         }
 
         var queryResult = await handler.Process(new LegacyGetFilesRequest()
@@ -185,7 +179,7 @@ public class LegacyFileController : Controller
     {
         CallerIdentity? legacyToken = CreateLegacyToken(onBehalfOfConsumer, token);
         LogContextHelpers.EnrichLogsWithToken(legacyToken);
-        _logger.LogInformation("Downloading file {fileId}", fileId.ToString());
+        logger.LogInformation("Downloading file {fileId}", fileId.ToString());
         var queryResult = await handler.Process(new DownloadFileRequest()
         {
             FileTransferId = fileId,
@@ -213,7 +207,7 @@ public class LegacyFileController : Controller
     {
         CallerIdentity? legacyToken = CreateLegacyToken(onBehalfOfConsumer, token);
         LogContextHelpers.EnrichLogsWithToken(legacyToken);
-        _logger.LogInformation("Confirming download for file {fileId}", fileId.ToString());
+        logger.LogInformation("Confirming download for file {fileId}", fileId.ToString());
         var commandResult = await handler.Process(new ConfirmDownloadRequest()
         {
             FileTransferId = fileId,

--- a/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
+++ b/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
@@ -147,7 +147,7 @@ public class LegacyFileController(ILogger<LegacyFileController> logger) : Contro
         }
         else
         {
-            logger.LogInformation("Getting files with status {status} created {from} to {to} for consumer {consumer}", recipientStatus?.ToString(), from?.ToString(), to?.ToString(), onBehalfOfConsumer.SanitizeForLogs());
+            logger.LogInformation("Getting files with status {status} created {from} to {to} for consumer {consumer}", recipientStatus?.ToString(), from?.ToString(), to?.ToString(), onBehalfOfConsumer?.SanitizeForLogs());
         }
 
         var queryResult = await handler.Process(new LegacyGetFilesRequest()

--- a/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
+++ b/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
@@ -152,7 +152,7 @@ public class LegacyFileController(ILogger<LegacyFileController> logger) : Contro
             logger.LogInformation("Getting files with status {status} created {from} to {to} for recipients {recipients}",
                 recipientStatus?.ToString(), from?.ToString(), to?.ToString(), recipientsString);
         }
-        else
+        else if (onBehalfOfConsumer is not null)
         {
             if (!organizationNumberPattern.IsMatch(onBehalfOfConsumer))
             {

--- a/src/Altinn.Broker.API/Controllers/MalwareScanResultsController.cs
+++ b/src/Altinn.Broker.API/Controllers/MalwareScanResultsController.cs
@@ -17,17 +17,8 @@ namespace Altinn.Broker.Webhooks.Controllers;
 
 [ApiController]
 [Route("broker/api/v1/webhooks/malwarescanresults")]
-public class MalwareScanResultsController : Controller
+public class MalwareScanResultsController(IIdempotencyEventRepository idempotencyEventRepository, ILogger<MalwareScanResultsController> logger) : Controller
 {
-    private readonly IIdempotencyEventRepository _idempotencyEventRepository;
-    private readonly ILogger<MalwareScanResultsController> _logger;
-
-    public MalwareScanResultsController(IIdempotencyEventRepository idempotencyEventRepository, ILogger<MalwareScanResultsController> logger)
-    {
-        _idempotencyEventRepository = idempotencyEventRepository;
-        _logger = logger;
-    }
-
     [HttpPost]
     [Consumes("application/json")]
     public async Task<ActionResult> ProcessMalwareScanResult([FromServices] MalwareScanningResultHandler handler, CancellationToken cancellationToken)
@@ -36,7 +27,7 @@ public class MalwareScanResultsController : Controller
         EventGridEvent[] eventGridEvents = EventGridEvent.ParseMany(events);
         foreach (EventGridEvent eventGridEvent in eventGridEvents)
         {
-            _logger.LogInformation("Got malware scan event of type {EventType} with data: {eventData}", eventGridEvent.EventType, eventGridEvent.Data.ToString());
+            logger.LogInformation("Got malware scan event of type {EventType} with data: {eventData}", eventGridEvent.EventType, eventGridEvent.Data.ToString());
             if (eventGridEvent.TryGetSystemEventData(out object eventData))
             {
                 if (eventData is SubscriptionValidationEventData subscriptionValidationEventData)
@@ -58,7 +49,7 @@ public class MalwareScanResultsController : Controller
                     throw new InvalidOperationException("Failed to deserialize malware scan result data");
                 }
                 var processFunction = new Func<Task<OneOf<Task, Error>>>(() => handler.Process(result, cancellationToken));
-                var commandResult = await IdempotencyEventHelper.ProcessEvent(result.ETag, processFunction, _idempotencyEventRepository, cancellationToken);
+                var commandResult = await IdempotencyEventHelper.ProcessEvent(result.ETag, processFunction, idempotencyEventRepository, cancellationToken);
                 return commandResult.Match(
                     Ok,
                     Problem

--- a/src/Altinn.Broker.API/Helpers/SecurityHeadersMiddleware.cs
+++ b/src/Altinn.Broker.API/Helpers/SecurityHeadersMiddleware.cs
@@ -1,19 +1,12 @@
 using Microsoft.Extensions.Primitives;
 
-public class SecurityHeadersMiddleware
+public class SecurityHeadersMiddleware(RequestDelegate next)
 {
-    private readonly RequestDelegate _next;
-
-    public SecurityHeadersMiddleware(RequestDelegate next)
-    {
-        _next = next;
-    }
-
     public async Task InvokeAsync(HttpContext context)
     {
         context.Response.Headers.Append("X-Content-Type-Options", new StringValues("nosniff"));
         context.Response.Headers.Append("Cache-Control", new StringValues("no-store"));
 
-        await _next(context);
+        await next(context);
     }
 }

--- a/src/Altinn.Broker.API/Helpers/ValidateElementsInList.cs
+++ b/src/Altinn.Broker.API/Helpers/ValidateElementsInList.cs
@@ -2,23 +2,14 @@
 
 namespace Altinn.Broker.Helpers;
 
-public class ValidateElementsInList : ValidationAttribute
+public class ValidateElementsInList(Type attributeType, params object[] attributeArgs) : ValidationAttribute
 {
-    private readonly Type _attributeType;
-    private readonly object[] _attributeArgs;
-
-    public ValidateElementsInList(Type attributeType, params object[] attributeArgs)
-    {
-        _attributeType = attributeType;
-        _attributeArgs = attributeArgs;
-    }
-
     protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
     {
         var list = value as IEnumerable<string>;
         if (list != null)
         {
-            var attributeInstance = (ValidationAttribute)Activator.CreateInstance(_attributeType, _attributeArgs)!;
+            var attributeInstance = (ValidationAttribute)Activator.CreateInstance(attributeType, attributeArgs)!;
             foreach (var item in list)
             {
                 if (!attributeInstance.IsValid(item))

--- a/src/Altinn.Broker.API/Middlewares/RequestLoggingMiddleware.cs
+++ b/src/Altinn.Broker.API/Middlewares/RequestLoggingMiddleware.cs
@@ -1,20 +1,10 @@
 ﻿namespace Altinn.Broker.Middlewares;
 
-public class RequestLoggingMiddleware
-{
-    private readonly RequestDelegate _next;
-
-    private readonly ILogger<RequestLoggingMiddleware> _logger;
-
-    public RequestLoggingMiddleware(
-        RequestDelegate next,
-        ILogger<RequestLoggingMiddleware> logger
+public class RequestLoggingMiddleware(
+    RequestDelegate next,
+    ILogger<RequestLoggingMiddleware> logger
     )
-    {
-        _next = next;
-        _logger = logger;
-    }
-
+{
     private static readonly string[] IgnoredPaths =
     {
         "/health",
@@ -28,14 +18,14 @@ public class RequestLoggingMiddleware
         var requestPath = httpContext.Request.PathBase.Add(httpContext.Request.Path).ToString();
         if (!IgnoredPaths.Any(path => requestPath.ToLowerInvariant().StartsWith(path)))
         {
-            _logger.LogInformation(
+            logger.LogInformation(
                 "Request for method {RequestMethod} at {RequestPath}",
                 requestMethod,
                 requestPath
             );
         }
 
-        await _next(httpContext);
+        await next(httpContext);
 
         // Log response
         var statusCode = httpContext.Response.StatusCode;
@@ -43,7 +33,7 @@ public class RequestLoggingMiddleware
         {
             if (statusCode >= 200 && statusCode < 400)
             {
-                _logger.LogInformation(
+                logger.LogInformation(
                     "Response for method {RequestMethod} at {RequestPath} with status code {ResponseStatusCode}",
                     requestMethod,
                     requestPath,
@@ -52,7 +42,7 @@ public class RequestLoggingMiddleware
             }
             else if (statusCode >= 400 && statusCode < 500)
             {
-                _logger.LogWarning(
+                logger.LogWarning(
                     "Response for method {RequestMethod} at {RequestPath} with status code {ResponseStatusCode}",
                     requestMethod,
                     requestPath,
@@ -61,7 +51,7 @@ public class RequestLoggingMiddleware
             }
             else if (statusCode >= 500)
             {
-                _logger.LogError(
+                logger.LogError(
                     "Response for method {RequestMethod} at {RequestPath} with status code {ResponseStatusCode}",
                     requestMethod,
                     requestPath,

--- a/src/Altinn.Broker.API/Models/FileTransferInitializeExt.cs
+++ b/src/Altinn.Broker.API/Models/FileTransferInitializeExt.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
+using Altinn.Broker.API.Configuration;
 using Altinn.Broker.Helpers;
 
 namespace Altinn.Broker.Models;
@@ -37,7 +38,7 @@ public class FileTransferInitalizeExt
     /// The sender organization of the file
     /// </summary>
     [JsonPropertyName("sender")]
-    [RegularExpressionAttribute(@"^\d{4}:\d{9}$", ErrorMessage = "Organization numbers should be on the form countrycode:organizationnumber, for instance 0192:910753614")]
+    [RegularExpressionAttribute(Constants.OrgNumberPattern, ErrorMessage = "Organization numbers should be on the form countrycode:organizationnumber, for instance 0192:910753614")]
     [Required]
     public string Sender { get; set; } = string.Empty;
 
@@ -45,7 +46,7 @@ public class FileTransferInitalizeExt
     /// The recipient organizations of the broker fileTransfer
     /// </summary>
     [JsonPropertyName("recipients")]
-    [ValidateElementsInList(typeof(RegularExpressionAttribute), @"^\d{4}:\d{9}$", ErrorMessage = "Each recipient should be on the form countrycode:organizationnumber, for instance 0192:910753614")]
+    [ValidateElementsInList(typeof(RegularExpressionAttribute), Constants.OrgNumberPattern, ErrorMessage = "Each recipient should be on the form countrycode:organizationnumber, for instance 0192:910753614")]
     [Required]
     [MinLength(1, ErrorMessage = "One or more recipients are required")]
     public List<string> Recipients { get; set; } = new List<string>();

--- a/src/Altinn.Broker.API/Models/Maskinporten/MaskinportenConsumer.cs
+++ b/src/Altinn.Broker.API/Models/Maskinporten/MaskinportenConsumer.cs
@@ -2,21 +2,15 @@
 
 namespace Altinn.Broker.Models.Maskinporten;
 
-public class MaskinportenConsumer
-{
-    [JsonConstructor]
-    public MaskinportenConsumer(
-        string authority,
-        string id
+[method: JsonConstructor]
+public class MaskinportenConsumer(
+    string authority,
+    string id
     )
-    {
-        Authority = authority;
-        ID = id;
-    }
-
+{
     [JsonPropertyName("authority")]
-    public string Authority { get; }
+    public string Authority { get; } = authority;
 
     [JsonPropertyName("ID")]
-    public string ID { get; }
+    public string ID { get; } = id;
 }

--- a/src/Altinn.Broker.API/Models/Maskinporten/MaskinportenSupplier.cs
+++ b/src/Altinn.Broker.API/Models/Maskinporten/MaskinportenSupplier.cs
@@ -2,22 +2,16 @@
 
 namespace Altinn.Broker.Models.Maskinporten;
 
-public class MaskinportenSupplier
-{
-    [JsonConstructor]
-    public MaskinportenSupplier(
-        string authority,
-        string id
+[method: JsonConstructor]
+public class MaskinportenSupplier(
+    string authority,
+    string id
     )
-    {
-        Authority = authority;
-        ID = id;
-    }
-
+{
     [JsonPropertyName("authority")]
-    public string Authority { get; }
+    public string Authority { get; } = authority;
 
     [JsonPropertyName("ID")]
-    public string ID { get; }
+    public string ID { get; } = id;
 }
 

--- a/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
+++ b/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
@@ -3,6 +3,7 @@
 using Altinn.Broker.Application.Settings;
 using Altinn.Broker.Core.Application;
 using Altinn.Broker.Core.Domain;
+using Altinn.Broker.Core.Helpers;
 using Altinn.Broker.Core.Repositories;
 
 using Microsoft.Extensions.Logging;
@@ -18,7 +19,7 @@ public class ConfigureResourceHandler(IResourceRepository resourceRepository, IO
 
     public async Task<OneOf<Task, Error>> Process(ConfigureResourceRequest request, CancellationToken cancellationToken)
     {
-        logger.LogInformation("Processing request to configure resource {ResourceId}", request.ResourceId);
+        logger.LogInformation("Processing request to configure resource {ResourceId}", request.ResourceId.SanitizeForLogs());
         var resource = await resourceRepository.GetResource(request.ResourceId, cancellationToken);
         if (resource is null)
         {

--- a/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
+++ b/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
@@ -5,18 +5,20 @@ using Altinn.Broker.Core.Application;
 using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Repositories;
 
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using OneOf;
 
 namespace Altinn.Broker.Application.ConfigureResource;
-public class ConfigureResourceHandler(IResourceRepository resourceRepository, IAuthorizationService resourceRightsRepository, IOptions<ApplicationSettings> applicationSettings) : IHandler<ConfigureResourceRequest, Task>
+public class ConfigureResourceHandler(IResourceRepository resourceRepository, IOptions<ApplicationSettings> applicationSettings, ILogger<ConfigureResourceHandler> logger) : IHandler<ConfigureResourceRequest, Task>
 {
     private readonly long _maxFileUploadSize = applicationSettings.Value.MaxFileUploadSize;
     private readonly string _maxGracePeriod = applicationSettings.Value.MaxGracePeriod;
 
     public async Task<OneOf<Task, Error>> Process(ConfigureResourceRequest request, CancellationToken cancellationToken)
     {
+        logger.LogInformation("Processing request to configure resource {ResourceId}", request.ResourceId);
         var resource = await resourceRepository.GetResource(request.ResourceId, cancellationToken);
         if (resource is null)
         {

--- a/src/Altinn.Broker.Application/ConfirmDownload/ConfirmDownloadHandler.cs
+++ b/src/Altinn.Broker.Application/ConfirmDownload/ConfirmDownloadHandler.cs
@@ -18,12 +18,13 @@ using Microsoft.Extensions.Options;
 
 using OneOf;
 
-public class ConfirmDownloadHandler(IFileTransferRepository fileTransferRepository, IFileTransferStatusRepository fileTransferStatusRepository, IActorFileTransferStatusRepository actorFileTransferStatusRepository, IResourceRepository resourceRepository, IAuthorizationService resourceRightsRepository, IBackgroundJobClient backgroundJobClient, IEventBus eventBus, ILogger<ConfirmDownloadHandler> logger, IOptions<ApplicationSettings> applicationSettings) : IHandler<ConfirmDownloadRequest, Task>
+public class ConfirmDownloadHandler(IFileTransferRepository fileTransferRepository, IFileTransferStatusRepository fileTransferStatusRepository, IActorFileTransferStatusRepository actorFileTransferStatusRepository, IResourceRepository resourceRepository, IAuthorizationService resourceRightsRepository, IBackgroundJobClient backgroundJobClient, IEventBus eventBus, IOptions<ApplicationSettings> applicationSettings, ILogger<ConfirmDownloadHandler> logger) : IHandler<ConfirmDownloadRequest, Task>
 {
     private readonly string _defaultGracePeriod = applicationSettings.Value.DefaultGracePeriod;
 
     public async Task<OneOf<Task, Error>> Process(ConfirmDownloadRequest request, CancellationToken cancellationToken)
     {
+        logger.LogInformation("Confirming download for file transfer {fileTransferId}", request.FileTransferId);
         var fileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
         if (fileTransfer is null)
         {

--- a/src/Altinn.Broker.Application/ConfirmDownload/ConfirmDownloadHandler.cs
+++ b/src/Altinn.Broker.Application/ConfirmDownload/ConfirmDownloadHandler.cs
@@ -18,38 +18,18 @@ using Microsoft.Extensions.Options;
 
 using OneOf;
 
-public class ConfirmDownloadHandler : IHandler<ConfirmDownloadRequest, Task>
+public class ConfirmDownloadHandler(IFileTransferRepository fileTransferRepository, IFileTransferStatusRepository fileTransferStatusRepository, IActorFileTransferStatusRepository actorFileTransferStatusRepository, IResourceRepository resourceRepository, IAuthorizationService resourceRightsRepository, IBackgroundJobClient backgroundJobClient, IEventBus eventBus, ILogger<ConfirmDownloadHandler> logger, IOptions<ApplicationSettings> applicationSettings) : IHandler<ConfirmDownloadRequest, Task>
 {
-    private readonly IFileTransferRepository _fileTransferRepository;
-    private readonly IFileTransferStatusRepository _fileTransferStatusRepository;
-    private readonly IActorFileTransferStatusRepository _actorFileTransferStatusRepository;
-    private readonly IResourceRepository _resourceRepository;
-    private readonly IAuthorizationService _resourceRightsRepository;
-    private readonly IBackgroundJobClient _backgroundJobClient;
-    private readonly IEventBus _eventBus;
-    private readonly ILogger<ConfirmDownloadHandler> _logger;
-    private readonly string _defaultGracePeriod;
+    private readonly string _defaultGracePeriod = applicationSettings.Value.DefaultGracePeriod;
 
-    public ConfirmDownloadHandler(IFileTransferRepository fileTransferRepository, IFileTransferStatusRepository fileTransferStatusRepository, IActorFileTransferStatusRepository actorFileTransferStatusRepository, IResourceRepository resourceRepository, IAuthorizationService resourceRightsRepository, IBackgroundJobClient backgroundJobClient, IEventBus eventBus, ILogger<ConfirmDownloadHandler> logger, IOptions<ApplicationSettings> applicationSettings)
-    {
-        _fileTransferRepository = fileTransferRepository;
-        _fileTransferStatusRepository = fileTransferStatusRepository;
-        _actorFileTransferStatusRepository = actorFileTransferStatusRepository;
-        _resourceRepository = resourceRepository;
-        _resourceRightsRepository = resourceRightsRepository;
-        _backgroundJobClient = backgroundJobClient;
-        _eventBus = eventBus;
-        _logger = logger;
-        _defaultGracePeriod = applicationSettings.Value.DefaultGracePeriod;
-    }
     public async Task<OneOf<Task, Error>> Process(ConfirmDownloadRequest request, CancellationToken cancellationToken)
     {
-        var fileTransfer = await _fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
+        var fileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
         if (fileTransfer is null)
         {
             return Errors.FileTransferNotFound;
         }
-        var hasAccess = await _resourceRightsRepository.CheckUserAccess(fileTransfer.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Read }, request.IsLegacy, cancellationToken);
+        var hasAccess = await resourceRightsRepository.CheckUserAccess(fileTransfer.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Read }, request.IsLegacy, cancellationToken);
         if (!hasAccess)
         {
             return Errors.FileTransferNotFound;
@@ -76,19 +56,19 @@ public class ConfirmDownloadHandler : IHandler<ConfirmDownloadRequest, Task>
         }
         return await TransactionWithRetriesPolicy.Execute(async (cancellationToken) =>
         {
-            await _eventBus.Publish(AltinnEventType.DownloadConfirmed, fileTransfer.ResourceId, fileTransfer.FileTransferId.ToString(), request.Token.Consumer, cancellationToken);
-            await _eventBus.Publish(AltinnEventType.DownloadConfirmed, fileTransfer.ResourceId, fileTransfer.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, cancellationToken);
-            await _actorFileTransferStatusRepository.InsertActorFileTransferStatus(request.FileTransferId, ActorFileTransferStatus.DownloadConfirmed, request.Token.Consumer, cancellationToken);
+            await eventBus.Publish(AltinnEventType.DownloadConfirmed, fileTransfer.ResourceId, fileTransfer.FileTransferId.ToString(), request.Token.Consumer, cancellationToken);
+            await eventBus.Publish(AltinnEventType.DownloadConfirmed, fileTransfer.ResourceId, fileTransfer.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, cancellationToken);
+            await actorFileTransferStatusRepository.InsertActorFileTransferStatus(request.FileTransferId, ActorFileTransferStatus.DownloadConfirmed, request.Token.Consumer, cancellationToken);
             bool shouldConfirmAll = fileTransfer.RecipientCurrentStatuses.Where(recipientStatus => recipientStatus.Actor.ActorExternalId != request.Token.Consumer).All(status => status.Status >= ActorFileTransferStatus.DownloadConfirmed);
             if (shouldConfirmAll)
             {
-                await _eventBus.Publish(AltinnEventType.AllConfirmedDownloaded, fileTransfer.ResourceId, fileTransfer.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, cancellationToken);
-                await _fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.AllConfirmedDownloaded);
-                var resource = await _resourceRepository.GetResource(fileTransfer.ResourceId, cancellationToken);
-                _backgroundJobClient.Delete(fileTransfer.HangfireJobId);
+                await eventBus.Publish(AltinnEventType.AllConfirmedDownloaded, fileTransfer.ResourceId, fileTransfer.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, cancellationToken);
+                await fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.AllConfirmedDownloaded);
+                var resource = await resourceRepository.GetResource(fileTransfer.ResourceId, cancellationToken);
+                backgroundJobClient.Delete(fileTransfer.HangfireJobId);
                 if (resource!.PurgeFileTransferAfterAllRecipientsConfirmed)
                 {
-                    _backgroundJobClient.Enqueue<ExpireFileTransferHandler>((expireFileTransferHandler) => expireFileTransferHandler.Process(new ExpireFileTransferRequest
+                    backgroundJobClient.Enqueue<ExpireFileTransferHandler>((expireFileTransferHandler) => expireFileTransferHandler.Process(new ExpireFileTransferRequest
                     {
                         FileTransferId = request.FileTransferId,
                         Force = true
@@ -97,7 +77,7 @@ public class ConfirmDownloadHandler : IHandler<ConfirmDownloadRequest, Task>
                 else
                 {
                     var gracePeriod = resource.PurgeFileTransferGracePeriod ?? XmlConvert.ToTimeSpan(_defaultGracePeriod);
-                    _backgroundJobClient.Schedule<ExpireFileTransferHandler>((expireFileTransferHandler) => expireFileTransferHandler.Process(new ExpireFileTransferRequest
+                    backgroundJobClient.Schedule<ExpireFileTransferHandler>((expireFileTransferHandler) => expireFileTransferHandler.Process(new ExpireFileTransferRequest
                     {
                         FileTransferId = request.FileTransferId,
                         Force = true
@@ -105,6 +85,6 @@ public class ConfirmDownloadHandler : IHandler<ConfirmDownloadRequest, Task>
                 }
             }
             return Task.CompletedTask;
-        }, _logger, cancellationToken);
+        }, logger, cancellationToken);
     }
 }

--- a/src/Altinn.Broker.Application/DownloadFile/DownloadFileHandler.cs
+++ b/src/Altinn.Broker.Application/DownloadFile/DownloadFileHandler.cs
@@ -7,30 +7,11 @@ using Microsoft.Extensions.Logging;
 using OneOf;
 
 namespace Altinn.Broker.Application.DownloadFile;
-public class DownloadFileHandler : IHandler<DownloadFileRequest, DownloadFileResponse>
+public class DownloadFileHandler(IResourceRepository resourceRepository, IServiceOwnerRepository serviceOwnerRepository, IAuthorizationService resourceRightsRepository, IFileTransferRepository fileTransferRepository, IActorFileTransferStatusRepository actorFileTransferStatusRepository, IBrokerStorageService brokerStorageService, ILogger<DownloadFileHandler> logger) : IHandler<DownloadFileRequest, DownloadFileResponse>
 {
-    private readonly IResourceRepository _resourceRepository;
-    private readonly IServiceOwnerRepository _serviceOwnerRepository;
-    private readonly IAuthorizationService _resourceRightsRepository;
-    private readonly IFileTransferRepository _fileTransferRepository;
-    private readonly IActorFileTransferStatusRepository _actorFileTransferStatusRepository;
-    private readonly IBrokerStorageService _brokerStorageService;
-    private readonly ILogger<DownloadFileHandler> _logger;
-
-    public DownloadFileHandler(IResourceRepository resourceRepository, IServiceOwnerRepository serviceOwnerRepository, IAuthorizationService resourceRightsRepository, IFileTransferRepository fileTransferRepository, IActorFileTransferStatusRepository actorFileTransferStatusRepository, IBrokerStorageService brokerStorageService, ILogger<DownloadFileHandler> logger)
-    {
-        _resourceRepository = resourceRepository;
-        _serviceOwnerRepository = serviceOwnerRepository;
-        _resourceRightsRepository = resourceRightsRepository;
-        _fileTransferRepository = fileTransferRepository;
-        _actorFileTransferStatusRepository = actorFileTransferStatusRepository;
-        _brokerStorageService = brokerStorageService;
-        _logger = logger;
-    }
-
     public async Task<OneOf<DownloadFileResponse, Error>> Process(DownloadFileRequest request, CancellationToken cancellationToken)
     {
-        var fileTransfer = await _fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
+        var fileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
         if (fileTransfer is null)
         {
             return Errors.FileTransferNotFound;
@@ -47,23 +28,23 @@ public class DownloadFileHandler : IHandler<DownloadFileRequest, DownloadFileRes
         {
             return Errors.NoFileUploaded;
         }
-        var hasAccess = await _resourceRightsRepository.CheckUserAccess(fileTransfer.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Read }, request.IsLegacy, cancellationToken);
+        var hasAccess = await resourceRightsRepository.CheckUserAccess(fileTransfer.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Read }, request.IsLegacy, cancellationToken);
         if (!hasAccess)
         {
             return Errors.NoAccessToResource;
         };
-        var resource = await _resourceRepository.GetResource(fileTransfer.ResourceId, cancellationToken);
+        var resource = await resourceRepository.GetResource(fileTransfer.ResourceId, cancellationToken);
         if (resource is null)
         {
             return Errors.InvalidResourceDefinition;
         };
-        var serviceOwner = await _serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId);
+        var serviceOwner = await serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId);
         if (serviceOwner is null)
         {
             return Errors.ServiceOwnerNotConfigured;
         };
-        var downloadStream = await _brokerStorageService.DownloadFile(serviceOwner, fileTransfer, cancellationToken);
-        await _actorFileTransferStatusRepository.InsertActorFileTransferStatus(request.FileTransferId, ActorFileTransferStatus.DownloadStarted, request.Token.Consumer, cancellationToken);
+        var downloadStream = await brokerStorageService.DownloadFile(serviceOwner, fileTransfer, cancellationToken);
+        await actorFileTransferStatusRepository.InsertActorFileTransferStatus(request.FileTransferId, ActorFileTransferStatus.DownloadStarted, request.Token.Consumer, cancellationToken);
         return new DownloadFileResponse()
         {
             FileName = fileTransfer.FileName,

--- a/src/Altinn.Broker.Application/DownloadFile/DownloadFileHandler.cs
+++ b/src/Altinn.Broker.Application/DownloadFile/DownloadFileHandler.cs
@@ -11,6 +11,7 @@ public class DownloadFileHandler(IResourceRepository resourceRepository, IServic
 {
     public async Task<OneOf<DownloadFileResponse, Error>> Process(DownloadFileRequest request, CancellationToken cancellationToken)
     {
+        logger.LogInformation("Starting download of file transfer {FileTransferId}", request.FileTransferId);
         var fileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
         if (fileTransfer is null)
         {

--- a/src/Altinn.Broker.Application/GetFileTransferDetails/GetFileTransferDetailsHandler.cs
+++ b/src/Altinn.Broker.Application/GetFileTransferDetails/GetFileTransferDetailsHandler.cs
@@ -6,24 +6,11 @@ using OneOf;
 
 namespace Altinn.Broker.Application.GetFileTransferDetails;
 
-public class GetFileTransferDetailsHandler : IHandler<GetFileTransferDetailsRequest, GetFileTransferDetailsResponse>
+public class GetFileTransferDetailsHandler(IFileTransferRepository fileTransferRepository, IAuthorizationService resourceRightsRepository, IFileTransferStatusRepository fileTransferStatusRepository, IActorFileTransferStatusRepository actorFileTransferStatusRepository) : IHandler<GetFileTransferDetailsRequest, GetFileTransferDetailsResponse>
 {
-    private readonly IFileTransferRepository _fileTransferRepository;
-    private readonly IAuthorizationService _resourceRightsRepository;
-    private readonly IFileTransferStatusRepository _fileTransferStatusRepository;
-    private readonly IActorFileTransferStatusRepository _actorFileTransferStatusRepository;
-
-    public GetFileTransferDetailsHandler(IFileTransferRepository fileTransferRepository, IAuthorizationService resourceRightsRepository, IFileTransferStatusRepository fileTransferStatusRepository, IActorFileTransferStatusRepository actorFileTransferStatusRepository)
-    {
-        _fileTransferStatusRepository = fileTransferStatusRepository;
-        _actorFileTransferStatusRepository = actorFileTransferStatusRepository;
-        _fileTransferRepository = fileTransferRepository;
-        _resourceRightsRepository = resourceRightsRepository;
-    }
-
     public async Task<OneOf<GetFileTransferDetailsResponse, Error>> Process(GetFileTransferDetailsRequest request, CancellationToken cancellationToken)
     {
-        var fileTransfer = await _fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
+        var fileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
         if (fileTransfer is null)
         {
             return Errors.FileTransferNotFound;
@@ -33,13 +20,13 @@ public class GetFileTransferDetailsHandler : IHandler<GetFileTransferDetailsRequ
         {
             return Errors.FileTransferNotFound;
         }
-        var hasAccess = await _resourceRightsRepository.CheckUserAccess(fileTransfer.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write, ResourceAccessLevel.Read }, cancellationToken: cancellationToken);
+        var hasAccess = await resourceRightsRepository.CheckUserAccess(fileTransfer.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write, ResourceAccessLevel.Read }, cancellationToken: cancellationToken);
         if (!hasAccess)
         {
             return Errors.NoAccessToResource;
         };
-        var fileTransferEvents = await _fileTransferStatusRepository.GetFileTransferStatusHistory(request.FileTransferId, cancellationToken);
-        var actorEvents = await _actorFileTransferStatusRepository.GetActorEvents(request.FileTransferId, cancellationToken);
+        var fileTransferEvents = await fileTransferStatusRepository.GetFileTransferStatusHistory(request.FileTransferId, cancellationToken);
+        var actorEvents = await actorFileTransferStatusRepository.GetActorEvents(request.FileTransferId, cancellationToken);
         return new GetFileTransferDetailsResponse()
         {
             FileTransfer = fileTransfer,

--- a/src/Altinn.Broker.Application/GetFileTransferDetails/GetFileTransferDetailsHandler.cs
+++ b/src/Altinn.Broker.Application/GetFileTransferDetails/GetFileTransferDetailsHandler.cs
@@ -2,14 +2,17 @@ using Altinn.Broker.Core.Application;
 using Altinn.Broker.Core.Domain.Enums;
 using Altinn.Broker.Core.Repositories;
 
+using Microsoft.Extensions.Logging;
+
 using OneOf;
 
 namespace Altinn.Broker.Application.GetFileTransferDetails;
 
-public class GetFileTransferDetailsHandler(IFileTransferRepository fileTransferRepository, IAuthorizationService resourceRightsRepository, IFileTransferStatusRepository fileTransferStatusRepository, IActorFileTransferStatusRepository actorFileTransferStatusRepository) : IHandler<GetFileTransferDetailsRequest, GetFileTransferDetailsResponse>
+public class GetFileTransferDetailsHandler(IFileTransferRepository fileTransferRepository, IAuthorizationService resourceRightsRepository, IFileTransferStatusRepository fileTransferStatusRepository, IActorFileTransferStatusRepository actorFileTransferStatusRepository, ILogger<GetFileTransferDetailsHandler> logger) : IHandler<GetFileTransferDetailsRequest, GetFileTransferDetailsResponse>
 {
     public async Task<OneOf<GetFileTransferDetailsResponse, Error>> Process(GetFileTransferDetailsRequest request, CancellationToken cancellationToken)
     {
+        logger.LogInformation("Getting file transfer details for {fileTransferId}.", request.FileTransferId);
         var fileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
         if (fileTransfer is null)
         {

--- a/src/Altinn.Broker.Application/GetFileTransferOverview/GetFileTransferOverviewHandler.cs
+++ b/src/Altinn.Broker.Application/GetFileTransferOverview/GetFileTransferOverviewHandler.cs
@@ -9,22 +9,11 @@ using OneOf;
 
 namespace Altinn.Broker.Application.GetFileTransferOverview;
 
-public class GetFileTransferOverviewHandler : IHandler<GetFileTransferOverviewRequest, GetFileTransferOverviewResponse>
+public class GetFileTransferOverviewHandler(IAuthorizationService resourceRightsRepository, IFileTransferRepository fileTransferRepository, IResourceManager resourceManager, ILogger<GetFileTransferOverviewHandler> logger) : IHandler<GetFileTransferOverviewRequest, GetFileTransferOverviewResponse>
 {
-    private readonly IAuthorizationService _resourceRightsRepository;
-    private readonly IFileTransferRepository _fileTransferRepository;
-    private readonly ILogger<GetFileTransferOverviewHandler> _logger;
-
-    public GetFileTransferOverviewHandler(IAuthorizationService resourceRightsRepository, IFileTransferRepository fileTransferRepository, IResourceManager resourceManager, ILogger<GetFileTransferOverviewHandler> logger)
-    {
-        _resourceRightsRepository = resourceRightsRepository;
-        _fileTransferRepository = fileTransferRepository;
-        _logger = logger;
-    }
-
     public async Task<OneOf<GetFileTransferOverviewResponse, Error>> Process(GetFileTransferOverviewRequest request, CancellationToken cancellationToken)
     {
-        var fileTransfer = await _fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
+        var fileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
         if (fileTransfer is null)
         {
             return Errors.FileTransferNotFound;
@@ -34,7 +23,7 @@ public class GetFileTransferOverviewHandler : IHandler<GetFileTransferOverviewRe
         {
             return Errors.FileTransferNotFound;
         }
-        var hasAccess = await _resourceRightsRepository.CheckUserAccess(fileTransfer.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write, ResourceAccessLevel.Read }, request.IsLegacy, cancellationToken);
+        var hasAccess = await resourceRightsRepository.CheckUserAccess(fileTransfer.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write, ResourceAccessLevel.Read }, request.IsLegacy, cancellationToken);
         if (!hasAccess)
         {
             return Errors.NoAccessToResource;

--- a/src/Altinn.Broker.Application/GetFileTransferOverview/GetFileTransferOverviewHandler.cs
+++ b/src/Altinn.Broker.Application/GetFileTransferOverview/GetFileTransferOverviewHandler.cs
@@ -9,10 +9,11 @@ using OneOf;
 
 namespace Altinn.Broker.Application.GetFileTransferOverview;
 
-public class GetFileTransferOverviewHandler(IAuthorizationService resourceRightsRepository, IFileTransferRepository fileTransferRepository, IResourceManager resourceManager, ILogger<GetFileTransferOverviewHandler> logger) : IHandler<GetFileTransferOverviewRequest, GetFileTransferOverviewResponse>
+public class GetFileTransferOverviewHandler(IAuthorizationService resourceRightsRepository, IFileTransferRepository fileTransferRepository, ILogger<GetFileTransferOverviewHandler> logger) : IHandler<GetFileTransferOverviewRequest, GetFileTransferOverviewResponse>
 {
     public async Task<OneOf<GetFileTransferOverviewResponse, Error>> Process(GetFileTransferOverviewRequest request, CancellationToken cancellationToken)
     {
+        logger.LogInformation("Retrieving file overview for file transfer {fileTransferId}. Legacy: {legacy}", request.FileTransferId, request.IsLegacy);
         var fileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
         if (fileTransfer is null)
         {

--- a/src/Altinn.Broker.Application/GetFileTransfers/GetFileTransfersHandler.cs
+++ b/src/Altinn.Broker.Application/GetFileTransfers/GetFileTransfersHandler.cs
@@ -1,6 +1,7 @@
 using Altinn.Broker.Core.Application;
 using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Domain.Enums;
+using Altinn.Broker.Core.Helpers;
 using Altinn.Broker.Core.Repositories;
 
 using Microsoft.Extensions.Logging;
@@ -13,7 +14,7 @@ public class GetFileTransfersHandler(IAuthorizationService resourceRightsReposit
 {
     public async Task<OneOf<List<Guid>, Error>> Process(GetFileTransfersRequest request, CancellationToken cancellationToken)
     {
-        logger.LogInformation("Getting file transfers for {resourceId}", request.ResourceId);
+        logger.LogInformation("Getting file transfers for {resourceId}", request.ResourceId.SanitizeForLogs());
         var hasAccess = await resourceRightsRepository.CheckUserAccess(request.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write, ResourceAccessLevel.Read }, cancellationToken: cancellationToken);
         if (!hasAccess)
         {

--- a/src/Altinn.Broker.Application/GetFileTransfers/GetFileTransfersHandler.cs
+++ b/src/Altinn.Broker.Application/GetFileTransfers/GetFileTransfersHandler.cs
@@ -13,6 +13,7 @@ public class GetFileTransfersHandler(IAuthorizationService resourceRightsReposit
 {
     public async Task<OneOf<List<Guid>, Error>> Process(GetFileTransfersRequest request, CancellationToken cancellationToken)
     {
+        logger.LogInformation("Getting file transfers for {resourceId}", request.ResourceId);
         var hasAccess = await resourceRightsRepository.CheckUserAccess(request.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write, ResourceAccessLevel.Read }, cancellationToken: cancellationToken);
         if (!hasAccess)
         {

--- a/src/Altinn.Broker.Application/GetFileTransfers/GetFileTransfersHandler.cs
+++ b/src/Altinn.Broker.Application/GetFileTransfers/GetFileTransfersHandler.cs
@@ -9,36 +9,21 @@ using OneOf;
 
 namespace Altinn.Broker.Application.GetFileTransfers;
 
-public class GetFileTransfersHandler : IHandler<GetFileTransfersRequest, List<Guid>>
+public class GetFileTransfersHandler(IAuthorizationService resourceRightsRepository, IResourceRepository resourceRepository, IFileTransferRepository fileTransferRepository, IActorRepository actorRepository, ILogger<GetFileTransfersHandler> logger) : IHandler<GetFileTransfersRequest, List<Guid>>
 {
-    private readonly IAuthorizationService _resourceRightsRepository;
-    private readonly IResourceRepository _resourceRepository;
-    private readonly IFileTransferRepository _fileTransferRepository;
-    private readonly IActorRepository _actorRepository;
-    private readonly ILogger<GetFileTransfersHandler> _logger;
-
-    public GetFileTransfersHandler(IAuthorizationService resourceRightsRepository, IResourceRepository resourceRepository, IFileTransferRepository fileTransferRepository, IActorRepository actorRepository, ILogger<GetFileTransfersHandler> logger)
-    {
-        _resourceRightsRepository = resourceRightsRepository;
-        _resourceRepository = resourceRepository;
-        _fileTransferRepository = fileTransferRepository;
-        _actorRepository = actorRepository;
-        _logger = logger;
-    }
-
     public async Task<OneOf<List<Guid>, Error>> Process(GetFileTransfersRequest request, CancellationToken cancellationToken)
     {
-        var hasAccess = await _resourceRightsRepository.CheckUserAccess(request.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write, ResourceAccessLevel.Read }, cancellationToken: cancellationToken);
+        var hasAccess = await resourceRightsRepository.CheckUserAccess(request.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write, ResourceAccessLevel.Read }, cancellationToken: cancellationToken);
         if (!hasAccess)
         {
             return Errors.NoAccessToResource;
         };
-        var service = await _resourceRepository.GetResource(request.ResourceId, cancellationToken);
+        var service = await resourceRepository.GetResource(request.ResourceId, cancellationToken);
         if (service is null)
         {
             return Errors.InvalidResourceDefinition;
         };
-        var callingActor = await _actorRepository.GetActorAsync(request.Token.Consumer, cancellationToken);
+        var callingActor = await actorRepository.GetActorAsync(request.Token.Consumer, cancellationToken);
         if (callingActor is null)
         {
             return new List<Guid>();
@@ -64,11 +49,11 @@ public class GetFileTransfersHandler : IHandler<GetFileTransfersRequest, List<Gu
         if (request.RecipientStatus.HasValue)
         {
             fileTransferSearchEntity.RecipientStatus = request.RecipientStatus;
-            return await _fileTransferRepository.GetFileTransfersForRecipientWithRecipientStatus(fileTransferSearchEntity, cancellationToken);
+            return await fileTransferRepository.GetFileTransfersForRecipientWithRecipientStatus(fileTransferSearchEntity, cancellationToken);
         }
         else
         {
-            return await _fileTransferRepository.GetFileTransfersAssociatedWithActor(fileTransferSearchEntity, cancellationToken);
+            return await fileTransferRepository.GetFileTransfersAssociatedWithActor(fileTransferSearchEntity, cancellationToken);
         }
     }
 }

--- a/src/Altinn.Broker.Application/GetFileTransfers/LegacyGetFilesHandler.cs
+++ b/src/Altinn.Broker.Application/GetFileTransfers/LegacyGetFilesHandler.cs
@@ -27,6 +27,7 @@ public class LegacyGetFilesHandler(IAuthorizationService resourceRightsRepositor
 
     public async Task<OneOf<List<Guid>, Error>> Process(LegacyGetFilesRequest request, CancellationToken cancellationToken)
     {
+        logger.LogInformation("Legacy get files for {resourceId}", request.ResourceId ?? "all resources");
         LegacyFileSearchEntity fileSearch = new()
         {
             ResourceId = request.ResourceId ?? string.Empty

--- a/src/Altinn.Broker.Application/GetFileTransfers/LegacyGetFilesHandler.cs
+++ b/src/Altinn.Broker.Application/GetFileTransfers/LegacyGetFilesHandler.cs
@@ -1,5 +1,6 @@
 using Altinn.Broker.Core.Application;
 using Altinn.Broker.Core.Domain;
+using Altinn.Broker.Core.Helpers;
 using Altinn.Broker.Core.Repositories;
 
 using Microsoft.Extensions.Logging;
@@ -27,7 +28,7 @@ public class LegacyGetFilesHandler(IFileTransferRepository fileTransferRepositor
 
     public async Task<OneOf<List<Guid>, Error>> Process(LegacyGetFilesRequest request, CancellationToken cancellationToken)
     {
-        logger.LogInformation("Legacy get files for {resourceId}", request.ResourceId ?? "all resources");
+        logger.LogInformation("Legacy get files for {resourceId}", request.ResourceId is null ? "all resources" : request.ResourceId.SanitizeForLogs());
         LegacyFileSearchEntity fileSearch = new()
         {
             ResourceId = request.ResourceId ?? string.Empty

--- a/src/Altinn.Broker.Application/GetFileTransfers/LegacyGetFilesHandler.cs
+++ b/src/Altinn.Broker.Application/GetFileTransfers/LegacyGetFilesHandler.cs
@@ -8,7 +8,7 @@ using OneOf;
 
 namespace Altinn.Broker.Application.GetFileTransfers;
 
-public class LegacyGetFilesHandler(IAuthorizationService resourceRightsRepository, IResourceRepository resourceRepository, IFileTransferRepository fileTransferRepository, IActorRepository actorRepository, ILogger<GetFileTransfersHandler> logger) : IHandler<LegacyGetFilesRequest, List<Guid>>
+public class LegacyGetFilesHandler(IFileTransferRepository fileTransferRepository, IActorRepository actorRepository, ILogger<GetFileTransfersHandler> logger) : IHandler<LegacyGetFilesRequest, List<Guid>>
 {
     private async Task<List<ActorEntity>> GetActors(string[] recipients, CancellationToken cancellationToken)
     {

--- a/src/Altinn.Broker.Application/GetFileTransfers/LegacyGetFilesHandler.cs
+++ b/src/Altinn.Broker.Application/GetFileTransfers/LegacyGetFilesHandler.cs
@@ -8,29 +8,14 @@ using OneOf;
 
 namespace Altinn.Broker.Application.GetFileTransfers;
 
-public class LegacyGetFilesHandler : IHandler<LegacyGetFilesRequest, List<Guid>>
+public class LegacyGetFilesHandler(IAuthorizationService resourceRightsRepository, IResourceRepository resourceRepository, IFileTransferRepository fileTransferRepository, IActorRepository actorRepository, ILogger<GetFileTransfersHandler> logger) : IHandler<LegacyGetFilesRequest, List<Guid>>
 {
-    private readonly IAuthorizationService _resourceRightsRepository;
-    private readonly IResourceRepository _resourceRepository;
-    private readonly IFileTransferRepository _fileTransferRepository;
-    private readonly IActorRepository _actorRepository;
-    private readonly ILogger<GetFileTransfersHandler> _logger;
-
-    public LegacyGetFilesHandler(IAuthorizationService resourceRightsRepository, IResourceRepository resourceRepository, IFileTransferRepository fileTransferRepository, IActorRepository actorRepository, ILogger<GetFileTransfersHandler> logger)
-    {
-        _resourceRightsRepository = resourceRightsRepository;
-        _resourceRepository = resourceRepository;
-        _fileTransferRepository = fileTransferRepository;
-        _actorRepository = actorRepository;
-        _logger = logger;
-    }
-
     private async Task<List<ActorEntity>> GetActors(string[] recipients, CancellationToken cancellationToken)
     {
         List<ActorEntity> actors = new();
         foreach (string recipient in recipients)
         {
-            var entity = await _actorRepository.GetActorAsync(recipient, cancellationToken);
+            var entity = await actorRepository.GetActorAsync(recipient, cancellationToken);
             if (entity is not null)
             {
                 actors.Add(entity);
@@ -53,7 +38,7 @@ public class LegacyGetFilesHandler : IHandler<LegacyGetFilesRequest, List<Guid>>
         }
         else
         {
-            fileSearch.Actor = await _actorRepository.GetActorAsync(request.OnBehalfOfConsumer ?? string.Empty, cancellationToken);
+            fileSearch.Actor = await actorRepository.GetActorAsync(request.OnBehalfOfConsumer ?? string.Empty, cancellationToken);
             if (fileSearch.Actor is null)
             {
                 return new List<Guid>();
@@ -80,6 +65,6 @@ public class LegacyGetFilesHandler : IHandler<LegacyGetFilesRequest, List<Guid>>
             fileSearch.FileTransferStatus = request.FileTransferStatus;
         }
 
-        return await _fileTransferRepository.LegacyGetFilesForRecipientsWithRecipientStatus(fileSearch, cancellationToken);
+        return await fileTransferRepository.LegacyGetFilesForRecipientsWithRecipientStatus(fileSearch, cancellationToken);
     }
 }

--- a/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
+++ b/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
@@ -32,7 +32,7 @@ public class InitializeFileTransferHandler(
 {
     public async Task<OneOf<Guid, Error>> Process(InitializeFileTransferRequest request, CancellationToken cancellationToken)
     {
-        logger.LogInformation("Initializing file transfer on {resourceId}", request.ResourceId);
+        logger.LogInformation("Initializing file transfer on {resourceId}", request.ResourceId.SanitizeForLogs());
         var hasAccess = await resourceRightsRepository.CheckUserAccess(request.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write }, request.IsLegacy, cancellationToken);
         if (!hasAccess)
         {

--- a/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
+++ b/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
@@ -32,6 +32,7 @@ public class InitializeFileTransferHandler(
 {
     public async Task<OneOf<Guid, Error>> Process(InitializeFileTransferRequest request, CancellationToken cancellationToken)
     {
+        logger.LogInformation("Initializing file transfer on {resourceId}", request.ResourceId);
         var hasAccess = await resourceRightsRepository.CheckUserAccess(request.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write }, request.IsLegacy, cancellationToken);
         if (!hasAccess)
         {

--- a/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
+++ b/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
@@ -19,82 +19,59 @@ using Polly;
 using Serilog.Context;
 
 namespace Altinn.Broker.Application.InitializeFileTransfer;
-public class InitializeFileTransferHandler : IHandler<InitializeFileTransferRequest, Guid>
+public class InitializeFileTransferHandler(
+    IResourceRepository resourceRepository,
+    IServiceOwnerRepository serviceOwnerRepository,
+    IAuthorizationService resourceRightsRepository,
+    IFileTransferRepository fileTransferRepository,
+    IFileTransferStatusRepository fileTransferStatusRepository,
+    IActorFileTransferStatusRepository actorFileTransferStatusRepository,
+    IBackgroundJobClient backgroundJobClient,
+    IEventBus eventBus,
+    ILogger<InitializeFileTransferHandler> logger) : IHandler<InitializeFileTransferRequest, Guid>
 {
-    private readonly IResourceRepository _resourceRepository;
-    private readonly IServiceOwnerRepository _serviceOwnerRepository;
-    private readonly IAuthorizationService _resourceRightsRepository;
-    private readonly IFileTransferRepository _fileTransferRepository;
-    private readonly IFileTransferStatusRepository _fileTransferStatusRepository;
-    private readonly IActorFileTransferStatusRepository _actorFileTransferStatusRepository;
-    private readonly IBackgroundJobClient _backgroundJobClient;
-    private readonly IEventBus _eventBus;
-    private readonly ILogger<InitializeFileTransferHandler> _logger;
-
-    public InitializeFileTransferHandler(
-        IResourceRepository resourceRepository,
-        IServiceOwnerRepository serviceOwnerRepository,
-        IAuthorizationService resourceRightsRepository,
-        IFileTransferRepository fileTransferRepository,
-        IFileTransferStatusRepository fileTransferStatusRepository,
-        IActorFileTransferStatusRepository actorFileTransferStatusRepository,
-        IBackgroundJobClient backgroundJobClient,
-        IEventBus eventBus,
-        ILogger<InitializeFileTransferHandler> logger)
-    {
-        _resourceRepository = resourceRepository;
-        _serviceOwnerRepository = serviceOwnerRepository;
-        _resourceRightsRepository = resourceRightsRepository;
-        _fileTransferRepository = fileTransferRepository;
-        _fileTransferStatusRepository = fileTransferStatusRepository;
-        _actorFileTransferStatusRepository = actorFileTransferStatusRepository;
-        _backgroundJobClient = backgroundJobClient;
-        _eventBus = eventBus;
-        _logger = logger;
-    }
-
     public async Task<OneOf<Guid, Error>> Process(InitializeFileTransferRequest request, CancellationToken cancellationToken)
     {
-        var hasAccess = await _resourceRightsRepository.CheckUserAccess(request.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write }, request.IsLegacy, cancellationToken);
+        var hasAccess = await resourceRightsRepository.CheckUserAccess(request.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write }, request.IsLegacy, cancellationToken);
         if (!hasAccess)
         {
             return Errors.NoAccessToResource;
         };
-        var resource = await _resourceRepository.GetResource(request.ResourceId, cancellationToken);
+        var resource = await resourceRepository.GetResource(request.ResourceId, cancellationToken);
         if (resource is null)
         {
             return Errors.InvalidResourceDefinition;
         };
-        var serviceOwner = await _serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId);
+        var serviceOwner = await serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId);
         if (serviceOwner?.StorageProvider is null)
         {
             return Errors.ServiceOwnerNotConfigured;
         }
         var fileExpirationTime = DateTime.UtcNow.Add(resource.FileTransferTimeToLive ?? TimeSpan.FromDays(30));
-        var fileTransferId = await _fileTransferRepository.AddFileTransfer(serviceOwner, resource, request.FileName, request.SendersFileTransferReference, request.SenderExternalId, request.RecipientExternalIds, fileExpirationTime, request.PropertyList, request.Checksum, null, null, cancellationToken);
+        var fileTransferId = await fileTransferRepository.AddFileTransfer(serviceOwner, resource, request.FileName, request.SendersFileTransferReference, request.SenderExternalId, request.RecipientExternalIds, fileExpirationTime, request.PropertyList, request.Checksum, null, null, cancellationToken);
         LogContext.PushProperty("fileTransferId", fileTransferId);        
-        var addRecipientEventTasks = request.RecipientExternalIds.Select(recipientId => _actorFileTransferStatusRepository.InsertActorFileTransferStatus(fileTransferId, ActorFileTransferStatus.Initialized, recipientId, cancellationToken));
+        var addRecipientEventTasks = request.RecipientExternalIds.Select(recipientId => actorFileTransferStatusRepository.InsertActorFileTransferStatus(fileTransferId, ActorFileTransferStatus.Initialized, recipientId, cancellationToken));
         try
         {
             await Task.WhenAll(addRecipientEventTasks);
         }
         catch (Exception ex)
         {
-            _logger.LogError("Failed when adding recipient initialized events: {message}\n{stackTrace}", ex.Message, ex.StackTrace);
+            logger.LogError("Failed when adding recipient initialized events: {message}\n{stackTrace}", ex.Message, ex.StackTrace);
             throw;
         }
-        var jobId = _backgroundJobClient.Schedule<ExpireFileTransferHandler>((ExpireFileTransferHandler) => ExpireFileTransferHandler.Process(new ExpireFileTransferRequest
+        var jobId = backgroundJobClient.Schedule<ExpireFileTransferHandler>((ExpireFileTransferHandler) => ExpireFileTransferHandler.Process(new ExpireFileTransferRequest
         {
             FileTransferId = fileTransferId,
             Force = false
         }, cancellationToken), fileExpirationTime);
-        await _fileTransferRepository.SetFileTransferHangfireJobId(fileTransferId, jobId, cancellationToken);
+        await fileTransferRepository.SetFileTransferHangfireJobId(fileTransferId, jobId, cancellationToken);
         return await TransactionWithRetriesPolicy.Execute(async (cancellationToken) =>
         {
-            await _fileTransferStatusRepository.InsertFileTransferStatus(fileTransferId, FileTransferStatus.Initialized, cancellationToken: cancellationToken);
-            await _eventBus.Publish(AltinnEventType.FileTransferInitialized, resource.Id, fileTransferId.ToString(), request.SenderExternalId, cancellationToken);
+            await fileTransferStatusRepository.InsertFileTransferStatus(fileTransferId, FileTransferStatus.Initialized, cancellationToken: cancellationToken);
+            await eventBus.Publish(AltinnEventType.FileTransferInitialized, resource.Id, fileTransferId.ToString(), request.SenderExternalId, cancellationToken);
             return fileTransferId;
-        }, _logger, cancellationToken);
+        }, logger, cancellationToken);
     }
 }
 

--- a/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
+++ b/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
@@ -1,6 +1,5 @@
 
 using System.Text.Json;
-using System.Transactions;
 
 using Altinn.Broker.Application.ExpireFileTransfer;
 using Altinn.Broker.Core.Application;
@@ -15,8 +14,6 @@ using Hangfire;
 using Microsoft.Extensions.Logging;
 
 using OneOf;
-
-using Polly;
 
 namespace Altinn.Broker.Application;
 public class MalwareScanningResultHandler(
@@ -67,5 +64,13 @@ public class MalwareScanningResultHandler(
             }
             return Task.CompletedTask;
         }, logger, cancellationToken);
+    }
+}
+public class Foo
+{
+    private readonly IFileTransferRepository _fileTransferRepository;
+    public Foo(IFileTransferRepository fileTransferRepository)
+    {
+        _fileTransferRepository = fileTransferRepository;
     }
 }

--- a/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
+++ b/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
@@ -19,38 +19,23 @@ using OneOf;
 using Polly;
 
 namespace Altinn.Broker.Application;
-public class MalwareScanningResultHandler : IHandler<ScanResultData, Task>
+public class MalwareScanningResultHandler(
+    IFileTransferStatusRepository fileTransferStatusRepository,
+    IFileTransferRepository fileTransferRepository,
+    IEventBus eventBus,
+    ILogger<MalwareScanningResultHandler> logger,
+    IBackgroundJobClient backgroundJobClient) : IHandler<ScanResultData, Task>
 {
-    private readonly IFileTransferStatusRepository _fileTransferStatusRepository;
-    private readonly IFileTransferRepository _fileTransferRepository;
-    private readonly IEventBus _eventBus;
-    private readonly ILogger<MalwareScanningResultHandler> _logger;
-    private readonly IBackgroundJobClient _backgroundJobClient;
-
-    public MalwareScanningResultHandler(
-        IFileTransferStatusRepository fileTransferStatusRepository,
-        IFileTransferRepository fileTransferRepository,
-        IEventBus eventBus,
-        ILogger<MalwareScanningResultHandler> logger,
-        IBackgroundJobClient backgroundJobClient)
-    {
-        _fileTransferStatusRepository = fileTransferStatusRepository;
-        _fileTransferRepository = fileTransferRepository;
-        _eventBus = eventBus;
-        _logger = logger;
-        _backgroundJobClient = backgroundJobClient;
-    }
-
     public async Task<OneOf<Task, Error>> Process(ScanResultData data, CancellationToken cancellationToken)
     {
         string fileTransferIdFromUri = data.BlobUri.Split("/").Last() ?? Guid.Empty.ToString();
         Guid fileTransferId;
         if (!Guid.TryParse(fileTransferIdFromUri, out fileTransferId))
         {
-            _logger.LogError("Could not parse Guid from {fileTransferIdFromUri}", fileTransferIdFromUri);
+            logger.LogError("Could not parse Guid from {fileTransferIdFromUri}", fileTransferIdFromUri);
             return Errors.FileTransferNotFound;
         }
-        var fileTransfer = await _fileTransferRepository.GetFileTransfer(fileTransferId, cancellationToken);
+        var fileTransfer = await fileTransferRepository.GetFileTransfer(fileTransferId, cancellationToken);
         if (fileTransfer is null)
         {
             return Errors.FileTransferNotFound;
@@ -60,20 +45,20 @@ public class MalwareScanningResultHandler : IHandler<ScanResultData, Task>
         {
             if (data.ScanResultType.Equals("No threats found", StringComparison.InvariantCultureIgnoreCase))
             {
-                _logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", fileTransferId, data.ScanResultType);
-                await _fileTransferStatusRepository.InsertFileTransferStatus(fileTransferId, Core.Domain.Enums.FileTransferStatus.Published, cancellationToken: cancellationToken);
-                await _eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, fileTransferIdFromUri, fileTransfer.Sender.ActorExternalId, cancellationToken);
+                logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", fileTransferId, data.ScanResultType);
+                await fileTransferStatusRepository.InsertFileTransferStatus(fileTransferId, Core.Domain.Enums.FileTransferStatus.Published, cancellationToken: cancellationToken);
+                await eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, fileTransferIdFromUri, fileTransfer.Sender.ActorExternalId, cancellationToken);
                 foreach (var recipient in fileTransfer.RecipientCurrentStatuses)
                 {
-                    await _eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, fileTransferIdFromUri, recipient.Actor.ActorExternalId, cancellationToken);
+                    await eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, fileTransferIdFromUri, recipient.Actor.ActorExternalId, cancellationToken);
                 }
             }
             else
             {
-                _logger.LogWarning("Suspicious scan result for file transfer {fileTransferId} with body {body}", fileTransferId, JsonSerializer.Serialize(data));
-                await _fileTransferStatusRepository.InsertFileTransferStatus(fileTransferId, Core.Domain.Enums.FileTransferStatus.Failed, $"Malware scan failed: {data.ScanResultType}. Extra details: " + JsonSerializer.Serialize(data.ScanResultDetails), cancellationToken);
-                await _eventBus.Publish(AltinnEventType.UploadFailed, fileTransfer.ResourceId, fileTransferIdFromUri, fileTransfer.Sender.ActorExternalId, cancellationToken);
-                _backgroundJobClient.Enqueue<ExpireFileTransferHandler>(handler => handler.Process(new ExpireFileTransferRequest
+                logger.LogWarning("Suspicious scan result for file transfer {fileTransferId} with body {body}", fileTransferId, JsonSerializer.Serialize(data));
+                await fileTransferStatusRepository.InsertFileTransferStatus(fileTransferId, Core.Domain.Enums.FileTransferStatus.Failed, $"Malware scan failed: {data.ScanResultType}. Extra details: " + JsonSerializer.Serialize(data.ScanResultDetails), cancellationToken);
+                await eventBus.Publish(AltinnEventType.UploadFailed, fileTransfer.ResourceId, fileTransferIdFromUri, fileTransfer.Sender.ActorExternalId, cancellationToken);
+                backgroundJobClient.Enqueue<ExpireFileTransferHandler>(handler => handler.Process(new ExpireFileTransferRequest
                 {
                     FileTransferId = fileTransfer.FileTransferId,
                     Force = true,
@@ -81,6 +66,6 @@ public class MalwareScanningResultHandler : IHandler<ScanResultData, Task>
                 }, CancellationToken.None));
             }
             return Task.CompletedTask;
-        }, _logger, cancellationToken);
+        }, logger, cancellationToken);
     }
 }

--- a/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
@@ -21,6 +21,7 @@ public class UploadFileHandler(IAuthorizationService resourceRightsRepository, I
 
     public async Task<OneOf<Guid, Error>> Process(UploadFileRequest request, CancellationToken cancellationToken)
     {
+        logger.LogInformation("Uploading file for file transfer {fileTransferId}", request.FileTransferId);
         var fileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
         if (fileTransfer is null)
         {

--- a/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
@@ -15,41 +15,18 @@ using OneOf;
 
 namespace Altinn.Broker.Application.UploadFile;
 
-public class UploadFileHandler : IHandler<UploadFileRequest, Guid>
+public class UploadFileHandler(IAuthorizationService resourceRightsRepository, IResourceRepository resourceRepository, IServiceOwnerRepository serviceOwnerRepository, IFileTransferRepository fileTransferRepository, IFileTransferStatusRepository fileTransferStatusRepository, IBrokerStorageService brokerStorageService, IBackgroundJobClient backgroundJobClient, IEventBus eventBus, ILogger<UploadFileHandler> logger, IOptions<ApplicationSettings> applicationSettings) : IHandler<UploadFileRequest, Guid>
 {
-    private readonly IAuthorizationService _resourceRightsRepository;
-    private readonly IResourceRepository _resourceRepository;
-    private readonly IServiceOwnerRepository _serviceOwnerRepository;
-    private readonly IFileTransferRepository _fileTransferRepository;
-    private readonly IFileTransferStatusRepository _fileTransferStatusRepository;
-    private readonly IBrokerStorageService _brokerStorageService;
-    private readonly IBackgroundJobClient _backgroundJobClient;
-    private readonly IEventBus _eventBus;
-    private readonly ILogger<UploadFileHandler> _logger;
-    private readonly long _maxFileUploadSize;
-
-    public UploadFileHandler(IAuthorizationService resourceRightsRepository, IResourceRepository resourceRepository, IServiceOwnerRepository serviceOwnerRepository, IFileTransferRepository fileTransferRepository, IFileTransferStatusRepository fileTransferStatusRepository, IBrokerStorageService brokerStorageService, IBackgroundJobClient backgroundJobClient, IEventBus eventBus, ILogger<UploadFileHandler> logger, IOptions<ApplicationSettings> applicationSettings)
-    {
-        _resourceRightsRepository = resourceRightsRepository;
-        _resourceRepository = resourceRepository;
-        _serviceOwnerRepository = serviceOwnerRepository;
-        _fileTransferRepository = fileTransferRepository;
-        _fileTransferStatusRepository = fileTransferStatusRepository;
-        _brokerStorageService = brokerStorageService;
-        _backgroundJobClient = backgroundJobClient;
-        _eventBus = eventBus;
-        _logger = logger;
-        _maxFileUploadSize = applicationSettings.Value.MaxFileUploadSize;
-    }
+    private readonly long _maxFileUploadSize = applicationSettings.Value.MaxFileUploadSize;
 
     public async Task<OneOf<Guid, Error>> Process(UploadFileRequest request, CancellationToken cancellationToken)
     {
-        var fileTransfer = await _fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
+        var fileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
         if (fileTransfer is null)
         {
             return Errors.FileTransferNotFound;
         }
-        var hasAccess = await _resourceRightsRepository.CheckUserAccess(fileTransfer.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write }, request.IsLegacy, cancellationToken);
+        var hasAccess = await resourceRightsRepository.CheckUserAccess(fileTransfer.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write }, request.IsLegacy, cancellationToken);
         if (!hasAccess)
         {
             return Errors.FileTransferNotFound;
@@ -62,12 +39,12 @@ public class UploadFileHandler : IHandler<UploadFileRequest, Guid>
         {
             return Errors.FileTransferAlreadyUploaded;
         }
-        var resource = await _resourceRepository.GetResource(fileTransfer.ResourceId, cancellationToken);
+        var resource = await resourceRepository.GetResource(fileTransfer.ResourceId, cancellationToken);
         if (resource is null)
         {
             return Errors.InvalidResourceDefinition;
         };
-        var serviceOwner = await _serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId);
+        var serviceOwner = await serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId);
         if (serviceOwner?.StorageProvider is null)
         {
             return Errors.ServiceOwnerNotConfigured;
@@ -78,50 +55,50 @@ public class UploadFileHandler : IHandler<UploadFileRequest, Guid>
             return Errors.FileSizeTooBig;
         }
 
-        await _fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.UploadStarted, cancellationToken: cancellationToken);
+        await fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.UploadStarted, cancellationToken: cancellationToken);
 
         try
         {
-            var checksum = await _brokerStorageService.UploadFile(serviceOwner, fileTransfer, request.UploadStream, cancellationToken);
+            var checksum = await brokerStorageService.UploadFile(serviceOwner, fileTransfer, request.UploadStream, cancellationToken);
             if (string.IsNullOrWhiteSpace(fileTransfer.Checksum))
             {
-                await _fileTransferRepository.SetChecksum(request.FileTransferId, checksum, cancellationToken);
+                await fileTransferRepository.SetChecksum(request.FileTransferId, checksum, cancellationToken);
             }
             else if (!string.Equals(checksum, fileTransfer.Checksum, StringComparison.InvariantCultureIgnoreCase))
             {
-                await _fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.Failed, "Checksum mismatch", cancellationToken);
-                _backgroundJobClient.Enqueue(() => _brokerStorageService.DeleteFile(serviceOwner, fileTransfer, cancellationToken));
+                await fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.Failed, "Checksum mismatch", cancellationToken);
+                backgroundJobClient.Enqueue(() => brokerStorageService.DeleteFile(serviceOwner, fileTransfer, cancellationToken));
                 return Errors.ChecksumMismatch;
             }
         }
         catch (Exception e)
         {
-            _logger.LogError("Unexpected error occurred while uploading file: {errorMessage} \nStack trace: {stackTrace}", e.Message, e.StackTrace);
+            logger.LogError("Unexpected error occurred while uploading file: {errorMessage} \nStack trace: {stackTrace}", e.Message, e.StackTrace);
              return await TransactionWithRetriesPolicy.Execute(async (cancellationToken) =>
              {
-                await _fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.Failed, "Error occurred while uploading fileTransfer", cancellationToken);
-                await _eventBus.Publish(AltinnEventType.UploadFailed, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, cancellationToken);
+                await fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.Failed, "Error occurred while uploading fileTransfer", cancellationToken);
+                await eventBus.Publish(AltinnEventType.UploadFailed, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, cancellationToken);
                 return Errors.UploadFailed;
-            }, _logger, cancellationToken);
+            }, logger, cancellationToken);
         }
         return await TransactionWithRetriesPolicy.Execute(async (cancellationToken) =>
         {
-            await _fileTransferRepository.SetStorageDetails(request.FileTransferId, serviceOwner.StorageProvider.Id, request.FileTransferId.ToString(), request.UploadStream.Length, cancellationToken);
+            await fileTransferRepository.SetStorageDetails(request.FileTransferId, serviceOwner.StorageProvider.Id, request.FileTransferId.ToString(), request.UploadStream.Length, cancellationToken);
             if (serviceOwner.StorageProvider.Type == StorageProviderType.Altinn3Azure)
             {
-                await _fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.UploadProcessing, cancellationToken: cancellationToken);
-                await _eventBus.Publish(AltinnEventType.UploadProcessing, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, cancellationToken);
+                await fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.UploadProcessing, cancellationToken: cancellationToken);
+                await eventBus.Publish(AltinnEventType.UploadProcessing, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, cancellationToken);
             }
             else if (serviceOwner.StorageProvider.Type == StorageProviderType.Azurite) // When running in Azurite storage emulator, there is no async malwarescan that runs before publish
             {
-                await _fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.Published);
-                await _eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, cancellationToken);
+                await fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.Published);
+                await eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, cancellationToken);
                 foreach (var recipient in fileTransfer.RecipientCurrentStatuses)
                 {
-                    await _eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), recipient.Actor.ActorExternalId, cancellationToken);
+                    await eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), recipient.Actor.ActorExternalId, cancellationToken);
                 }
             }
             return fileTransfer.FileTransferId;
-        }, _logger, cancellationToken);
+        }, logger, cancellationToken);
     }
 }

--- a/src/Altinn.Broker.Core/Altinn.Broker.Core.csproj
+++ b/src/Altinn.Broker.Core/Altinn.Broker.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Altinn.Broker.Core/Helpers/SanitizerMethods.cs
+++ b/src/Altinn.Broker.Core/Helpers/SanitizerMethods.cs
@@ -1,0 +1,5 @@
+﻿namespace Altinn.Broker.Core.Helpers;
+public static class SanitizerMethods
+{
+    public static string SanitizeForLogs(this string input) => input.Replace(Environment.NewLine, null);
+}

--- a/src/Altinn.Broker.Integrations/Altinn/Events/AltinnEventBus.cs
+++ b/src/Altinn.Broker.Integrations/Altinn/Events/AltinnEventBus.cs
@@ -22,11 +22,12 @@ public class AltinnEventBus : IEventBus
     private readonly IBackgroundJobClient _backgroundJobClient;
     private readonly ILogger<AltinnEventBus> _logger;
 
-    public AltinnEventBus(HttpClient httpClient, IAltinnRegisterService altinnRegisterService, IOptions<AltinnOptions> altinnOptions, ILogger<AltinnEventBus> logger, IPartyRepository partyRepository)
+    public AltinnEventBus(HttpClient httpClient, IAltinnRegisterService altinnRegisterService, IBackgroundJobClient backgroundJobClient, IOptions<AltinnOptions> altinnOptions, ILogger<AltinnEventBus> logger, IPartyRepository partyRepository)
     {
         _httpClient = httpClient;
         _altinnOptions = altinnOptions.Value;
         _altinnRegisterService = altinnRegisterService;
+        _backgroundJobClient = backgroundJobClient;
         _partyRepository = partyRepository;
         _logger = logger;
     }

--- a/src/Altinn.Broker.Integrations/Altinn/Events/ConsoleLogEventBus.cs
+++ b/src/Altinn.Broker.Integrations/Altinn/Events/ConsoleLogEventBus.cs
@@ -4,18 +4,11 @@ using Altinn.Broker.Core.Services.Enums;
 using Microsoft.Extensions.Logging;
 
 namespace Altinn.Broker.Integrations.Altinn.Events;
-public class ConsoleLogEventBus : IEventBus
+public class ConsoleLogEventBus(ILogger<ConsoleLogEventBus> logger) : IEventBus
 {
-    private readonly ILogger<ConsoleLogEventBus> _logger;
-
-    public ConsoleLogEventBus(ILogger<ConsoleLogEventBus> logger)
-    {
-        _logger = logger;
-    }
-
     public Task Publish(AltinnEventType type, string resourceId, string fileTransferId, string? organizationId = null, CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("{CloudEventType} event raised on instance {fileTransferId} for party with organization number {organizationId}", type.ToString(), fileTransferId, organizationId);
+        logger.LogInformation("{CloudEventType} event raised on instance {fileTransferId} for party with organization number {organizationId}", type.ToString(), fileTransferId, organizationId);
         return Task.CompletedTask;
     }
 }

--- a/src/Altinn.Broker.Integrations/Azure/BlobService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/BlobService.cs
@@ -10,19 +10,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Altinn.Broker.Integrations.Azure;
 
-public class BlobService : IBrokerStorageService
+public class BlobService(IResourceManager resourceManager, ILogger<BlobService> logger) : IBrokerStorageService
 {
-    private readonly IResourceManager _resourceManager;
-    private readonly ILogger<BlobService> _logger;
-    public BlobService(IResourceManager resourceManager, ILogger<BlobService> logger)
-    {
-        _resourceManager = resourceManager;
-        _logger = logger;
-    }
-
     private async Task<BlobClient> GetBlobClient(Guid fileId, ServiceOwnerEntity serviceOwnerEntity)
     {
-        var connectionString = await _resourceManager.GetStorageConnectionString(serviceOwnerEntity);
+        var connectionString = await resourceManager.GetStorageConnectionString(serviceOwnerEntity);
         var blobServiceClient = new BlobServiceClient(connectionString, new BlobClientOptions()
         {
             Retry =
@@ -45,7 +37,7 @@ public class BlobService : IBrokerStorageService
         }
         catch (RequestFailedException requestFailedException)
         {
-            _logger.LogError("Error occurred while downloading file: {errorCode}: {errorMessage} ", requestFailedException.ErrorCode, requestFailedException.Message);
+            logger.LogError("Error occurred while downloading file: {errorCode}: {errorMessage} ", requestFailedException.ErrorCode, requestFailedException.Message);
             throw;
         }
     }
@@ -66,7 +58,7 @@ public class BlobService : IBrokerStorageService
         }
         catch (RequestFailedException requestFailedException)
         {
-            _logger.LogError("Error occurred while uploading file: {errorCode}: {errorMessage} ", requestFailedException.ErrorCode, requestFailedException.Message);
+            logger.LogError("Error occurred while uploading file: {errorCode}: {errorMessage} ", requestFailedException.ErrorCode, requestFailedException.Message);
             await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
             throw;
         }
@@ -81,7 +73,7 @@ public class BlobService : IBrokerStorageService
         }
         catch (RequestFailedException requestFailedException)
         {
-            _logger.LogError("Error occurred while deleting file: {errorCode}: {errorMessage} ", requestFailedException.ErrorCode, requestFailedException.Message);
+            logger.LogError("Error occurred while deleting file: {errorCode}: {errorMessage} ", requestFailedException.ErrorCode, requestFailedException.Message);
             throw;
         }
     }

--- a/src/Altinn.Broker.Integrations/DependencyInjection.cs
+++ b/src/Altinn.Broker.Integrations/DependencyInjection.cs
@@ -33,7 +33,7 @@ public static class DependencyInjection
         var altinnOptions = new AltinnOptions();
         configuration.GetSection(nameof(AltinnOptions)).Bind(altinnOptions);
 
-        if (isDevelopment)
+        if (false)
         {
             services.AddSingleton<IEventBus, ConsoleLogEventBus>();
         }

--- a/src/Altinn.Broker.Integrations/Hangfire/IdempotencyService.cs
+++ b/src/Altinn.Broker.Integrations/Hangfire/IdempotencyService.cs
@@ -4,23 +4,14 @@ using Hangfire;
 
 using Microsoft.Extensions.Logging;
 
-public class IdempotencyService
+public class IdempotencyService(
+    IIdempotencyEventRepository idempotencyEventRepository,
+    ILogger<IdempotencyService> logger)
 {
-    private readonly IIdempotencyEventRepository _idempotencyEventRepository;
-    private readonly ILogger<IdempotencyService> _logger;
-
-    public IdempotencyService(
-        IIdempotencyEventRepository idempotencyEventRepository,
-        ILogger<IdempotencyService> logger)
-    {
-        _idempotencyEventRepository = idempotencyEventRepository;
-        _logger = logger;
-    }
-
     [AutomaticRetry(Attempts = 0)]
     public async Task DeleteOldIdempotencyEvents()
     {
-        _logger.LogInformation("Deleting old idempotency events");
-        await _idempotencyEventRepository.DeleteOldIdempotencyEvents();
+        logger.LogInformation("Deleting old idempotency events");
+        await idempotencyEventRepository.DeleteOldIdempotencyEvents();
     }
 }

--- a/src/Altinn.Broker.Persistence/Repositories/ActorRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/ActorRepository.cs
@@ -5,18 +5,11 @@ using Npgsql;
 
 namespace Altinn.Broker.Persistence.Repositories;
 
-public class ActorRepository : IActorRepository
+public class ActorRepository(NpgsqlDataSource dataSource) : IActorRepository
 {
-    private NpgsqlDataSource _dataSource;
-
-    public ActorRepository(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
-
     public async Task<ActorEntity?> GetActorAsync(string actorExternalId, CancellationToken cancellationToken)
     {
-        await using var command = _dataSource.CreateCommand(
+        await using var command = dataSource.CreateCommand(
         "SELECT actor_id_pk, actor_external_id FROM broker.actor WHERE actor_external_id = @actorExternalId");
         command.Parameters.AddWithValue("@actorExternalId", actorExternalId);
 
@@ -36,7 +29,7 @@ public class ActorRepository : IActorRepository
 
     public async Task<long> AddActorAsync(ActorEntity actor, CancellationToken cancellationToken)
     {
-        await using NpgsqlCommand command = _dataSource.CreateCommand(
+        await using NpgsqlCommand command = dataSource.CreateCommand(
                 "INSERT INTO broker.actor (actor_external_id) " +
                 "VALUES (@actorExternalId) " +
                 "RETURNING actor_id_pk");

--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferStatusRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferStatusRepository.cs
@@ -5,18 +5,11 @@ using Altinn.Broker.Core.Repositories;
 using Npgsql;
 
 namespace Altinn.Broker.Persistence.Repositories;
-public class FileTransferStatusRepository : IFileTransferStatusRepository
+public class FileTransferStatusRepository(NpgsqlDataSource dataSource) : IFileTransferStatusRepository
 {
-    private NpgsqlDataSource _dataSource;
-
-    public FileTransferStatusRepository(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
-
     public async Task InsertFileTransferStatus(Guid fileTransferId, FileTransferStatus status, string? detailedFileTransferStatus = null, CancellationToken cancellationToken = default)
     {
-        await using var command = _dataSource.CreateCommand(
+        await using var command = dataSource.CreateCommand(
                     "INSERT INTO broker.file_transfer_status (file_transfer_id_fk, file_transfer_status_description_id_fk, file_transfer_status_date, file_transfer_status_detailed_description) " +
                     "VALUES (@fileTransferId, @statusId, NOW(), @detailedFileTransferStatus) RETURNING file_transfer_status_id_pk;");
         command.Parameters.AddWithValue("@fileTransferId", fileTransferId);
@@ -32,7 +25,7 @@ public class FileTransferStatusRepository : IFileTransferStatusRepository
 
     public async Task<List<FileTransferStatusEntity>> GetFileTransferStatusHistory(Guid fileTransferId, CancellationToken cancellationToken)
     {
-        await using var command = _dataSource.CreateCommand(
+        await using var command = dataSource.CreateCommand(
             "SELECT file_transfer_id_fk, file_transfer_status_description_id_fk, file_transfer_status_date, file_transfer_status_detailed_description " +
             "FROM broker.file_transfer_status fis " +
             "WHERE fis.file_transfer_id_fk = @fileTransferId");

--- a/src/Altinn.Broker.Persistence/Repositories/IdempotencyEventRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/IdempotencyEventRepository.cs
@@ -4,19 +4,11 @@ using Npgsql;
 
 namespace Altinn.Broker.Persistence.Repositories;
 
-public class IdempotencyEventRepository : IIdempotencyEventRepository
+public class IdempotencyEventRepository(NpgsqlDataSource dataSource) : IIdempotencyEventRepository
 {
-    private NpgsqlDataSource _dataSource;
-
-    public IdempotencyEventRepository(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
-
-
     public async Task AddIdempotencyEventAsync(string IdempotencyEventId, CancellationToken cancellationToken)
     {
-        await using NpgsqlCommand command = _dataSource.CreateCommand(
+        await using NpgsqlCommand command = dataSource.CreateCommand(
                     "INSERT INTO broker.idempotency_event (idempotency_event_id_pk, created)" +
                     "VALUES (@idempotency_event_id_pk, @created) ");
         command.Parameters.AddWithValue("@idempotency_event_id_pk", IdempotencyEventId);
@@ -26,7 +18,7 @@ public class IdempotencyEventRepository : IIdempotencyEventRepository
     }
     public async Task DeleteIdempotencyEventAsync(string IdempotencyEventId, CancellationToken cancellationToken)
     {
-        await using NpgsqlCommand command = _dataSource.CreateCommand(
+        await using NpgsqlCommand command = dataSource.CreateCommand(
                     "DELETE FROM broker.idempotency_event " +
                     "WHERE idempotency_event_id_pk = @idempotency_event_id_pk");
         command.Parameters.AddWithValue("@idempotency_event_id_pk", IdempotencyEventId);
@@ -35,7 +27,7 @@ public class IdempotencyEventRepository : IIdempotencyEventRepository
     }
     public async Task DeleteOldIdempotencyEvents()
     {
-        await using NpgsqlCommand command = _dataSource.CreateCommand(
+        await using NpgsqlCommand command = dataSource.CreateCommand(
                     "DELETE FROM broker.idempotency_event " +
                     "WHERE created < @created");
 

--- a/src/Altinn.Broker.Persistence/Repositories/PartyRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/PartyRepository.cs
@@ -4,18 +4,11 @@ using Altinn.Broker.Core.Repositories;
 using Npgsql;
 
 namespace Altinn.Broker.Persistence.Repositories;
-public class PartyRepository : IPartyRepository
+public class PartyRepository(NpgsqlDataSource dataSource) : IPartyRepository
 {
-    private readonly NpgsqlDataSource _dataSource;
-
-    public PartyRepository(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
-
     public async Task<PartyEntity?> GetParty(string organizationId, CancellationToken cancellationToken)
     {
-        await using var command = _dataSource.CreateCommand(
+        await using var command = dataSource.CreateCommand(
             "SELECT organization_number_pk, party_id, created from broker.party " +
             "WHERE organization_number_pk = @organizationId ");
         command.Parameters.AddWithValue("@organizationId", organizationId);
@@ -36,7 +29,7 @@ public class PartyRepository : IPartyRepository
 
     public async Task InitializeParty(string organizationId, string partyId)
     {
-        await using var command = _dataSource.CreateCommand(
+        await using var command = dataSource.CreateCommand(
             "INSERT INTO broker.party (organization_number_pk, party_id, created) " +
             "VALUES (@organizationId, @partyId, NOW())");
         command.Parameters.AddWithValue("@organizationId", organizationId);

--- a/src/Altinn.Broker.Persistence/Repositories/ServiceOwnerRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/ServiceOwnerRepository.cs
@@ -4,18 +4,11 @@ using Altinn.Broker.Core.Repositories;
 using Npgsql;
 
 namespace Altinn.Broker.Persistence.Repositories;
-public class ServiceOwnerRepository : IServiceOwnerRepository
+public class ServiceOwnerRepository(NpgsqlDataSource dataSource) : IServiceOwnerRepository
 {
-    private readonly NpgsqlDataSource _dataSource;
-
-    public ServiceOwnerRepository(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
-
     public async Task<ServiceOwnerEntity?> GetServiceOwner(string serviceOwnerId)
     {
-        await using var command = _dataSource.CreateCommand(
+        await using var command = dataSource.CreateCommand(
             "SELECT service_owner_id_pk, service_owner_name, " +
             "storage_provider_id_pk, created, resource_name, storage_provider_type " +
             "FROM broker.service_owner " +
@@ -47,7 +40,7 @@ public class ServiceOwnerRepository : IServiceOwnerRepository
 
     public async Task InitializeServiceOwner(string sub, string name)
     {
-        await using var command = _dataSource.CreateCommand(
+        await using var command = dataSource.CreateCommand(
             "INSERT INTO broker.service_owner (service_owner_id_pk, service_owner_name) " +
             "VALUES (@sub, @name)");
         command.Parameters.AddWithValue("@sub", sub);
@@ -60,7 +53,7 @@ public class ServiceOwnerRepository : IServiceOwnerRepository
 
     public async Task InitializeStorageProvider(string sub, string resourceName, StorageProviderType storageType)
     {
-        await using var command = _dataSource.CreateCommand(
+        await using var command = dataSource.CreateCommand(
             "INSERT INTO broker.storage_provider (created, resource_name, storage_provider_type, service_owner_id_fk) " +
             "VALUES (NOW(), @resourceName, @storageType, @serviceOwnerId)");
         command.Parameters.AddWithValue("@resourceName", resourceName);

--- a/tests/Altinn.Broker.Tests/HangfireStorageCompatibilityTests.cs
+++ b/tests/Altinn.Broker.Tests/HangfireStorageCompatibilityTests.cs
@@ -42,16 +42,11 @@ public class HangfireStorageCompatibilityTests(CustomWebApplicationFactory facto
         Assert.True((long)postCommitCommand.ExecuteScalar() == 1);
     }
 
-    internal class TestConnectionFactory : IConnectionFactory
+    internal class TestConnectionFactory(NpgsqlDataSource dataSource) : IConnectionFactory
     {
-        private readonly NpgsqlDataSource _dataSource;
-        public TestConnectionFactory(NpgsqlDataSource dataSource)
-        {
-            _dataSource = dataSource;
-        }
         public NpgsqlConnection GetOrCreateConnection()
         {
-            return _dataSource.CreateConnection();
+            return dataSource.CreateConnection();
         }
     }   
 }


### PR DESCRIPTION
## Description
Initial commit was a small fix of some code where I had forgotten to set a field variable in the constructor. Quick oversight! But it makes me think it might be worthwhile to start using the [new "Primary Constructor"-syntax introduced in C# 12](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/primary-constructors). Instead of using a constructor, the injected fields are set like so:
```
public class Foo(IFileTransferRepository fileTransferRepository)
{
}
```
With traditional syntax the same would be:
```
public class Foo
{
    private readonly IFileTransferRepository _fileTransferRepository;
    public Foo(IFileTransferRepository fileTransferRepository)
    {
        _fileTransferRepository = fileTransferRepository;
    }
}
```
I think primary constructor is clearer and more concise.

My main gripe with it has been that it cannot always be used. For instance, in [AltinnAuthorizationService.cs](https://github.com/Altinn/altinn-broker/blob/main/src/Altinn.Broker.Integrations/Altinn/Authorization/AltinnAuthorizationService.cs) we call a method in the constructor (httpClient.DefaultRequestHeaders.Add(...)) and thus this class cannot use primary constructor.
However, I see this is very much exception and not rule. Vast majority of our constructors just map parameters to fields.

## Related Issue(s)
- #527 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
