### PR TITLE
Updated Broker Legacy Manifest to use "Created" as source for "SentDate"

### DIFF
--- a/src/Altinn.Broker.Core/Helpers/BrokerServiceManifest.cs
+++ b/src/Altinn.Broker.Core/Helpers/BrokerServiceManifest.cs
@@ -63,7 +63,7 @@ public static class BrokerServiceManifestExtensions
             ExternalServiceEditionCode = resource.UseManifestFileShim == true ? resource.ExternalServiceEditionCodeLegacy : null,
             SendersReference = entity.SendersFileTransferReference,
             Reportee = entity.RecipientCurrentStatuses.First().Actor.ActorExternalId,
-            SentDate = DateTime.UtcNow,
+            SentDate = entity.Created.ToLocalTime().DateTime,
             FileList = new List<FileEntry>
                 {
                     new FileEntry { FileName = entity.FileName }

--- a/tests/Altinn.Broker.Tests/ManifestDownloadStreamTests.cs
+++ b/tests/Altinn.Broker.Tests/ManifestDownloadStreamTests.cs
@@ -59,27 +59,6 @@ public class ManifestDownloadStreamTests
         Assert.Equal(newBrokerManifest.SentDate, expectedSentDate);
     }
 
-
-    [Fact]
-    public async Task jallaTest()
-    {
-        DateTimeOffset orgDateTimeOffset = DateTimeOffset.Now;
-        DateTime orgDateTime = DateTime.Now;
-
-        DateTime conv1 = orgDateTimeOffset.LocalDateTime;
-        DateTime conv2 = orgDateTimeOffset.DateTime;
-        DateTime conv3 = (orgDateTimeOffset.ToLocalTime()).DateTime;
-
-        string s = "orgOffset: " + orgDateTimeOffset.ToString() + Environment.NewLine
-            + "orgDateTime: " + orgDateTime.ToString() + Environment.NewLine
-            + "conv1: " + conv1.ToString() + Environment.NewLine
-            + "conv2: " + conv2.ToString() + Environment.NewLine
-            + "conv2: " + conv3.ToString() + Environment.NewLine;
-
-        Assert.NotEmpty(s);
-    }
-
-
     [Fact]
     public async Task StreamThatIsNotZip_AddManifest_FailsAsync()
     {

--- a/tests/Altinn.Broker.Tests/ManifestDownloadStreamTests.cs
+++ b/tests/Altinn.Broker.Tests/ManifestDownloadStreamTests.cs
@@ -23,11 +23,13 @@ public class ManifestDownloadStreamTests
         var stream = ReadFile("Data/ManifestFileTests/Payload.zip");
         var originalFileLength = stream.Length;
         var file = FileTransferEntityFactory.BasicFileTransfer();
+        DateTime expectedSentDate = file.Created.ToLocalTime().DateTime;
         await stream.AddManifestFile(file, resource);
         Assert.True(stream.Length > originalFileLength);
         var brokerManifest = stream.GetBrokerManifest();
         Assert.Equal(brokerManifest.Reportee, file.RecipientCurrentStatuses.First().Actor.ActorExternalId);
         Assert.Equal(brokerManifest.SendersReference, file.SendersFileTransferReference);
+        Assert.Equal(brokerManifest.SentDate, expectedSentDate);
     }
 
     [Fact]
@@ -45,6 +47,7 @@ public class ManifestDownloadStreamTests
         var originalBrokerManifest = stream.GetBrokerManifest();
         var originalFileLength = stream.Length;
         var file = FileTransferEntityFactory.BasicFileTransfer();
+        DateTime expectedSentDate = file.Created.ToLocalTime().DateTime;
         await stream.AddManifestFile(file, resource);
         var newBrokerManifest = stream.GetBrokerManifest();
         Assert.NotEqual(stream.Length, originalFileLength);
@@ -53,7 +56,29 @@ public class ManifestDownloadStreamTests
         Assert.NotEqual(originalBrokerManifest.SentDate, newBrokerManifest.SentDate);
         Assert.Equal(newBrokerManifest.Reportee, file.RecipientCurrentStatuses.First().Actor.ActorExternalId);
         Assert.Equal(newBrokerManifest.SendersReference, file.SendersFileTransferReference);
+        Assert.Equal(newBrokerManifest.SentDate, expectedSentDate);
     }
+
+
+    [Fact]
+    public async Task jallaTest()
+    {
+        DateTimeOffset orgDateTimeOffset = DateTimeOffset.Now;
+        DateTime orgDateTime = DateTime.Now;
+
+        DateTime conv1 = orgDateTimeOffset.LocalDateTime;
+        DateTime conv2 = orgDateTimeOffset.DateTime;
+        DateTime conv3 = (orgDateTimeOffset.ToLocalTime()).DateTime;
+
+        string s = "orgOffset: " + orgDateTimeOffset.ToString() + Environment.NewLine
+            + "orgDateTime: " + orgDateTime.ToString() + Environment.NewLine
+            + "conv1: " + conv1.ToString() + Environment.NewLine
+            + "conv2: " + conv2.ToString() + Environment.NewLine
+            + "conv2: " + conv3.ToString() + Environment.NewLine;
+
+        Assert.NotEmpty(s);
+    }
+
 
     [Fact]
     public async Task StreamThatIsNotZip_AddManifest_FailsAsync()


### PR DESCRIPTION
## Description
Updated Broker Legacy Manifest to use "Created" as source for "SentDate" and ensured this was correctly converted to a local DateTime without timezone info.

## Related Issue(s)
- #595 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the way `SentDate` is recorded, now reflecting the local time based on the entity's creation time.

- **Bug Fixes**
	- Enhanced tests to verify that the `SentDate` in the broker manifest matches the expected local date and time.

- **Tests**
	- Added assertions in existing test methods to ensure proper handling of date conversions and validate the accuracy of `SentDate`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->