### PR TITLE
Retrieve APIM IP from Github environment secrets

### DIFF
--- a/.azure/applications/api/params.bicepparam
+++ b/.azure/applications/api/params.bicepparam
@@ -6,7 +6,7 @@ param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param platform_base_url = readEnvironmentVariable('PLATFORM_BASE_URL')
 param maskinporten_environment = readEnvironmentVariable('MASKINPORTEN_ENVIRONMENT')
 param environment = readEnvironmentVariable('ENVIRONMENT')
-param apimIp = (environment == 'test' ? '51.120.88.69' : environment == 'staging' ? '51.13.86.131' : environment == 'production' ? '51.120.88.54' : '')
+param apimIp = readEnvironmentVariable('APIM_IP')
 
 // secrets
 param sourceKeyVaultName = readEnvironmentVariable('KEY_VAULT_NAME')

--- a/.github/actions/release-version/action.yml
+++ b/.github/actions/release-version/action.yml
@@ -65,7 +65,7 @@ runs:
         NAME_PREFIX: ${{ inputs.AZURE_NAME_PREFIX }}
         PLATFORM_BASE_URL: ${{ inputs.PLATFORM_BASE_URL }}
         MASKINPORTEN_ENVIRONMENT: ${{ inputs.MASKINPORTEN_ENVIRONMENT }}
-        APIM_IP: ${{ secrets.APIM_IP }}
+        APIM_IP: ${{ inputs.APIM_IP }}
       with:
         scope: subscription
         subscriptionId: ${{ inputs.AZURE_SUBSCRIPTION_ID }}

--- a/.github/actions/release-version/action.yml
+++ b/.github/actions/release-version/action.yml
@@ -33,6 +33,9 @@ inputs:
   MASKINPORTEN_ENVIRONMENT:
     description: "Environment for maskinporten"
     required: true
+  APIM_IP:
+    description: "IP for APIM"
+    required: true
 
 runs:
   using: "composite"
@@ -62,6 +65,7 @@ runs:
         NAME_PREFIX: ${{ inputs.AZURE_NAME_PREFIX }}
         PLATFORM_BASE_URL: ${{ inputs.PLATFORM_BASE_URL }}
         MASKINPORTEN_ENVIRONMENT: ${{ inputs.MASKINPORTEN_ENVIRONMENT }}
+        APIM_IP: ${{ secrets.APIM_IP }}
       with:
         scope: subscription
         subscriptionId: ${{ inputs.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -98,4 +98,5 @@ jobs:
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         MASKINPORTEN_ENVIRONMENT: ${{ secrets.MASKINPORTEN_ENVIRONMENT }}
+        APIM_IP: ${{ secrets.APIM_IP }}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The APIM IPs are currently hardcoded in bicep.param for the test, staging and production environments. The APIM IP should instead be retireved from the environment secrets/variables to make it easier to add and configure the apim ip for the environments.

## Related Issue(s)
- #440 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- API Management now retrieves its IP address directly from an environment configuration, streamlining the deployment process.
	- The release process has been updated to require an input for the API Management IP, offering enhanced flexibility during deployments.
	- A new environment variable for the API Management IP has been added to the deployment workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->