### PR TITLE
Make Authorization service more testable by passing ClaimsPrincipal as argument

### DIFF
--- a/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
+++ b/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
@@ -45,7 +45,7 @@ public class LegacyFileController(ILogger<LegacyFileController> logger) : Contro
         LogContextHelpers.EnrichLogsWithToken(legacyToken);
         logger.LogInformation("Legacy - Initializing file");
         var commandRequest = LegacyInitializeFileMapper.MapToRequest(initializeExt, token);
-        var commandResult = await handler.Process(commandRequest, cancellationToken);
+        var commandResult = await handler.Process(commandRequest, HttpContext.User, cancellationToken);
         return commandResult.Match(
             fileId => Ok(fileId.ToString()),
             Problem
@@ -78,7 +78,7 @@ public class LegacyFileController(ILogger<LegacyFileController> logger) : Contro
             Token = legacyToken,
             UploadStream = Request.Body,
             IsLegacy = true
-        }, cancellationToken);
+        }, HttpContext.User, cancellationToken);
         return commandResult.Match(
             fileId => Ok(fileId.ToString()),
             Problem
@@ -107,7 +107,7 @@ public class LegacyFileController(ILogger<LegacyFileController> logger) : Contro
             FileTransferId = fileId,
             Token = legacyToken,
             IsLegacy = true
-        }, cancellationToken);
+        }, HttpContext.User, cancellationToken);
         return queryResult.Match(
             result => Ok(LegacyFileStatusOverviewExtMapper.MapToExternalModel(result.FileTransfer)),
             Problem
@@ -160,7 +160,7 @@ public class LegacyFileController(ILogger<LegacyFileController> logger) : Contro
             From = from,
             To = to,
             Recipients = recipients
-        }, cancellationToken);
+        }, HttpContext.User, cancellationToken);
         return queryResult.Match(
             Ok,
             Problem
@@ -188,7 +188,7 @@ public class LegacyFileController(ILogger<LegacyFileController> logger) : Contro
             FileTransferId = fileId,
             Token = legacyToken,
             IsLegacy = true
-        }, cancellationToken);
+        }, HttpContext.User, cancellationToken);
         return queryResult.Match<ActionResult>(
             result => File(result.DownloadStream, "application/octet-stream", result.FileName),
             Problem
@@ -216,7 +216,7 @@ public class LegacyFileController(ILogger<LegacyFileController> logger) : Contro
             FileTransferId = fileId,
             Token = legacyToken,
             IsLegacy = true
-        }, cancellationToken);
+        }, HttpContext.User, cancellationToken);
         return commandResult.Match(
             Ok,
             Problem

--- a/src/Altinn.Broker.API/Controllers/MalwareScanResultsController.cs
+++ b/src/Altinn.Broker.API/Controllers/MalwareScanResultsController.cs
@@ -48,7 +48,7 @@ public class MalwareScanResultsController(IIdempotencyEventRepository idempotenc
                 {
                     throw new InvalidOperationException("Failed to deserialize malware scan result data");
                 }
-                var processFunction = new Func<Task<OneOf<Task, Error>>>(() => handler.Process(result, cancellationToken));
+                var processFunction = new Func<Task<OneOf<Task, Error>>>(() => handler.Process(result, null, cancellationToken));
                 var commandResult = await IdempotencyEventHelper.ProcessEvent(result.ETag, processFunction, idempotencyEventRepository, cancellationToken);
                 return commandResult.Match(
                     Ok,

--- a/src/Altinn.Broker.API/Controllers/ResourceController.cs
+++ b/src/Altinn.Broker.API/Controllers/ResourceController.cs
@@ -32,7 +32,7 @@ public class ResourceController : Controller
             UseManifestFileShim = resourceExt.UseManifestFileShim,
             ExternalServiceCodeLegacy = resourceExt.ExternalServiceCodeLegacy,
             ExternalServiceEditionCodeLegacy = resourceExt.ExternalServiceEditionCodeLegacy
-        }, cancellationToken);
+        }, HttpContext.User, cancellationToken);
 
         return result.Match(
             (_) => Ok(null),

--- a/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
+++ b/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml;
+﻿using System.Security.Claims;
+using System.Xml;
 
 using Altinn.Broker.Application.Settings;
 using Altinn.Broker.Core.Application;
@@ -14,7 +15,7 @@ using OneOf;
 namespace Altinn.Broker.Application.ConfigureResource;
 public class ConfigureResourceHandler(IResourceRepository resourceRepository, IHostEnvironment hostEnvironment, ILogger<ConfigureResourceHandler> logger) : IHandler<ConfigureResourceRequest, Task>
 {
-    public async Task<OneOf<Task, Error>> Process(ConfigureResourceRequest request, CancellationToken cancellationToken)
+    public async Task<OneOf<Task, Error>> Process(ConfigureResourceRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
         logger.LogInformation("Processing request to configure resource {ResourceId}", request.ResourceId.SanitizeForLogs());
         var resource = await resourceRepository.GetResource(request.ResourceId, cancellationToken);

--- a/src/Altinn.Broker.Application/ConfirmDownload/ConfirmDownloadHandler.cs
+++ b/src/Altinn.Broker.Application/ConfirmDownload/ConfirmDownloadHandler.cs
@@ -80,7 +80,7 @@ public class ConfirmDownloadHandler(
                     {
                         FileTransferId = request.FileTransferId,
                         Force = true
-                    }, user, cancellationToken));
+                    }, null, cancellationToken));
                 }
                 else
                 {

--- a/src/Altinn.Broker.Application/ExpireFileTransfer/ExpireFileTransferHandler.cs
+++ b/src/Altinn.Broker.Application/ExpireFileTransfer/ExpireFileTransferHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Transactions;
+﻿using System.Security.Claims;
+using System.Transactions;
 
 using Altinn.Broker.Application.Settings;
 using Altinn.Broker.Core.Application;
@@ -21,7 +22,7 @@ namespace Altinn.Broker.Application.ExpireFileTransfer;
 public class ExpireFileTransferHandler(IFileTransferRepository fileTransferRepository, IFileTransferStatusRepository fileTransferStatusRepository, IServiceOwnerRepository serviceOwnerRepository, IBrokerStorageService brokerStorageService, IResourceRepository resourceRepository, IEventBus eventBus, ILogger<ExpireFileTransferHandler> logger) : IHandler<ExpireFileTransferRequest, Task>
 {
     [AutomaticRetry(Attempts = 0)]
-    public async Task<OneOf<Task, Error>> Process(ExpireFileTransferRequest request, CancellationToken cancellationToken)
+    public async Task<OneOf<Task, Error>> Process(ExpireFileTransferRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
         logger.LogInformation("Deleting file transfer with id {fileTransferId}", request.FileTransferId.ToString());
         var fileTransfer = await GetFileTransferAsync(request.FileTransferId, cancellationToken);

--- a/src/Altinn.Broker.Application/GetFileTransfers/GetFileTransfersHandler.cs
+++ b/src/Altinn.Broker.Application/GetFileTransfers/GetFileTransfersHandler.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+
 using Altinn.Broker.Core.Application;
 using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Domain.Enums;
@@ -12,10 +14,10 @@ namespace Altinn.Broker.Application.GetFileTransfers;
 
 public class GetFileTransfersHandler(IAuthorizationService resourceRightsRepository, IResourceRepository resourceRepository, IFileTransferRepository fileTransferRepository, IActorRepository actorRepository, ILogger<GetFileTransfersHandler> logger) : IHandler<GetFileTransfersRequest, List<Guid>>
 {
-    public async Task<OneOf<List<Guid>, Error>> Process(GetFileTransfersRequest request, CancellationToken cancellationToken)
+    public async Task<OneOf<List<Guid>, Error>> Process(GetFileTransfersRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
         logger.LogInformation("Getting file transfers for {resourceId}", request.ResourceId.SanitizeForLogs());
-        var hasAccess = await resourceRightsRepository.CheckUserAccess(request.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write, ResourceAccessLevel.Read }, cancellationToken: cancellationToken);
+        var hasAccess = await resourceRightsRepository.CheckUserAccess(user, request.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write, ResourceAccessLevel.Read }, cancellationToken: cancellationToken);
         if (!hasAccess)
         {
             return Errors.NoAccessToResource;

--- a/src/Altinn.Broker.Application/GetFileTransfers/LegacyGetFilesHandler.cs
+++ b/src/Altinn.Broker.Application/GetFileTransfers/LegacyGetFilesHandler.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+
 using Altinn.Broker.Core.Application;
 using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Helpers;
@@ -26,7 +28,7 @@ public class LegacyGetFilesHandler(IFileTransferRepository fileTransferRepositor
         return actors;
     }
 
-    public async Task<OneOf<List<Guid>, Error>> Process(LegacyGetFilesRequest request, CancellationToken cancellationToken)
+    public async Task<OneOf<List<Guid>, Error>> Process(LegacyGetFilesRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
         logger.LogInformation("Legacy get files for {resourceId}", request.ResourceId is null ? "all resources" : request.ResourceId.SanitizeForLogs());
         LegacyFileSearchEntity fileSearch = new()

--- a/src/Altinn.Broker.Application/IHandler.cs
+++ b/src/Altinn.Broker.Application/IHandler.cs
@@ -1,10 +1,12 @@
-﻿using Altinn.Broker.Application;
+﻿using System.Security.Claims;
+
+using Altinn.Broker.Application;
 
 using OneOf;
 
 namespace Altinn.Broker.Core.Application;
 internal interface IHandler<TRequest, TResponse>
 {
-    Task<OneOf<TResponse, Error>> Process(TRequest request, CancellationToken cancellationToken);
+    Task<OneOf<TResponse, Error>> Process(TRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken);
 }
 

--- a/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
+++ b/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
@@ -1,4 +1,5 @@
 
+using System.Security.Claims;
 using System.Text.Json;
 
 using Altinn.Broker.Application.ExpireFileTransfer;
@@ -23,7 +24,7 @@ public class MalwareScanningResultHandler(
     ILogger<MalwareScanningResultHandler> logger,
     IBackgroundJobClient backgroundJobClient) : IHandler<ScanResultData, Task>
 {
-    public async Task<OneOf<Task, Error>> Process(ScanResultData data, CancellationToken cancellationToken)
+    public async Task<OneOf<Task, Error>> Process(ScanResultData data, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
         string fileTransferIdFromUri = data.BlobUri.Split("/").Last() ?? Guid.Empty.ToString();
         Guid fileTransferId;
@@ -60,7 +61,7 @@ public class MalwareScanningResultHandler(
                     FileTransferId = fileTransfer.FileTransferId,
                     Force = true,
                     DoNotUpdateStatus = true
-                }, CancellationToken.None));
+                }, user, CancellationToken.None));
             }
             return Task.CompletedTask;
         }, logger, cancellationToken);

--- a/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
+++ b/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
@@ -61,7 +61,7 @@ public class MalwareScanningResultHandler(
                     FileTransferId = fileTransfer.FileTransferId,
                     Force = true,
                     DoNotUpdateStatus = true
-                }, user, CancellationToken.None));
+                }, null, CancellationToken.None));
             }
             return Task.CompletedTask;
         }, logger, cancellationToken);

--- a/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+
 using Altinn.Broker.Application.Settings;
 using Altinn.Broker.Core.Application;
 using Altinn.Broker.Core.Domain.Enums;
@@ -27,7 +29,7 @@ public class UploadFileHandler(
     IHostEnvironment hostEnvironment,
     ILogger<UploadFileHandler> logger) : IHandler<UploadFileRequest, Guid>
 {
-    public async Task<OneOf<Guid, Error>> Process(UploadFileRequest request, CancellationToken cancellationToken)
+    public async Task<OneOf<Guid, Error>> Process(UploadFileRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
         logger.LogInformation("Uploading file for file transfer {fileTransferId}", request.FileTransferId);
         var fileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
@@ -35,7 +37,7 @@ public class UploadFileHandler(
         {
             return Errors.FileTransferNotFound;
         }
-        var hasAccess = await resourceRightsRepository.CheckUserAccess(fileTransfer.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write }, request.IsLegacy, cancellationToken);
+        var hasAccess = await resourceRightsRepository.CheckUserAccess(user, fileTransfer.ResourceId, new List<ResourceAccessLevel> { ResourceAccessLevel.Write }, request.IsLegacy, cancellationToken);
         if (!hasAccess)
         {
             return Errors.FileTransferNotFound;

--- a/src/Altinn.Broker.Core/Repositories/IAuthorizationService.cs
+++ b/src/Altinn.Broker.Core/Repositories/IAuthorizationService.cs
@@ -1,7 +1,9 @@
-﻿using Altinn.Broker.Core.Domain.Enums;
+﻿using System.Security.Claims;
+
+using Altinn.Broker.Core.Domain.Enums;
 
 namespace Altinn.Broker.Core.Repositories;
 public interface IAuthorizationService
 {
-    Task<bool> CheckUserAccess(string resourceId, List<ResourceAccessLevel> rights, bool IsLegacyUser = false, CancellationToken cancellationToken = default);
+    Task<bool> CheckUserAccess(ClaimsPrincipal? user, string resourceId, List<ResourceAccessLevel> rights, bool IsLegacyUser = false, CancellationToken cancellationToken = default);
 }

--- a/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -1,5 +1,6 @@
 using System.Data.Common;
 using System.Net.Http.Headers;
+using System.Security.Claims;
 using System.Threading;
 
 using Altinn.Broker.API.Configuration;
@@ -99,8 +100,8 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
             services.AddSingleton(altinnResourceRepository.Object);
 
             var authorizationService = new Mock<IAuthorizationService>();
-            authorizationService.Setup(x => x.CheckUserAccess(It.IsAny<string>(), It.IsAny<List<ResourceAccessLevel>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
-            authorizationService.Setup(x => x.CheckUserAccess(TestConstants.RESOURCE_WITH_NO_ACCESS, It.IsAny<List<ResourceAccessLevel>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+            authorizationService.Setup(x => x.CheckUserAccess(It.IsAny<ClaimsPrincipal?>(), It.IsAny<string>(), It.IsAny<List<ResourceAccessLevel>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            authorizationService.Setup(x => x.CheckUserAccess(It.IsAny<ClaimsPrincipal?>(), TestConstants.RESOURCE_WITH_NO_ACCESS, It.IsAny<List<ResourceAccessLevel>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
             services.AddSingleton(authorizationService.Object);
 
             var eventBus = new Mock<IEventBus>();


### PR DESCRIPTION
## Description
Pass ClaimsPrincipal as argument instead of HttpContextAccessor to make code cleaner and easier to test

## Related Issue(s)
- [#433](https://github.com/Altinn/altinn-correspondence/issues/433)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user context handling in file transfer and resource management operations.
	- Improved access control by incorporating user claims into various processing methods.

- **Bug Fixes**
	- Adjusted error handling to ensure proper logging and responses based on user context during file operations.

- **Documentation**
	- Updated method signatures across multiple classes to reflect the inclusion of user context.

- **Refactor**
	- Streamlined dependency management in authorization services by removing unnecessary HTTP context dependencies.

- **Tests**
	- Updated test setups to accommodate changes in method signatures for user access checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->