### PR TITLE
Lagt til dynamiske felter for manifestfil

### DIFF
--- a/altinn-broker-postman-collection.json
+++ b/altinn-broker-postman-collection.json
@@ -860,7 +860,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"resourceId\": \"{{resourceId}}\",\r\n    \"maxFileTransferSize\": \"1073741824\",\r\n    \"fileTransferTimeToLive\": \"PT2H\",\r\n    \"purgeFileTransferAfterAllRecipientsConfirmed\" : false,\r\n    \"purgeFileTransferGracePeriod\": \"PT14H\",\r\n    \"useManifestFileShim\": false\r\n}",
+							"raw": "{\r\n    \"resourceId\": \"{{resourceId}}\",\r\n    \"maxFileTransferSize\": \"1112391230\",\r\n    \"fileTransferTimeToLive\": \"PT2H\",\r\n    \"PurgeFileTransferAfterAllRecipientsConfirmed\" : false,\r\n    \"purgeFileTransferGracePeriod\": \"PT14H\",\r\n    \"ExternalServiceCodeLegacy\": \"\",\r\n    \"ExternalServiceEditionCodeLegacy\": \"\",\r\n    \"UseManifestFileShim\": false\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1333,7 +1333,7 @@
 			}
 		}
 	],
-	"variable": [
+"variable": [
 		{
 			"key": "serviceowner_orgnumber",
 			"value": "Organization number of service owner / \"tjeneste-eier\". Nine digits, no prefix.",

--- a/src/Altinn.Broker.API/Controllers/ResourceController.cs
+++ b/src/Altinn.Broker.API/Controllers/ResourceController.cs
@@ -29,7 +29,9 @@ public class ResourceController : Controller
             FileTransferTimeToLive = resourceExt.FileTransferTimeToLive,
             PurgeFileTransferAfterAllRecipientsConfirmed = resourceExt.PurgeFileTransferAfterAllRecipientsConfirmed,
             PurgeFileTransferGracePeriod = resourceExt.PurgeFileTransferGracePeriod,
-            UseManifestFileShim = resourceExt.UseManifestFileShim
+            UseManifestFileShim = resourceExt.UseManifestFileShim,
+            ExternalServiceCodeLegacy = resourceExt.ExternalServiceCodeLegacy,
+            ExternalServiceEditionCodeLegacy = resourceExt.ExternalServiceEditionCodeLegacy
         }, cancellationToken);
 
         return result.Match(

--- a/src/Altinn.Broker.API/Helpers/ValidateUseManifestFileShim.cs
+++ b/src/Altinn.Broker.API/Helpers/ValidateUseManifestFileShim.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Altinn.Broker.Helpers
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class ValidateUseManifestFileShim : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var useManifestFileShimProperty = validationContext.ObjectType.GetProperty("UseManifestFileShim");
+            var externalServiceCodeLegacyProperty = validationContext.ObjectType.GetProperty("ExternalServiceCodeLegacy");
+            var externalServiceEditionCodeLegacyProperty = validationContext.ObjectType.GetProperty("ExternalServiceEditionCodeLegacy");
+            var useManifestFileShimValue = (bool?)useManifestFileShimProperty.GetValue(validationContext.ObjectInstance, null);
+            var externalServiceCodeLegacyValue = externalServiceCodeLegacyProperty.GetValue(validationContext.ObjectInstance, null);
+            var externalServiceEditionCodeLegacyValue = externalServiceEditionCodeLegacyProperty.GetValue(validationContext.ObjectInstance, null);
+
+            if (useManifestFileShimValue == true)
+            {
+                if (externalServiceCodeLegacyValue == null || (externalServiceCodeLegacyValue is string strValue && string.IsNullOrEmpty(strValue)))
+                {
+                    return new ValidationResult("ExternalServiceCodeLegacy must be set and not be an empty string.");
+                }
+
+                if (externalServiceEditionCodeLegacyValue == null || (externalServiceEditionCodeLegacyValue is int intValue && intValue == 0))
+                {
+                    return new ValidationResult("ExternalServiceEditionCodeLegacy must be set and not be zero.");
+                }
+            }
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/src/Altinn.Broker.API/Models/ResourceExt.cs
+++ b/src/Altinn.Broker.API/Models/ResourceExt.cs
@@ -1,10 +1,14 @@
 using System.Text.Json.Serialization;
 
+using Altinn.Broker.Helpers;
+
 namespace Altinn.Broker.Models;
 
 /// <summary>
 /// API input model for file initialization.
 /// </summary>
+[ValidateUseManifestFileShim]
+
 public class ResourceExt
 {
 

--- a/src/Altinn.Broker.API/Models/ResourceExt.cs
+++ b/src/Altinn.Broker.API/Models/ResourceExt.cs
@@ -37,4 +37,10 @@ public class ResourceExt
     /// </summary>
     [JsonPropertyName("useManifestFileShim")]
     public bool? UseManifestFileShim { get; set; }
+
+    [JsonPropertyName("externalServiceCodeLegacy")]
+    public string? ExternalServiceCodeLegacy { get; set; }
+
+    [JsonPropertyName("externalServiceEditionCodeLegacy")]
+    public string? ExternalServiceEditionCodeLegacy { get; set; }
 }

--- a/src/Altinn.Broker.API/Models/ResourceExt.cs
+++ b/src/Altinn.Broker.API/Models/ResourceExt.cs
@@ -42,5 +42,5 @@ public class ResourceExt
     public string? ExternalServiceCodeLegacy { get; set; }
 
     [JsonPropertyName("externalServiceEditionCodeLegacy")]
-    public string? ExternalServiceEditionCodeLegacy { get; set; }
+    public int? ExternalServiceEditionCodeLegacy { get; set; }
 }

--- a/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
+++ b/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
@@ -61,23 +61,13 @@ public class ConfigureResourceHandler(IResourceRepository resourceRepository, IO
         if (request.UseManifestFileShim is not null)
         {
             var updateManifestFileShimResult = await UpdateUseManifestFileShim(resource, request.UseManifestFileShim.Value, cancellationToken);
+            await resourceRepository.UpdateExternalServiceCodeLegacy(resource.Id, request.ExternalServiceCodeLegacy, cancellationToken);
+            await resourceRepository.UpdateExternalServiceEditionCodeLegacy(resource.Id, request.ExternalServiceEditionCodeLegacy, cancellationToken);
+            
             if (updateManifestFileShimResult.IsT1)
             {
                 return updateManifestFileShimResult.AsT1;
             }
-        }
-        if (request.UseManifestFileShim == true)
-        {
-            if (!string.IsNullOrEmpty(request.ExternalServiceCodeLegacy) && request.ExternalServiceEditionCodeLegacy is not null && request.ExternalServiceEditionCodeLegacy != 0)
-            {
-                await resourceRepository.UpdateExternalServiceCodeLegacy(resource.Id, request.ExternalServiceCodeLegacy, cancellationToken);
-                await resourceRepository.UpdateExternalServiceEditionCodeLegacy(resource.Id, request.ExternalServiceEditionCodeLegacy, cancellationToken);
-            } 
-            else
-            {
-                throw new ArgumentException("ExternalServiceCodeLegacy and ExternalServiceEditionCodeLegacy must be set when UseManifestFileShim is true");
-            }
-
         }
         return Task.CompletedTask;
     }

--- a/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
+++ b/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
@@ -68,19 +68,14 @@ public class ConfigureResourceHandler(IResourceRepository resourceRepository, IO
         }
         if (request.ExternalServiceCodeLegacy is not null && request.UseManifestFileShim == true)
         {
-            var updateExternalServiceCodeLegacyResult = await UpdateExternalServiceCodeLegacy(resource, request.ExternalServiceCodeLegacy, cancellationToken);
-            if (updateExternalServiceCodeLegacyResult.IsT1)
-            {
-                return updateExternalServiceCodeLegacyResult.AsT1;
-            }
+            await resourceRepository.UpdateExternalServiceCodeLegacy(resource.Id, request.ExternalServiceCodeLegacy, cancellationToken);
+
         }
         if (request.ExternalServiceEditionCodeLegacy is not null && request.UseManifestFileShim == true)
         {
-            var updateExternalServiceEditionCodeLegacyResult = await UpdateExternalServiceEditionCodeLegacy(resource, request.ExternalServiceEditionCodeLegacy, cancellationToken);
-            if (updateExternalServiceEditionCodeLegacyResult.IsT1)
-            {
-                return updateExternalServiceEditionCodeLegacyResult.AsT1;
-            }
+            await resourceRepository.UpdateExternalServiceEditionCodeLegacy(resource.Id, request.ExternalServiceEditionCodeLegacy, cancellationToken);
+
+
         }
         return Task.CompletedTask;
     }
@@ -147,14 +142,14 @@ public class ConfigureResourceHandler(IResourceRepository resourceRepository, IO
         return Task.CompletedTask;
     }
 
-    private async Task<OneOf<Task, Error>> UpdateExternalServiceCodeLegacy(ResourceEntity resource, string ExternalServiceCodeLegacy, CancellationToken cancellationToken)
-    {
-        await resourceRepository.UpdateExternalServiceCodeLegacy(resource.Id, ExternalServiceCodeLegacy, cancellationToken);
-        return Task.CompletedTask;
-    }
-    private async Task<OneOf<Task, Error>> UpdateExternalServiceEditionCodeLegacy(ResourceEntity resource, string ExternalServiceEditionCodeLegacy, CancellationToken cancellationToken)
-    {
-        await resourceRepository.UpdateExternalServiceEditionCodeLegacy(resource.Id, ExternalServiceEditionCodeLegacy, cancellationToken);
-        return Task.CompletedTask;
-    }
+    // private async Task<OneOf<Task, Error>> UpdateExternalServiceCodeLegacy(ResourceEntity resource, string ExternalServiceCodeLegacy, CancellationToken cancellationToken)
+    // {
+    //     await resourceRepository.UpdateExternalServiceCodeLegacy(resource.Id, ExternalServiceCodeLegacy, cancellationToken);
+    //     return Task.CompletedTask;
+    // }
+    // private async Task<OneOf<Task, Error>> UpdateExternalServiceEditionCodeLegacy(ResourceEntity resource, string ExternalServiceEditionCodeLegacy, CancellationToken cancellationToken)
+    // {
+    //     await resourceRepository.UpdateExternalServiceEditionCodeLegacy(resource.Id, ExternalServiceEditionCodeLegacy, cancellationToken);
+    //     return Task.CompletedTask;
+    // }
 }

--- a/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
+++ b/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
@@ -66,15 +66,14 @@ public class ConfigureResourceHandler(IResourceRepository resourceRepository, IO
                 return updateManifestFileShimResult.AsT1;
             }
         }
-        if (request.ExternalServiceCodeLegacy is not null && request.UseManifestFileShim == true)
+        if (request.UseManifestFileShim == true)
         {
-            await resourceRepository.UpdateExternalServiceCodeLegacy(resource.Id, request.ExternalServiceCodeLegacy, cancellationToken);
+            if (string.IsNullOrEmpty(request.ExternalServiceCodeLegacy) && request.ExternalServiceEditionCodeLegacy is null && request.ExternalServiceEditionCodeLegacy != 0)
 
-        }
-        if (request.ExternalServiceEditionCodeLegacy is not null && request.UseManifestFileShim == true)
-        {
-            await resourceRepository.UpdateExternalServiceEditionCodeLegacy(resource.Id, request.ExternalServiceEditionCodeLegacy, cancellationToken);
-
+            {
+                await resourceRepository.UpdateExternalServiceCodeLegacy(resource.Id, request.ExternalServiceCodeLegacy, cancellationToken);
+                await resourceRepository.UpdateExternalServiceEditionCodeLegacy(resource.Id, request.ExternalServiceEditionCodeLegacy, cancellationToken);
+            }
 
         }
         return Task.CompletedTask;
@@ -141,15 +140,4 @@ public class ConfigureResourceHandler(IResourceRepository resourceRepository, IO
         await resourceRepository.UpdateUseManifestFileShim(resource.Id, useManifestFileShim, cancellationToken);
         return Task.CompletedTask;
     }
-
-    // private async Task<OneOf<Task, Error>> UpdateExternalServiceCodeLegacy(ResourceEntity resource, string ExternalServiceCodeLegacy, CancellationToken cancellationToken)
-    // {
-    //     await resourceRepository.UpdateExternalServiceCodeLegacy(resource.Id, ExternalServiceCodeLegacy, cancellationToken);
-    //     return Task.CompletedTask;
-    // }
-    // private async Task<OneOf<Task, Error>> UpdateExternalServiceEditionCodeLegacy(ResourceEntity resource, string ExternalServiceEditionCodeLegacy, CancellationToken cancellationToken)
-    // {
-    //     await resourceRepository.UpdateExternalServiceEditionCodeLegacy(resource.Id, ExternalServiceEditionCodeLegacy, cancellationToken);
-    //     return Task.CompletedTask;
-    // }
 }

--- a/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
+++ b/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
@@ -66,6 +66,22 @@ public class ConfigureResourceHandler(IResourceRepository resourceRepository, IO
                 return updateManifestFileShimResult.AsT1;
             }
         }
+        if (request.ExternalServiceCodeLegacy is not null)
+        {
+            var updateExternalServiceCodeLegacyResult = await UpdateExternalServiceCodeLegacy(resource, request.ExternalServiceCodeLegacy, cancellationToken);
+            if (updateExternalServiceCodeLegacyResult.IsT1)
+            {
+                return updateExternalServiceCodeLegacyResult.AsT1;
+            }
+        }
+        if (request.ExternalServiceEditionCodeLegacy is not null)
+        {
+            var updateExternalServiceEditionCodeLegacyResult = await UpdateExternalServiceEditionCodeLegacy(resource, request.ExternalServiceEditionCodeLegacy, cancellationToken);
+            if (updateExternalServiceEditionCodeLegacyResult.IsT1)
+            {
+                return updateExternalServiceEditionCodeLegacyResult.AsT1;
+            }
+        }
         return Task.CompletedTask;
     }
 
@@ -128,6 +144,17 @@ public class ConfigureResourceHandler(IResourceRepository resourceRepository, IO
         logger.LogInformation("Updating manifest file shim setting for resource {ResourceId} to {UseManifestFileShim}", 
             resource.Id.SanitizeForLogs(), useManifestFileShim);
         await resourceRepository.UpdateUseManifestFileShim(resource.Id, useManifestFileShim, cancellationToken);
+        return Task.CompletedTask;
+    }
+
+    private async Task<OneOf<Task, Error>> UpdateExternalServiceCodeLegacy(ResourceEntity resource, string ExternalServiceCodeLegacy, CancellationToken cancellationToken)
+    {
+        await resourceRepository.UpdateExternalServiceCodeLegacy(resource.Id, ExternalServiceCodeLegacy, cancellationToken);
+        return Task.CompletedTask;
+    }
+    private async Task<OneOf<Task, Error>> UpdateExternalServiceEditionCodeLegacy(ResourceEntity resource, string ExternalServiceEditionCodeLegacy, CancellationToken cancellationToken)
+    {
+        await resourceRepository.UpdateExternalServiceEditionCodeLegacy(resource.Id, ExternalServiceEditionCodeLegacy, cancellationToken);
         return Task.CompletedTask;
     }
 }

--- a/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
+++ b/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
@@ -68,11 +68,14 @@ public class ConfigureResourceHandler(IResourceRepository resourceRepository, IO
         }
         if (request.UseManifestFileShim == true)
         {
-            if (string.IsNullOrEmpty(request.ExternalServiceCodeLegacy) && request.ExternalServiceEditionCodeLegacy is null && request.ExternalServiceEditionCodeLegacy != 0)
-
+            if (!string.IsNullOrEmpty(request.ExternalServiceCodeLegacy) && request.ExternalServiceEditionCodeLegacy is not null && request.ExternalServiceEditionCodeLegacy != 0)
             {
                 await resourceRepository.UpdateExternalServiceCodeLegacy(resource.Id, request.ExternalServiceCodeLegacy, cancellationToken);
                 await resourceRepository.UpdateExternalServiceEditionCodeLegacy(resource.Id, request.ExternalServiceEditionCodeLegacy, cancellationToken);
+            } 
+            else
+            {
+                throw new ArgumentException("ExternalServiceCodeLegacy and ExternalServiceEditionCodeLegacy must be set when UseManifestFileShim is true");
             }
 
         }

--- a/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
+++ b/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
@@ -66,7 +66,7 @@ public class ConfigureResourceHandler(IResourceRepository resourceRepository, IO
                 return updateManifestFileShimResult.AsT1;
             }
         }
-        if (request.ExternalServiceCodeLegacy is not null)
+        if (request.ExternalServiceCodeLegacy is not null && request.UseManifestFileShim == true)
         {
             var updateExternalServiceCodeLegacyResult = await UpdateExternalServiceCodeLegacy(resource, request.ExternalServiceCodeLegacy, cancellationToken);
             if (updateExternalServiceCodeLegacyResult.IsT1)
@@ -74,7 +74,7 @@ public class ConfigureResourceHandler(IResourceRepository resourceRepository, IO
                 return updateExternalServiceCodeLegacyResult.AsT1;
             }
         }
-        if (request.ExternalServiceEditionCodeLegacy is not null)
+        if (request.ExternalServiceEditionCodeLegacy is not null && request.UseManifestFileShim == true)
         {
             var updateExternalServiceEditionCodeLegacyResult = await UpdateExternalServiceEditionCodeLegacy(resource, request.ExternalServiceEditionCodeLegacy, cancellationToken);
             if (updateExternalServiceEditionCodeLegacyResult.IsT1)

--- a/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceRequest.cs
+++ b/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceRequest.cs
@@ -11,5 +11,5 @@ public class ConfigureResourceRequest
     public string? PurgeFileTransferGracePeriod { get; set; }
     public bool? UseManifestFileShim { get; set; }
     public string? ExternalServiceCodeLegacy { get; set; }
-    public string? ExternalServiceEditionCodeLegacy { get; set; }
+    public int? ExternalServiceEditionCodeLegacy { get; set; }
 }

--- a/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceRequest.cs
+++ b/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceRequest.cs
@@ -10,4 +10,6 @@ public class ConfigureResourceRequest
     public bool? PurgeFileTransferAfterAllRecipientsConfirmed { get; set; } = true;
     public string? PurgeFileTransferGracePeriod { get; set; }
     public bool? UseManifestFileShim { get; set; }
+    public string? ExternalServiceCodeLegacy { get; set; }
+    public string? ExternalServiceEditionCodeLegacy { get; set; }
 }

--- a/src/Altinn.Broker.Application/DownloadFile/DownloadFileHandler.cs
+++ b/src/Altinn.Broker.Application/DownloadFile/DownloadFileHandler.cs
@@ -51,7 +51,7 @@ public class DownloadFileHandler(IResourceRepository resourceRepository, IServic
             var fileBuffer = new byte[downloadStream.Length];
             downloadStream.Read(fileBuffer, 0, fileBuffer.Length);
             downloadStream = new ManifestDownloadStream(fileBuffer);
-            (downloadStream as ManifestDownloadStream)?.AddManifestFile(fileTransfer);
+            (downloadStream as ManifestDownloadStream)?.AddManifestFile(fileTransfer, resource);
         }
         await actorFileTransferStatusRepository.InsertActorFileTransferStatus(request.FileTransferId, ActorFileTransferStatus.DownloadStarted, request.Token.Consumer, cancellationToken);
         return new DownloadFileResponse()

--- a/src/Altinn.Broker.Core/Domain/ResourceEntity.cs
+++ b/src/Altinn.Broker.Core/Domain/ResourceEntity.cs
@@ -12,5 +12,5 @@ public class ResourceEntity
     public TimeSpan? PurgeFileTransferGracePeriod { get; set; }
     public bool? UseManifestFileShim { get; set; }
     public string? ExternalServiceCodeLegacy { get; set; }
-    public string? ExternalServiceEditionCodeLegacy { get; set; }
+    public int? ExternalServiceEditionCodeLegacy { get; set; }
 }

--- a/src/Altinn.Broker.Core/Domain/ResourceEntity.cs
+++ b/src/Altinn.Broker.Core/Domain/ResourceEntity.cs
@@ -11,4 +11,6 @@ public class ResourceEntity
     public bool PurgeFileTransferAfterAllRecipientsConfirmed { get; set; } = true;
     public TimeSpan? PurgeFileTransferGracePeriod { get; set; }
     public bool? UseManifestFileShim { get; set; }
+    public string? ExternalServiceCodeLegacy { get; set; }
+    public string? ExternalServiceEditionCodeLegacy { get; set; }
 }

--- a/src/Altinn.Broker.Core/Helpers/BrokerServiceManifest.cs
+++ b/src/Altinn.Broker.Core/Helpers/BrokerServiceManifest.cs
@@ -58,8 +58,9 @@ public static class BrokerServiceManifestExtensions
     {
         var manifest = new BrokerServiceManifest
         {
-            ExternalServiceCode = resource.ExternalServiceCodeLegacy,
-            ExternalServiceEditionCode = resource.ExternalServiceEditionCodeLegacy,
+            
+            ExternalServiceCode = (bool)resource.UseManifestFileShim ? resource.ExternalServiceCodeLegacy : null,
+            ExternalServiceEditionCode = (bool)resource.UseManifestFileShim ? resource.ExternalServiceEditionCodeLegacy : null,
             SendersReference = entity.SendersFileTransferReference,
             Reportee = entity.RecipientCurrentStatuses.First().Actor.ActorExternalId,
             SentDate = DateTime.UtcNow,

--- a/src/Altinn.Broker.Core/Helpers/BrokerServiceManifest.cs
+++ b/src/Altinn.Broker.Core/Helpers/BrokerServiceManifest.cs
@@ -59,8 +59,8 @@ public static class BrokerServiceManifestExtensions
         var manifest = new BrokerServiceManifest
         {
             
-            ExternalServiceCode = (bool)resource.UseManifestFileShim ? resource.ExternalServiceCodeLegacy : null,
-            ExternalServiceEditionCode = (bool)resource.UseManifestFileShim ? resource.ExternalServiceEditionCodeLegacy : null,
+            ExternalServiceCode = resource.UseManifestFileShim == true ? resource.ExternalServiceCodeLegacy : null,
+            ExternalServiceEditionCode = resource.UseManifestFileShim == true ? resource.ExternalServiceEditionCodeLegacy : null,
             SendersReference = entity.SendersFileTransferReference,
             Reportee = entity.RecipientCurrentStatuses.First().Actor.ActorExternalId,
             SentDate = DateTime.UtcNow,

--- a/src/Altinn.Broker.Core/Helpers/BrokerServiceManifest.cs
+++ b/src/Altinn.Broker.Core/Helpers/BrokerServiceManifest.cs
@@ -54,12 +54,12 @@ public class PropertyEntry
 
 public static class BrokerServiceManifestExtensions
 {
-    public static BrokerServiceManifest CreateManifest(this FileTransferEntity entity)
+    public static BrokerServiceManifest CreateManifest(this FileTransferEntity entity, ResourceEntity resource)
     {
         var manifest = new BrokerServiceManifest
         {
-            ExternalServiceCode = entity.ResourceId,
-            ExternalServiceEditionCode = "Altinn3",
+            ExternalServiceCode = resource.ExternalServiceCodeLegacy,
+            ExternalServiceEditionCode = resource.ExternalServiceEditionCodeLegacy,
             SendersReference = entity.SendersFileTransferReference,
             Reportee = entity.RecipientCurrentStatuses.First().Actor.ActorExternalId,
             SentDate = DateTime.UtcNow,

--- a/src/Altinn.Broker.Core/Helpers/BrokerServiceManifest.cs
+++ b/src/Altinn.Broker.Core/Helpers/BrokerServiceManifest.cs
@@ -15,7 +15,7 @@ public class BrokerServiceManifest
     public string ExternalServiceCode { get; set; }
 
     [XmlElement("ExternalServiceEditionCode")]
-    public string ExternalServiceEditionCode { get; set; }
+    public int? ExternalServiceEditionCode { get; set; }
 
     [XmlElement("SendersReference")]
     public string SendersReference { get; set; }

--- a/src/Altinn.Broker.Core/Helpers/IManifestDownloadStream.cs
+++ b/src/Altinn.Broker.Core/Helpers/IManifestDownloadStream.cs
@@ -3,5 +3,5 @@
 namespace Altinn.Broker.Core.Helpers;
 internal interface IManifestDownloadStream
 {
-    Task AddManifestFile(FileTransferEntity fileTransferEntity);
+    Task AddManifestFile(FileTransferEntity fileTransferEntity, ResourceEntity resource);
 }

--- a/src/Altinn.Broker.Core/Helpers/ManifestDownloadStream.cs
+++ b/src/Altinn.Broker.Core/Helpers/ManifestDownloadStream.cs
@@ -196,7 +196,7 @@ public class ManifestDownloadStream : Stream, IManifestDownloadStream
     }
 
 
-    public async Task AddManifestFile(FileTransferEntity fileTransferEntity)
+    public async Task AddManifestFile(FileTransferEntity fileTransferEntity, ResourceEntity resource)
     {
         ValidateNotClosed();
 
@@ -226,7 +226,7 @@ public class ManifestDownloadStream : Stream, IManifestDownloadStream
             var newManifestEntry = archive.CreateEntry("Manifest.xml");
             using (var manifestStream = newManifestEntry.Open())
             {
-                var manifest = fileTransferEntity.CreateManifest();
+                var manifest = fileTransferEntity.CreateManifest(resource);
                 WriteSerializeManifestToZip(manifest, manifestStream);
             }
         }

--- a/src/Altinn.Broker.Core/Repositories/IResourceRepository.cs
+++ b/src/Altinn.Broker.Core/Repositories/IResourceRepository.cs
@@ -10,6 +10,6 @@ public interface IResourceRepository
     Task UpdatePurgeFileTransferAfterAllRecipientsConfirmed(string resourceId, bool PurgeFileTransferAfterAllRecipientsConfirmed, CancellationToken cancellationToken = default);
     Task UpdatePurgeFileTransferGracePeriod(string resourceId, TimeSpan PurgeFileTransferGracePeriod, CancellationToken cancellationToken = default);
     Task UpdateUseManifestFileShim(string resourceId, bool useManifestFileShim, CancellationToken cancellationToken = default);
-    Task UpdateExternalServiceCodeLegacy(string resourceId, string ExternalServiceCodeLegacy, CancellationToken cancellationToken = default);
-    Task UpdateExternalServiceEditionCodeLegacy(string resourceId, string ExternalServiceEditionCodeLegacy, CancellationToken cancellationToken = default);
+    Task UpdateExternalServiceCodeLegacy(string resourceId, string externalServiceCodeLegacy, CancellationToken cancellationToken = default);
+    Task UpdateExternalServiceEditionCodeLegacy(string resourceId, string externalServiceEditionCodeLegacy, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Broker.Core/Repositories/IResourceRepository.cs
+++ b/src/Altinn.Broker.Core/Repositories/IResourceRepository.cs
@@ -10,4 +10,6 @@ public interface IResourceRepository
     Task UpdatePurgeFileTransferAfterAllRecipientsConfirmed(string resourceId, bool PurgeFileTransferAfterAllRecipientsConfirmed, CancellationToken cancellationToken = default);
     Task UpdatePurgeFileTransferGracePeriod(string resourceId, TimeSpan PurgeFileTransferGracePeriod, CancellationToken cancellationToken = default);
     Task UpdateUseManifestFileShim(string resourceId, bool useManifestFileShim, CancellationToken cancellationToken = default);
+    Task UpdateExternalServiceCodeLegacy(string resourceId, string ExternalServiceCodeLegacy, CancellationToken cancellationToken = default);
+    Task UpdateExternalServiceEditionCodeLegacy(string resourceId, string ExternalServiceEditionCodeLegacy, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Broker.Core/Repositories/IResourceRepository.cs
+++ b/src/Altinn.Broker.Core/Repositories/IResourceRepository.cs
@@ -11,5 +11,5 @@ public interface IResourceRepository
     Task UpdatePurgeFileTransferGracePeriod(string resourceId, TimeSpan PurgeFileTransferGracePeriod, CancellationToken cancellationToken = default);
     Task UpdateUseManifestFileShim(string resourceId, bool useManifestFileShim, CancellationToken cancellationToken = default);
     Task UpdateExternalServiceCodeLegacy(string resourceId, string externalServiceCodeLegacy, CancellationToken cancellationToken = default);
-    Task UpdateExternalServiceEditionCodeLegacy(string resourceId, string externalServiceEditionCodeLegacy, CancellationToken cancellationToken = default);
+    Task UpdateExternalServiceEditionCodeLegacy(string resourceId, int? externalServiceEditionCodeLegacy, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Broker.Persistence/Migrations/V0009__add_external_service_code.sql
+++ b/src/Altinn.Broker.Persistence/Migrations/V0009__add_external_service_code.sql
@@ -1,7 +1,7 @@
 ﻿ALTER TABLE broker.altinn_resource 
-ADD external_service_code_legacy varchar NULL;
+ADD external_service_code_legacy varchar(7);
 COMMENT ON COLUMN broker.altinn_resource.external_service_code_legacy IS 'Part of legacy solution';
 
 ALTER TABLE broker.altinn_resource 
-ADD external_service_edition_code_legacy varchar NULL;
+ADD external_service_edition_code_legacy int;
 COMMENT ON COLUMN broker.altinn_resource.external_service_edition_code_legacy IS 'Part of legacy solution';

--- a/src/Altinn.Broker.Persistence/Migrations/V0009__add_external_service_code.sql
+++ b/src/Altinn.Broker.Persistence/Migrations/V0009__add_external_service_code.sql
@@ -1,0 +1,7 @@
+﻿ALTER TABLE broker.altinn_resource 
+ADD external_service_code_legacy varchar NULL;
+COMMENT ON COLUMN broker.altinn_resource.external_service_code_legacy IS 'Part of legacy solution';
+
+ALTER TABLE broker.altinn_resource 
+ADD external_service_edition_code_legacy varchar NULL;
+COMMENT ON COLUMN broker.altinn_resource.external_service_edition_code_legacy IS 'Part of legacy solution';

--- a/src/Altinn.Broker.Persistence/Repositories/ResourceRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/ResourceRepository.cs
@@ -31,7 +31,7 @@ public class ResourceRepository(NpgsqlDataSource dataSource, IAltinnResourceRepo
                 PurgeFileTransferGracePeriod = reader.IsDBNull(reader.GetOrdinal("purge_file_transfer_grace_period")) ? null : reader.GetTimeSpan(reader.GetOrdinal("purge_file_transfer_grace_period")),
                 UseManifestFileShim = reader.IsDBNull(reader.GetOrdinal("use_manifest_file_shim")) ? null : reader.GetBoolean(reader.GetOrdinal("use_manifest_file_shim")),
                 ExternalServiceCodeLegacy = reader.IsDBNull(reader.GetOrdinal("external_service_code_legacy")) ? null : reader.GetString(reader.GetOrdinal("external_service_code_legacy")),
-                ExternalServiceEditionCodeLegacy = reader.IsDBNull(reader.GetOrdinal("external_service_edition_code_legacy")) ? null : reader.GetString(reader.GetOrdinal("external_service_edition_code_legacy"))
+                ExternalServiceEditionCodeLegacy = reader.IsDBNull(reader.GetOrdinal("external_service_edition_code_legacy")) ? null : reader.GetInt32(reader.GetOrdinal("external_service_edition_code_legacy"))
             };
         }
         if (resource is null)
@@ -119,7 +119,7 @@ public class ResourceRepository(NpgsqlDataSource dataSource, IAltinnResourceRepo
         command.Parameters.AddWithValue("@externalServiceCodeLegacy", externalServiceCodeLegacy);
         command.ExecuteNonQuery();
     }
-    public async Task UpdateExternalServiceEditionCodeLegacy(string resourceId, string externalServiceEditionCodeLegacy, CancellationToken cancellationToken = default)
+    public async Task UpdateExternalServiceEditionCodeLegacy(string resourceId, int externalServiceEditionCodeLegacy, CancellationToken cancellationToken = default)
     {
         await using var command = dataSource.CreateCommand(
             "UPDATE broker.altinn_resource " +

--- a/src/Altinn.Broker.Persistence/Repositories/ResourceRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/ResourceRepository.cs
@@ -119,7 +119,7 @@ public class ResourceRepository(NpgsqlDataSource dataSource, IAltinnResourceRepo
         command.Parameters.AddWithValue("@externalServiceCodeLegacy", externalServiceCodeLegacy);
         command.ExecuteNonQuery();
     }
-    public async Task UpdateExternalServiceEditionCodeLegacy(string resourceId, int externalServiceEditionCodeLegacy, CancellationToken cancellationToken = default)
+    public async Task UpdateExternalServiceEditionCodeLegacy(string resourceId, int? externalServiceEditionCodeLegacy, CancellationToken cancellationToken = default)
     {
         await using var command = dataSource.CreateCommand(
             "UPDATE broker.altinn_resource " +

--- a/src/Altinn.Broker.Persistence/Repositories/ResourceRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/ResourceRepository.cs
@@ -126,7 +126,7 @@ public class ResourceRepository(NpgsqlDataSource dataSource, IAltinnResourceRepo
             "SET external_service_edition_code_legacy = @externalServiceEditionCodeLegacy " +
             "WHERE resource_id_pk = @resourceId");
         command.Parameters.AddWithValue("@resourceId", resourceId);
-        command.Parameters.AddWithValue("@externalServiceEditionCodeLegacy", externalServiceEditionCodeLegacy);
+                command.Parameters.AddWithValue("@externalServiceEditionCodeLegacy", (object?)externalServiceEditionCodeLegacy ?? DBNull.Value); 
         command.ExecuteNonQuery();
     }
 }

--- a/tests/Altinn.Broker.Tests/ManifestDownloadStreamTests.cs
+++ b/tests/Altinn.Broker.Tests/ManifestDownloadStreamTests.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Broker.Core.Helpers;
+﻿using Altinn.Broker.Core.Domain;
+using Altinn.Broker.Core.Helpers;
 using Altinn.Broker.Tests.Factories;
 using Altinn.Broker.Tests.Helpers;
 
@@ -11,10 +12,18 @@ public class ManifestDownloadStreamTests
     [Fact]
     public async Task StreamWithoutManifest_AddManifest_ManifestIsAddedAsync()
     {
+        var resource = new ResourceEntity
+        {
+            Id = "manifest-shim-resource",
+            ServiceOwnerId = "someServiceOwnerId",
+            UseManifestFileShim = true,
+            ExternalServiceCodeLegacy = "someExternalServiceCode",
+            ExternalServiceEditionCodeLegacy = "someExternalServiceEditionCode"
+        };
         var stream = ReadFile("Data/ManifestFileTests/Payload.zip");
         var originalFileLength = stream.Length;
         var file = FileTransferEntityFactory.BasicFileTransfer();
-        await stream.AddManifestFile(file);
+        await stream.AddManifestFile(file, resource);
         Assert.True(stream.Length > originalFileLength);
         var brokerManifest = stream.GetBrokerManifest();
         Assert.Equal(brokerManifest.Reportee, file.RecipientCurrentStatuses.First().Actor.ActorExternalId);
@@ -24,11 +33,19 @@ public class ManifestDownloadStreamTests
     [Fact]
     public async Task StreamWithManifest_AddManifest_ExistingManifestIsReplacedAsync()
     {
+        var resource = new ResourceEntity
+        {
+            Id = "manifest-shim-resource",
+            ServiceOwnerId = "someServiceOwnerId",
+            UseManifestFileShim = true,
+            ExternalServiceCodeLegacy = "someExternalServiceCode",
+            ExternalServiceEditionCodeLegacy = "someExternalServiceEditionCode"
+        };
         var stream = ReadFile("Data/ManifestFileTests/PayloadWithExistingManifest.zip");
         var originalBrokerManifest = stream.GetBrokerManifest();
         var originalFileLength = stream.Length;
         var file = FileTransferEntityFactory.BasicFileTransfer();
-        await stream.AddManifestFile(file);
+        await stream.AddManifestFile(file, resource);
         var newBrokerManifest = stream.GetBrokerManifest();
         Assert.NotEqual(stream.Length, originalFileLength);
         Assert.NotEqual(originalBrokerManifest.Reportee, newBrokerManifest.Reportee);
@@ -41,9 +58,17 @@ public class ManifestDownloadStreamTests
     [Fact]
     public async Task StreamThatIsNotZip_AddManifest_FailsAsync()
     {
+        var resource = new ResourceEntity
+        {
+            Id = "manifest-shim-resource",
+            ServiceOwnerId = "someServiceOwnerId",
+            UseManifestFileShim = true,
+            ExternalServiceCodeLegacy = "someExternalServiceCode",
+            ExternalServiceEditionCodeLegacy = "someExternalServiceEditionCode"
+        };
         var stream = ReadFile("Data/ManifestFileTests/payload.txt");    
         var file = FileTransferEntityFactory.BasicFileTransfer();
-        await Assert.ThrowsAsync<InvalidOperationException>(() => stream.AddManifestFile(file));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => stream.AddManifestFile(file, resource));
     }
 
     private ManifestDownloadStream ReadFile(string path)

--- a/tests/Altinn.Broker.Tests/ManifestDownloadStreamTests.cs
+++ b/tests/Altinn.Broker.Tests/ManifestDownloadStreamTests.cs
@@ -18,7 +18,7 @@ public class ManifestDownloadStreamTests
             ServiceOwnerId = "someServiceOwnerId",
             UseManifestFileShim = true,
             ExternalServiceCodeLegacy = "someExternalServiceCode",
-            ExternalServiceEditionCodeLegacy = "someExternalServiceEditionCode"
+            ExternalServiceEditionCodeLegacy = 123
         };
         var stream = ReadFile("Data/ManifestFileTests/Payload.zip");
         var originalFileLength = stream.Length;
@@ -39,7 +39,7 @@ public class ManifestDownloadStreamTests
             ServiceOwnerId = "someServiceOwnerId",
             UseManifestFileShim = true,
             ExternalServiceCodeLegacy = "someExternalServiceCode",
-            ExternalServiceEditionCodeLegacy = "someExternalServiceEditionCode"
+            ExternalServiceEditionCodeLegacy = 123
         };
         var stream = ReadFile("Data/ManifestFileTests/PayloadWithExistingManifest.zip");
         var originalBrokerManifest = stream.GetBrokerManifest();
@@ -64,7 +64,7 @@ public class ManifestDownloadStreamTests
             ServiceOwnerId = "someServiceOwnerId",
             UseManifestFileShim = true,
             ExternalServiceCodeLegacy = "someExternalServiceCode",
-            ExternalServiceEditionCodeLegacy = "someExternalServiceEditionCode"
+            ExternalServiceEditionCodeLegacy = 123
         };
         var stream = ReadFile("Data/ManifestFileTests/payload.txt");    
         var file = FileTransferEntityFactory.BasicFileTransfer();


### PR DESCRIPTION
## Description
Added fields ExternalServiceCodeLegacy and ExternalServiceEditionCodeLegacy to the update resource API. The set values will be used in manifest file.

## Related Issue(s)
- #573 
## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for legacy external service codes in resource configuration.
  - Enhanced manifest file handling during downloads with new parameters.
  - Introduced validation for legacy service codes based on the manifest file shim setting.
  - Updated API requests to include new fields for legacy service codes.

- **Bug Fixes**
  - Improved error handling in tests related to manifest file operations.

- **Documentation**
  - Updated API request structures and variable descriptions for clarity.

- **Tests**
  - Expanded test coverage for manifest file handling to include legacy service code management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->