### PR TITLE
Add Workflow to verify future PRs contain a label that is used for release notes

### DIFF
--- a/.github/workflows/check-label-for-pr.yml
+++ b/.github/workflows/check-label-for-pr.yml
@@ -1,0 +1,25 @@
+name: Checking label for PR
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, labeled, unlabeled]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: minimum
+          count: 1
+          labels: |
+            kind/breaking-change
+            kind/feature
+            kind/feature-request
+            kind/bug
+            kind/other
+            kind/user-story
+            kind/dependencies
+            kind/enhancement
+            kind/incident
+            kind/chore


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

## Related Issue(s)
- #564 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a GitHub Actions workflow to enforce labeling on pull requests, ensuring they meet specific criteria before being processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->