### PR TITLE
Corrected BrokerManifest.Reportee value

### DIFF
--- a/src/Altinn.Broker.Core/Helpers/BrokerServiceManifest.cs
+++ b/src/Altinn.Broker.Core/Helpers/BrokerServiceManifest.cs
@@ -62,7 +62,7 @@ public static class BrokerServiceManifestExtensions
             ExternalServiceCode = resource.UseManifestFileShim == true ? resource.ExternalServiceCodeLegacy : null,
             ExternalServiceEditionCode = resource.UseManifestFileShim == true ? resource.ExternalServiceEditionCodeLegacy : null,
             SendersReference = entity.SendersFileTransferReference,
-            Reportee = entity.RecipientCurrentStatuses.First().Actor.ActorExternalId,
+            Reportee = entity.Sender.ActorExternalId.Split(':', StringSplitOptions.None)[1],
             SentDate = DateTime.UtcNow,
             FileList = new List<FileEntry>
                 {

--- a/tests/Altinn.Broker.Tests/LegacyFileControllerTests.cs
+++ b/tests/Altinn.Broker.Tests/LegacyFileControllerTests.cs
@@ -471,7 +471,7 @@ public class LegacyFileControllerTests : IClassFixture<CustomWebApplicationFacto
 
         // Assert
         Assert.NotNull(addedManifest);
-        Assert.Equal(addedManifest.Reportee, file.Recipients[0]);
+        Assert.Equal("991825827", addedManifest.Reportee);
         Assert.Equal(addedManifest.SendersReference, file.SendersFileTransferReference);
         Assert.True(addedManifest.PropertyList.All(property => file.PropertyList[property.PropertyKey] == property.PropertyValue));
     }

--- a/tests/Altinn.Broker.Tests/ManifestDownloadStreamTests.cs
+++ b/tests/Altinn.Broker.Tests/ManifestDownloadStreamTests.cs
@@ -26,7 +26,7 @@ public class ManifestDownloadStreamTests
         await stream.AddManifestFile(file, resource);
         Assert.True(stream.Length > originalFileLength);
         var brokerManifest = stream.GetBrokerManifest();
-        Assert.Equal(brokerManifest.Reportee, file.RecipientCurrentStatuses.First().Actor.ActorExternalId);
+        Assert.Equal(brokerManifest.Reportee, "991825827");
         Assert.Equal(brokerManifest.SendersReference, file.SendersFileTransferReference);
     }
 
@@ -51,7 +51,7 @@ public class ManifestDownloadStreamTests
         Assert.NotEqual(originalBrokerManifest.Reportee, newBrokerManifest.Reportee);
         Assert.NotEqual(originalBrokerManifest.SendersReference, newBrokerManifest.SendersReference);
         Assert.NotEqual(originalBrokerManifest.SentDate, newBrokerManifest.SentDate);
-        Assert.Equal(newBrokerManifest.Reportee, file.RecipientCurrentStatuses.First().Actor.ActorExternalId);
+        Assert.Equal(newBrokerManifest.Reportee, "991825827");
         Assert.Equal(newBrokerManifest.SendersReference, file.SendersFileTransferReference);
     }
 

--- a/tests/Altinn.Broker.Tests/ManifestDownloadStreamTests.cs
+++ b/tests/Altinn.Broker.Tests/ManifestDownloadStreamTests.cs
@@ -26,7 +26,8 @@ public class ManifestDownloadStreamTests
         await stream.AddManifestFile(file, resource);
         Assert.True(stream.Length > originalFileLength);
         var brokerManifest = stream.GetBrokerManifest();
-        Assert.Equal(brokerManifest.Reportee, "991825827");
+        Assert.NotNull(brokerManifest);
+        Assert.Equal("991825827", brokerManifest.Reportee);
         Assert.Equal(brokerManifest.SendersReference, file.SendersFileTransferReference);
     }
 
@@ -50,8 +51,8 @@ public class ManifestDownloadStreamTests
         Assert.NotEqual(stream.Length, originalFileLength);
         Assert.NotEqual(originalBrokerManifest.Reportee, newBrokerManifest.Reportee);
         Assert.NotEqual(originalBrokerManifest.SendersReference, newBrokerManifest.SendersReference);
-        Assert.NotEqual(originalBrokerManifest.SentDate, newBrokerManifest.SentDate);
-        Assert.Equal(newBrokerManifest.Reportee, "991825827");
+        Assert.NotEqual(originalBrokerManifest.SentDate, newBrokerManifest.SentDate);        
+        Assert.Equal("991825827", newBrokerManifest.Reportee);
         Assert.Equal(newBrokerManifest.SendersReference, file.SendersFileTransferReference);
     }
 


### PR DESCRIPTION
## Description
Corrected BrokerManifest.Reportee to be the Sender Orgumber as expeced by Altinn 2 consumers.

## Related Issue(s)
- #603 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the logic for determining the `Reportee` property in the manifest, now based on the sender's external ID.

- **Tests**
	- Updated assertions in test methods to reflect the new `Reportee` logic with a hardcoded value, ensuring consistency in test outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->