### PR TITLE
Added slack integration for hangfire and prod

### DIFF
--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -52,7 +52,7 @@ public class FileTransferController(ILogger<FileTransferController> logger, IIde
         LogContextHelpers.EnrichLogsWithInitializeFile(initializeExt);
         logger.LogInformation("Initializing file transfer");
         var commandRequest = InitializeFileTransferMapper.MapToRequest(initializeExt);
-
+throw new NotImplementedException();
         var commandResult = await handler.Process(commandRequest, HttpContext.User, cancellationToken);
         return commandResult.Match(
             fileTransferId => Ok(new FileTransferInitializeResponseExt()

--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -52,6 +52,7 @@ public class FileTransferController(ILogger<FileTransferController> logger, IIde
         LogContextHelpers.EnrichLogsWithInitializeFile(initializeExt);
         logger.LogInformation("Initializing file transfer");
         var commandRequest = InitializeFileTransferMapper.MapToRequest(initializeExt);
+        
         var commandResult = await handler.Process(commandRequest, HttpContext.User, cancellationToken);
         return commandResult.Match(
             fileTransferId => Ok(new FileTransferInitializeResponseExt()
@@ -330,5 +331,4 @@ public class FileTransferController(ILogger<FileTransferController> logger, IIde
     }
 
     private ObjectResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);
-
 }

--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -8,6 +8,7 @@ using Altinn.Broker.Application.GetFileTransferOverview;
 using Altinn.Broker.Application.GetFileTransfers;
 using Altinn.Broker.Application.InitializeFileTransfer;
 using Altinn.Broker.Application.UploadFile;
+using Altinn.Broker.Application.ExpireFileTransfer;
 using Altinn.Broker.Common;
 using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Domain.Enums;
@@ -23,6 +24,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 using OneOf;
+using Hangfire;
 
 namespace Altinn.Broker.Controllers;
 
@@ -52,7 +54,6 @@ public class FileTransferController(ILogger<FileTransferController> logger, IIde
         LogContextHelpers.EnrichLogsWithInitializeFile(initializeExt);
         logger.LogInformation("Initializing file transfer");
         var commandRequest = InitializeFileTransferMapper.MapToRequest(initializeExt);
-throw new NotImplementedException();
         var commandResult = await handler.Process(commandRequest, HttpContext.User, cancellationToken);
         return commandResult.Match(
             fileTransferId => Ok(new FileTransferInitializeResponseExt()
@@ -331,4 +332,38 @@ throw new NotImplementedException();
     }
 
     private ObjectResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);
+
+    /// <summary>
+    /// Test endpoint that throws an exception to test Slack notifications
+    /// </summary>
+    [HttpGet]
+    [Route("test/exception")]
+    [AllowAnonymous]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public IActionResult TestException()
+    {
+        throw new InvalidOperationException("This is a test exception that should be sent to Slack");
+    }
+
+    /// <summary>
+    /// Test endpoint that triggers a Hangfire job with an invalid expiration time
+    /// </summary>
+    [HttpGet]
+    [Route("test/hangfire-exception")]
+    [AllowAnonymous]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult TestHangfireException([FromServices] IBackgroundJobClient backgroundJobClient)
+    {
+        var invalidExpirationTime = DateTime.UtcNow.AddYears(-1);
+        var fileTransferId = Guid.NewGuid();
+        
+        backgroundJobClient.Schedule<ExpireFileTransferHandler>(
+            (handler) => handler.Process(
+                new ExpireFileTransferRequest { FileTransferId = fileTransferId, Force = false }, 
+                null, 
+                CancellationToken.None), 
+            invalidExpirationTime);
+
+        return Ok($"Scheduled Hangfire job with invalid expiration time for file transfer {fileTransferId}");
+    }
 }

--- a/src/Altinn.Broker.Core/Options/SlackSettings.cs
+++ b/src/Altinn.Broker.Core/Options/SlackSettings.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Hosting;
+
+namespace Altinn.Broker.Core.Options;
+
+public class SlackSettings
+{
+    private readonly IHostEnvironment _hostEnvironment;
+
+    public SlackSettings(IHostEnvironment hostEnvironment)
+    {
+        _hostEnvironment = hostEnvironment;
+    }
+
+    public string NotificationChannel => _hostEnvironment.IsProduction() ? "#mf-varsling-critical" : "#test-varslinger";
+} 

--- a/src/Altinn.Broker.Integrations/DependencyInjection.cs
+++ b/src/Altinn.Broker.Integrations/DependencyInjection.cs
@@ -60,5 +60,9 @@ public static class DependencyInjection
         {
             services.AddSingleton<ISlackClient>(new SlackClient(generalSettings.SlackUrl));
         }
+
+        services.AddSingleton<SlackSettings>();
+        services.AddSingleton<SlackExceptionNotificationHandler>();
+        services.AddExceptionHandler<SlackExceptionNotificationHandler>();
     }
 }

--- a/src/Altinn.Broker.Integrations/Hangfire/DependencyInjection.cs
+++ b/src/Altinn.Broker.Integrations/Hangfire/DependencyInjection.cs
@@ -3,6 +3,9 @@ using Hangfire.PostgreSql;
 
 using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Altinn.Broker.Integrations.Slack;
 
 namespace Altinn.Broker.Integrations.Hangfire;
 public static class DependencyInjection
@@ -17,6 +20,12 @@ public static class DependencyInjection
             );
             config.UseSerilogLogProvider();
             config.UseFilter(new HangfireAppRequestFilter(provider.GetRequiredService<TelemetryClient>()));
+            config.UseSerializerSettings(new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore });
+            config.UseFilter(
+                new SlackExceptionHandler(
+                    provider.GetRequiredService<SlackExceptionNotificationHandler>(),
+                    provider.GetRequiredService<ILogger<SlackExceptionHandler>>())
+                );
         }
         );
         services.AddHangfireServer();

--- a/src/Altinn.Broker.Integrations/Hangfire/SlackExceptionHandler.cs
+++ b/src/Altinn.Broker.Integrations/Hangfire/SlackExceptionHandler.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Logging;
+using Hangfire.Common;
+using Hangfire.States;
+using Hangfire.Server;
+using Altinn.Broker.Integrations.Slack;
+
+namespace Altinn.Broker.Integrations.Hangfire
+{
+    public class SlackExceptionHandler : JobFilterAttribute, IServerFilter
+    {
+        private readonly SlackExceptionNotificationHandler _slackExceptionNotification;
+        private readonly ILogger<SlackExceptionHandler> _logger;
+
+        public SlackExceptionHandler(SlackExceptionNotificationHandler slackExceptionNotification, ILogger<SlackExceptionHandler> logger)
+        {
+            _slackExceptionNotification = slackExceptionNotification;
+            _logger = logger;
+        }
+
+        public void OnPerforming(PerformingContext filterContext)
+        {
+            // Log the start of the job execution
+            var jobId = filterContext.BackgroundJob.Id;
+            var jobName = filterContext.BackgroundJob.Job.Type.Name;
+            _logger.LogInformation("Starting job {JobId} of type {JobName}", jobId, jobName);
+        }
+
+        public async void OnPerformed(PerformedContext filterContext)
+        {
+            // Log the completion of the job execution
+            var exception = filterContext.Exception;
+            var jobId = filterContext.BackgroundJob.Id;
+            var jobName = filterContext.BackgroundJob.Job.Type.Name;
+            _logger.LogInformation("Completed job {JobId} of type {JobName}", jobId, jobName);
+            
+            // Properly await the notification
+            if(exception != null) {
+                await _slackExceptionNotification.TryHandleBackgroundJobAsync(jobId, jobName, exception);
+            }
+        }
+
+        public async void OnStateElection(ElectStateContext context)
+        {
+            if (context.CandidateState is FailedState failedState)
+            {
+                var exception = failedState.Exception;
+                var jobId = context.BackgroundJob.Id;
+                var jobName = context.BackgroundJob.Job.Type.Name;
+
+                _logger.LogError(exception, "Job {JobId} of type {JobName} failed", jobId, jobName);
+                
+                // Properly await the notification
+                await _slackExceptionNotification.TryHandleBackgroundJobAsync(jobId, jobName, exception);
+            }
+        }
+    }
+} 

--- a/src/Altinn.Broker.Integrations/Slack/SlackDevClient.cs
+++ b/src/Altinn.Broker.Integrations/Slack/SlackDevClient.cs
@@ -5,14 +5,16 @@ namespace Altinn.Broker.Integrations.Slack
     public class SlackDevClient : ISlackClient
     {
         private readonly HttpClient _httpClient;
-        private readonly Uri _webhookUri;
+        private readonly Uri? _webhookUri;
         private const string POST_SUCCESS = "ok";
-        public SlackDevClient(string webhookUrl, HttpClient httpClient = null)
+        public SlackDevClient(string webhookUrl, HttpClient? httpClient = null)
         {
             _httpClient = httpClient ?? new HttpClient();
             if (!Uri.TryCreate(webhookUrl, UriKind.Absolute, out _webhookUri))
-                // throw new ArgumentException("Please enter a valid webhook url"); Commented out from source code to avoid throwing exception when testing without providing a webhook url
+            {
+                // In development, we don't throw if the webhook URL is invalid
                 return;
+            }
         }
         public virtual bool Post(SlackMessage slackMessage)
         {
@@ -24,7 +26,11 @@ namespace Altinn.Broker.Integrations.Slack
         }
         public async Task<bool> PostAsync(SlackMessage slackMessage, bool configureAwait = true)
         {
-            if (_webhookUri == null) return true; // Mock success if no webhook url is provided
+            if (_webhookUri == null)
+            {
+                // In development, we just return success if no webhook URL is provided
+                return true;
+            }
 
             using (var request = new HttpRequestMessage(HttpMethod.Post, _webhookUri))
             {
@@ -36,11 +42,13 @@ namespace Altinn.Broker.Integrations.Slack
         }
         public bool PostToChannels(SlackMessage message, IEnumerable<string> channels)
         {
+            // Not implemented in dev client
             return true;
         }
         public IEnumerable<Task<bool>> PostToChannelsAsync(SlackMessage message, IEnumerable<string> channels)
         {
-            return [];
+            // Not implemented in dev client
+            return new[] { Task.FromResult(true) };
         }
     }
 }

--- a/src/Altinn.Broker.Integrations/Slack/SlackExceptionNotificationHandler.cs
+++ b/src/Altinn.Broker.Integrations/Slack/SlackExceptionNotificationHandler.cs
@@ -45,7 +45,7 @@ public class SlackExceptionNotificationHandler : IExceptionHandler
             "Unhandled exception occurred. Type: {ExceptionType}, Message: {Message}, Path: {Path}",
             exception.GetType().Name,
             exception.Message,
-            httpContext.Request.Path);
+            httpContext.Request.Path.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
 
         try
         {

--- a/src/Altinn.Broker.Integrations/Slack/SlackExceptionNotificationHandler.cs
+++ b/src/Altinn.Broker.Integrations/Slack/SlackExceptionNotificationHandler.cs
@@ -45,7 +45,7 @@ public class SlackExceptionNotificationHandler : IExceptionHandler
             "Unhandled exception occurred. Type: {ExceptionType}, Message: {Message}, Path: {Path}",
             exception.GetType().Name,
             exception.Message,
-            httpContext.Request.Path.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
+            httpContext.Request.Path.ToString().Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
 
         try
         {

--- a/src/Altinn.Broker.Integrations/Slack/SlackExceptionNotificationHandler.cs
+++ b/src/Altinn.Broker.Integrations/Slack/SlackExceptionNotificationHandler.cs
@@ -1,0 +1,139 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Diagnostics;
+using Slack.Webhooks;
+using Microsoft.AspNetCore.Http;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using System.Net;
+using Altinn.Broker.Core.Options;
+
+namespace Altinn.Broker.Integrations.Slack;
+
+public class SlackExceptionNotificationHandler : IExceptionHandler
+{
+    private readonly ILogger<SlackExceptionNotificationHandler> _logger;
+    private readonly ISlackClient _slackClient;
+    private readonly IProblemDetailsService _problemDetailsService;
+    private readonly IHostEnvironment _hostEnvironment;
+    private readonly SlackSettings _slackSettings;
+    private string Channel => _slackSettings.NotificationChannel;
+
+    public SlackExceptionNotificationHandler(
+        ILogger<SlackExceptionNotificationHandler> logger,
+        ISlackClient slackClient,
+        IProblemDetailsService problemDetailsService,
+        IHostEnvironment hostEnvironment,
+        SlackSettings slackSettings)
+    {
+        _logger = logger;
+        _slackClient = slackClient;
+        _problemDetailsService = problemDetailsService;
+        _hostEnvironment = hostEnvironment;
+        _slackSettings = slackSettings;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        var exceptionMessage = FormatExceptionMessage(exception, httpContext);
+
+        _logger.LogError(
+            exception,
+            "Unhandled exception occurred. Type: {ExceptionType}, Message: {Message}, Path: {Path}",
+            exception.GetType().Name,
+            exception.Message,
+            httpContext.Request.Path);
+
+        try
+        {
+            await SendSlackNotificationWithMessage(exceptionMessage);
+            var statusCode = HttpStatusCode.InternalServerError;
+            var problemDetails = new ProblemDetails
+            {
+                Status = (int)statusCode,
+                Title = "Internal Server Error",
+                Type = "https://tools.ietf.org/html/rfc9110#section-15.6.1",
+                Detail = _hostEnvironment.IsDevelopment() ? exception.Message : "",
+                Instance = httpContext.Request.Path
+            };
+            var traceId = Activity.Current?.Id ?? httpContext.TraceIdentifier;
+            problemDetails.Extensions["traceId"] = traceId;
+
+            await _problemDetailsService.WriteAsync(new ProblemDetailsContext
+            {
+                HttpContext = httpContext,
+                ProblemDetails = problemDetails
+            });
+
+            return true;
+        }
+        catch (Exception slackEx)
+        {
+            _logger.LogError(
+                slackEx,
+                "Failed to send Slack notification");
+            return true;
+        }
+    }
+
+    public async Task<bool> TryHandleBackgroundJobAsync(string jobId, string jobName, Exception exception)
+    {
+        var exceptionMessage = FormatBackgroundJobExceptionMessage(jobId, jobName, exception);
+
+        _logger.LogError(
+            exception,
+            "Unhandled exception occurred in background job. Job ID: {JobId}, Job Name: {JobName}, Type: {ExceptionType}, Message: {Message}",
+            jobId,
+            jobName,
+            exception.GetType().Name,
+            exception.Message);
+
+        try
+        {
+            await SendSlackNotificationWithMessage(exceptionMessage);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send Slack notification");
+            return false;
+        }
+    }
+
+    private string FormatExceptionMessage(Exception exception, HttpContext context)
+    {
+        return $":warning: *Unhandled Exception*\n" +
+               $"*Environment:* {_hostEnvironment.EnvironmentName}\n" +
+               $"*System:* Broker\n" +
+               $"*Type:* {exception.GetType().Name}\n" +
+               $"*Message:* {exception.Message}\n" +
+               $"*Path:* {context.Request.Path}\n" +
+               $"*Time:* {DateTime.UtcNow:u}\n" +
+               $"*Stacktrace:* \n{exception.StackTrace}";
+    }
+
+    private string FormatBackgroundJobExceptionMessage(string jobId, string jobName, Exception exception)
+    {
+        return $":warning: *Unhandled Exception in Background Job*\n" +
+               $"*Environment:* {_hostEnvironment.EnvironmentName}\n" +
+               $"*Job ID:* {jobId}\n" +
+               $"*Job Name:* {jobName}\n" +
+               $"*Type:* {exception.GetType().Name}\n" +
+               $"*Message:* {exception.Message}\n" +
+               $"*Time:* {DateTime.UtcNow:u}\n" +
+               $"*Stacktrace:* \n{exception.StackTrace}";
+    }
+
+    private async Task SendSlackNotificationWithMessage(string message)
+    {
+        var slackMessage = new SlackMessage
+        {
+            Text = message,
+            Channel = Channel
+        };
+        await _slackClient.PostAsync(slackMessage);
+    }
+} 


### PR DESCRIPTION
## Description
Adding the same slack notification integration as in Correspondence. Both notifications for hangfire jobs and separate notification channel for errors in prod.

## Related Issue(s)
- #661 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced environment-aware notification settings that automatically select the correct alert channel based on whether the system is running in production or testing.
	- Enhanced background job error handling with automated notifications to better capture and report failures.
	- Improved development stability by gracefully handling configuration issues, ensuring smoother operation during testing and development cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->