### PR TITLE
Use ReadExactly to get all the bytes for the buffer. 

### DIFF
--- a/src/Altinn.Broker.Application/DownloadFile/DownloadFileHandler.cs
+++ b/src/Altinn.Broker.Application/DownloadFile/DownloadFileHandler.cs
@@ -51,7 +51,7 @@ public class DownloadFileHandler(IResourceRepository resourceRepository, IServic
         if (resource.UseManifestFileShim == true && request.IsLegacy) // For specific legacy resources during transition period
         {
             var fileBuffer = new byte[fileTransfer.FileTransferSize];
-            downloadStream.Read(fileBuffer, 0, fileBuffer.Length);
+            downloadStream.ReadExactly(fileBuffer, 0, fileBuffer.Length);
             downloadStream = new ManifestDownloadStream(fileBuffer);
             (downloadStream as ManifestDownloadStream)?.AddManifestFile(fileTransfer, resource);
         }


### PR DESCRIPTION
## Description
Use ReadExactly to get all the bytes for the buffer. Just .Read() may not read all the bytes.

## Related Issue(s)
- #600 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved error handling for file download requests, ensuring better validation of file transfer status.
	- Enhanced access control checks for user permissions related to file downloads.

- **Bug Fixes**
	- Updated file reading logic to ensure complete data retrieval from streams, improving download reliability.

- **Chores**
	- Adjustments made to logging for better tracking of file transfer processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->