### PR TITLE
Add "enhancement" as label for release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,15 +9,20 @@ changelog:
     - title: New Features 🎉
       labels:
         - kind/feature
+        - kind/feature-request
     - title: Bugfixes 🐛
       labels:
         - kind/bug
     - title: Other Changes
       labels:
         - kind/other
+        - kind/user-story
     - title: Dependency Upgrades 📦
       labels:
         - kind/dependencies
+    - title: Enhancements
+      labels:
+        - kind/enhancement
     - title: Incident
       labels:
         - kind/incident


### PR DESCRIPTION
The label enhancement is added as a label for release notes

## Description
In addition to "kind/enhancement", the "kind/feature-request" is also added to the Feature Request label in case it is used.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
