### PR TITLE
Use default behaviour in token middleware

### DIFF
--- a/src/Altinn.Broker.API/Helpers/JWTBearerEventsHelper.cs
+++ b/src/Altinn.Broker.API/Helpers/JWTBearerEventsHelper.cs
@@ -7,13 +7,13 @@ public class JWTBearerEventsHelper
 {
     public static Task OnAuthenticationFailed(AuthenticationFailedContext context)
     {
-        context.Response.ContentType = "application/problem+json";
-        context.Response.Headers.Append("WWW-Authenticate", context.Options.Challenge + " error=\"invalid_token\"");
         if (context.Exception is SecurityTokenInvalidIssuerException)
         {
             var issuer = ((SecurityTokenInvalidIssuerException)context.Exception).InvalidIssuer;
             if (issuer.ToString().Contains("maskinporten.no"))
             {
+                context.Response.ContentType = "application/problem+json";
+                context.Response.Headers.Append("WWW-Authenticate", context.Options.Challenge + " error=\"invalid_token\"");
                 context.Response.StatusCode = StatusCodes.Status403Forbidden;
                 return context.Response.WriteAsJsonAsync(new ProblemDetails()
                 {
@@ -23,12 +23,6 @@ public class JWTBearerEventsHelper
                 });
             }
         }
-        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-        return context.Response.WriteAsJsonAsync(new ProblemDetails
-        {
-            Status = StatusCodes.Status401Unauthorized,
-            Title = "Authentication failed",
-            Detail = context.Exception.Message
-        });
+        return Task.CompletedTask;
     }
 }

--- a/src/Altinn.Broker.API/Program.cs
+++ b/src/Altinn.Broker.API/Program.cs
@@ -130,16 +130,7 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
             };
             options.Events = new JwtBearerEvents()
             {
-                OnAuthenticationFailed = context => JWTBearerEventsHelper.OnAuthenticationFailed(context),
-                OnChallenge = context =>
-                {
-                    if (context.AuthenticateFailure != null)
-                    {
-                        context.HandleResponse();
-                        return Task.CompletedTask;
-                    }
-                    return context.Response.CompleteAsync();
-                }
+                OnAuthenticationFailed = context => JWTBearerEventsHelper.OnAuthenticationFailed(context)
             };
         })
         .AddJwtBearer(AuthorizationConstants.Legacy, options => // To support "overgangslosningen"


### PR DESCRIPTION
## Description
In certain error cases, this middleware could fail as it overrides other middlewares. Instead return a Task to cause default behaviour.

## Related Issue(s)
- #

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
