### PR TITLE
Optimize legacy search with composite index

### DIFF
--- a/src/Altinn.Broker.Persistence/Migrations/V0014__optimize_legacy_search_index.sql
+++ b/src/Altinn.Broker.Persistence/Migrations/V0014__optimize_legacy_search_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_actor_file_transfer_status_actor_file
+ON broker.actor_file_transfer_status(actor_id_fk, file_transfer_id_fk, actor_file_transfer_status_description_id_fk);


### PR DESCRIPTION
## Description
By having all columns in same index we preserve the sorting order "for free" for the entire legacy search query (which user order by) and we get index-only scans all around.

## Related Issue(s)
- #673 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
