### PR TITLE
Correct LegacyFileStatus and enum usage in LegacyFileController

### DIFF
--- a/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
+++ b/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
@@ -112,8 +112,8 @@ public class LegacyFileController(ILogger<LegacyFileController> logger) : Contro
     /// <returns></returns>
     [HttpGet]
     public async Task<ActionResult<List<Guid>>> GetFiles(
-        [FromQuery] FileTransferStatusExt? status,
-        [FromQuery] RecipientFileTransferStatusExt? recipientStatus,
+        [FromQuery] LegacyFileStatusExt? status,
+        [FromQuery] LegacyRecipientFileStatusExt? recipientStatus,
         [FromQuery] DateTimeOffset? from,
         [FromQuery] DateTimeOffset? to,
         [FromQuery] string? resourceId,
@@ -137,8 +137,8 @@ public class LegacyFileController(ILogger<LegacyFileController> logger) : Contro
         var queryResult = await handler.Process(new LegacyGetFilesRequest()
         {
             ResourceId = resourceId ?? string.Empty,
-            RecipientFileTransferStatus = recipientStatus is not null ? (ActorFileTransferStatus)recipientStatus : null,
-            FileTransferStatus = status is not null ? (FileTransferStatus)status : null,
+            RecipientFileTransferStatus = recipientStatus is not null ? LegacyFileStatusOverviewExtMapper.MapToDomainEnum(recipientStatus) : null,
+            FileTransferStatus = status is not null ? LegacyFileStatusOverviewExtMapper.MapToDomainEnum(status) : null,
             OnBehalfOfConsumer = onBehalfOfConsumer,
             From = from,
             To = to,

--- a/src/Altinn.Broker.API/Enums/LegacyFileStatusExt.cs
+++ b/src/Altinn.Broker.API/Enums/LegacyFileStatusExt.cs
@@ -8,6 +8,6 @@ public enum LegacyFileStatusExt
     Published,
     Cancelled,
     AllConfirmedDownloaded,
-    Deleted,
+    Purged,
     Failed
 }

--- a/src/Altinn.Broker.API/Mappers/LegacyFileStatusOverviewExtMapper.cs
+++ b/src/Altinn.Broker.API/Mappers/LegacyFileStatusOverviewExtMapper.cs
@@ -40,8 +40,45 @@ internal static class LegacyFileStatusOverviewExtMapper
             FileTransferStatus.Published => LegacyFileStatusExt.Published,
             FileTransferStatus.Cancelled => LegacyFileStatusExt.Cancelled,
             FileTransferStatus.AllConfirmedDownloaded => LegacyFileStatusExt.AllConfirmedDownloaded,
-            FileTransferStatus.Purged => LegacyFileStatusExt.Deleted,
+            FileTransferStatus.Purged => LegacyFileStatusExt.Purged,
             FileTransferStatus.Failed => LegacyFileStatusExt.Failed,
+            _ => throw new InvalidEnumArgumentException()
+        };
+    }
+
+    internal static FileTransferStatus MapToDomainEnum(LegacyFileStatusExt? legacyEnum)
+    {
+        if (legacyEnum is null)
+        {
+            throw new ArgumentNullException(nameof(legacyEnum));
+        }
+
+        return legacyEnum switch
+        {
+            LegacyFileStatusExt.Initialized => FileTransferStatus.Initialized,
+            LegacyFileStatusExt.UploadStarted => FileTransferStatus.UploadStarted,
+            LegacyFileStatusExt.UploadProcessing => FileTransferStatus.UploadProcessing,
+            LegacyFileStatusExt.Published => FileTransferStatus.Published,
+            LegacyFileStatusExt.Cancelled => FileTransferStatus.Cancelled,
+            LegacyFileStatusExt.AllConfirmedDownloaded => FileTransferStatus.AllConfirmedDownloaded,
+            LegacyFileStatusExt.Purged => FileTransferStatus.Purged,
+            LegacyFileStatusExt.Failed => FileTransferStatus.Failed,
+            _ => throw new InvalidEnumArgumentException()
+        };
+    }
+
+    internal static ActorFileTransferStatus MapToDomainEnum(LegacyRecipientFileStatusExt? legacyEnum)
+    {
+        if (legacyEnum is null)
+        {
+            throw new ArgumentNullException(nameof(legacyEnum));
+        }
+
+        return legacyEnum switch
+        {
+            LegacyRecipientFileStatusExt.Initialized => ActorFileTransferStatus.Initialized,
+            LegacyRecipientFileStatusExt.DownloadStarted => ActorFileTransferStatus.DownloadStarted,
+            LegacyRecipientFileStatusExt.DownloadConfirmed => ActorFileTransferStatus.DownloadConfirmed,
             _ => throw new InvalidEnumArgumentException()
         };
     }


### PR DESCRIPTION
Fix for reported bug and slight cleanup in usage of enums in LegacyFileController used by Broker Transition Solution.

## Description
Changed "Deleted" -> "Purged" for LegacyFileStatusExt to be more in-line with rest of solution and equivalent value set in Altinn 2 codebase.
Also corrected inconsistent useage of enum types in Legacy controller.
- This has not had an impact due to the enums values used having identical value.But performed the change and added mapping methods for LegacyFileStatusExt and LegacyRecipientFileStatusExt so that changes in domain enums are able to be disconnected from Legacy Enums in future updates.

## Related Issue(s)
- #662

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable): N/A.
