### PR TITLE
Legacy file uploads also need content length

### DIFF
--- a/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
+++ b/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
@@ -77,6 +77,7 @@ public class LegacyFileController(ILogger<LegacyFileController> logger) : Contro
             FileTransferId = fileTransferId,
             Token = legacyToken,
             UploadStream = Request.Body,
+            ContentLength = Request.Body.Length,
             IsLegacy = true
         }, HttpContext.User, cancellationToken);
         return commandResult.Match(


### PR DESCRIPTION
## Description
Legacy file uploads also need content length. Can use Body.Length here because the body is buffered.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
