### PR TITLE
Made Accept header in requests optional

### DIFF
--- a/src/Altinn.Broker.API/Helpers/AcceptHeaderValidationMiddleware.cs
+++ b/src/Altinn.Broker.API/Helpers/AcceptHeaderValidationMiddleware.cs
@@ -21,16 +21,11 @@ public class AcceptHeaderValidationMiddleware
                 .OfType<ProducesAttribute>()
                 .FirstOrDefault();
             
-            if (producesAttribute != null)
+            if (producesAttribute != null && acceptHeaders.Length > 0)
             {
                 var validMimeTypes = producesAttribute.ContentTypes.ToList();
+                validMimeTypes.Add("*/*");
 
-                if (acceptHeaders.Length == 0)
-                {
-                    context.Response.StatusCode = StatusCodes.Status406NotAcceptable;
-                    await context.Response.WriteAsync("Accept header is required");
-                    return;
-                }
                 if (!acceptHeaders.Any(header => header != null && IsValidAcceptHeader(header, validMimeTypes)))
                 {
                     context.Response.StatusCode = StatusCodes.Status406NotAcceptable;
@@ -53,6 +48,6 @@ public class AcceptHeaderValidationMiddleware
                 return parts[0].Trim().ToLowerInvariant();
             })
             .ToList();
-        return acceptHeader == "*/*" || acceptedMimeTypes.Any(mimeType => validMimeTypes.Contains(mimeType));
+        return acceptedMimeTypes.Any(mimeType => validMimeTypes.Contains(mimeType));
     }
 }

--- a/tests/Altinn.Broker.Tests/AcceptHeaderValidationTests.cs
+++ b/tests/Altinn.Broker.Tests/AcceptHeaderValidationTests.cs
@@ -43,7 +43,7 @@ public class FileTransferControllerTests : IClassFixture<CustomWebApplicationFac
     }
 
     [Fact]
-    public async Task InitializeFiletransfer_WithNoAcceptHeader_ReturnsNotAcceptable()
+    public async Task InitializeFiletransfer_WithNoAcceptHeader_ReturnsOk()
     {
         // Arrange
         _senderClient.DefaultRequestHeaders.Accept.Clear();
@@ -52,7 +52,7 @@ public class FileTransferControllerTests : IClassFixture<CustomWebApplicationFac
         var initializeFileTransferResponse = await _senderClient.PostAsJsonAsync("broker/api/v1/filetransfer", FileTransferInitializeExtTestFactory.BasicFileTransfer());
 
         // Assert
-        Assert.Equal(HttpStatusCode.NotAcceptable, initializeFileTransferResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, initializeFileTransferResponse.StatusCode);
     }
 
     [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently the Accept-header is required for endpoints where the accept-header is validated however it should be an optional header. This PR makes the accept-header optional.

## Related Issue(s)
- https://github.com/Altinn/altinn-correspondence/issues/496

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
