### PR TITLE
Added sorting based on Created to Legacy.GetFiles

### DIFF
--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
@@ -198,7 +198,7 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
     public async Task<List<Guid>> LegacyGetFilesForRecipientsWithRecipientStatus(LegacyFileSearchEntity fileTransferSearch, CancellationToken cancellationToken)
     {
         StringBuilder commandString = new StringBuilder();
-        commandString.AppendLine("SELECT DISTINCT f.file_transfer_id_pk ");
+        commandString.AppendLine("SELECT DISTINCT f.file_transfer_id_pk, f.Created");
         commandString.AppendLine("FROM broker.file_transfer f");
         commandString.AppendLine("INNER JOIN LATERAL ");
         commandString.AppendLine("(SELECT afs.actor_file_transfer_status_description_id_fk FROM broker.actor_file_transfer_status afs ");
@@ -245,6 +245,7 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
         {
             commandString.AppendLine("AND filetransferstatus.file_transfer_status_description_id_fk = @fileTransferStatus");
         }
+        commandString.AppendLine("ORDER BY f.created ASC");
         commandString.AppendLine(";");
 
         await using var command = dataSource.CreateCommand(

--- a/tests/Altinn.Broker.Tests/LegacyFileControllerTests.cs
+++ b/tests/Altinn.Broker.Tests/LegacyFileControllerTests.cs
@@ -342,6 +342,39 @@ public class LegacyFileControllerTests : IClassFixture<CustomWebApplicationFacto
         Assert.DoesNotContain(fileData, g => g == Guid.Parse(fileId2));
     }
 
+    [Fact]
+    public async Task GetFileOverview_3Published_GetInOrder_Success()
+    {
+        // Arrange
+        var file = FileTransferInitializeExtTestFactory.BasicFileTransfer();
+        string fileId1 = await InitializeFile();
+        await UploadFile(fileId1);
+        string fileId2 = await InitializeFile();
+        await UploadFile(fileId2);
+        string fileId3 = await InitializeFile();
+        await UploadFile(fileId3);
+
+        // Act
+        var getResponse = await _legacyClient.GetAsync($"broker/api/v1/legacy/file"
+        + $"?status=Published"
+        + $"&recipientStatus=Initialized"
+        + $"&resourceId={file.ResourceId}"
+        + $"&onBehalfOfConsumer={file.Recipients[0]}");
+        string s = await getResponse.Content.ReadAsStringAsync();
+        var fileData = await getResponse.Content.ReadFromJsonAsync<List<Guid>>(_responseSerializerOptions);
+
+        // Assert        
+        int fileIndex1, fileIndex2, fileIndex3 = -1;
+        Assert.Equal(System.Net.HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.NotNull(fileData);
+        fileIndex1 = fileData.FindIndex(g => g == Guid.Parse(fileId1));
+        fileIndex2 = fileData.FindIndex(g => g == Guid.Parse(fileId2));
+        fileIndex3 = fileData.FindIndex(g => g == Guid.Parse(fileId3));
+        Assert.NotEqual(-1, fileIndex1);
+        Assert.NotEqual(-1, fileIndex2);
+        Assert.NotEqual(-1, fileIndex3);
+        Assert.True(fileIndex1 < fileIndex2 && fileIndex2 < fileIndex3);
+    }
 
     [Fact]
     public async Task GetFileOverview_FileDoesNotExist_FileNotFound()


### PR DESCRIPTION
Added sorting based on Filetransfer.Created to ensure consistent order from GetFiles as expected by some Legacy consumers.

## Related Issue(s)
- #[816
](https://github.com/Altinn/altinn-correspondence/issues/816)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- File listings now include the creation date and are presented in chronological order, offering a more organized view of transfers.
  
- **Tests**
	- Added validations to ensure that published files are returned in the expected sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->