### PR TITLE
Set TLS version in deploy

### DIFF
--- a/.azure/modules/storageAccount/create.bicep
+++ b/.azure/modules/storageAccount/create.bicep
@@ -12,6 +12,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   }
   properties: {
     accessTier: 'Cool'
+    minimumTlsVersion: 'TLS1_2'
   }
 }
 

--- a/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
@@ -90,6 +90,15 @@ public class AzureResourceManagerService : IResourceManager
         storageAccountData.Tags.Add("customer_id", serviceOwnerEntity.Id);
         var storageAccountCollection = resourceGroup.Value.GetStorageAccounts();
         var storageAccount = await storageAccountCollection.CreateOrUpdateAsync(WaitUntil.Completed, storageAccountName, storageAccountData, cancellationToken);
+        if (storageAccount != null)
+        {
+            var updateData = new StorageAccountPatch
+            {
+                MinimumTlsVersion = "TLS1_2"
+            };
+
+            await storageAccount.Value.UpdateAsync(updateData);
+        }
         if (virusScan) { 
             await EnableMicrosoftDefender(resourceGroupName, storageAccountName, cancellationToken);
         }

--- a/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
@@ -86,10 +86,10 @@ public class AzureResourceManagerService : IResourceManager
 
         // Create or get the storage account
         var storageAccountData = new StorageAccountCreateOrUpdateContent(new StorageSku(StorageSkuName.StandardLrs), StorageKind.StorageV2, new AzureLocation(_resourceManagerOptions.Location));
+        storageAccountData.MinimumTlsVersion = "TLS1_2";
         storageAccountData.Tags.Add("customer_id", serviceOwnerEntity.Id);
         var storageAccountCollection = resourceGroup.Value.GetStorageAccounts();
         var storageAccount = await storageAccountCollection.CreateOrUpdateAsync(WaitUntil.Completed, storageAccountName, storageAccountData, cancellationToken);
-        storageAccount.Value.Data.MinimumTlsVersion = "TLS1_2";
         if (virusScan) { 
             await EnableMicrosoftDefender(resourceGroupName, storageAccountName, cancellationToken);
         }

--- a/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
@@ -90,15 +90,6 @@ public class AzureResourceManagerService : IResourceManager
         storageAccountData.Tags.Add("customer_id", serviceOwnerEntity.Id);
         var storageAccountCollection = resourceGroup.Value.GetStorageAccounts();
         var storageAccount = await storageAccountCollection.CreateOrUpdateAsync(WaitUntil.Completed, storageAccountName, storageAccountData, cancellationToken);
-        if (storageAccount != null)
-        {
-            var updateData = new StorageAccountPatch
-            {
-                MinimumTlsVersion = "TLS1_2"
-            };
-
-            await storageAccount.Value.UpdateAsync(updateData);
-        }
         if (virusScan) { 
             await EnableMicrosoftDefender(resourceGroupName, storageAccountName, cancellationToken);
         }

--- a/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureResourceManagerService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
@@ -88,6 +89,7 @@ public class AzureResourceManagerService : IResourceManager
         storageAccountData.Tags.Add("customer_id", serviceOwnerEntity.Id);
         var storageAccountCollection = resourceGroup.Value.GetStorageAccounts();
         var storageAccount = await storageAccountCollection.CreateOrUpdateAsync(WaitUntil.Completed, storageAccountName, storageAccountData, cancellationToken);
+        storageAccount.Value.Data.MinimumTlsVersion = "TLS1_2";
         if (virusScan) { 
             await EnableMicrosoftDefender(resourceGroupName, storageAccountName, cancellationToken);
         }


### PR DESCRIPTION
## Description
Changes make sure that minimum TLS version is set to 1.2 when new deploy is done.

## Related Issue(s)
- #642 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced security by enforcing a minimum TLS 1.2 requirement for secure resource deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->