### PR TITLE
Fix malwarescan webhook failures

### DIFF
--- a/src/Altinn.Broker.API/Controllers/MalwareScanResultsController.cs
+++ b/src/Altinn.Broker.API/Controllers/MalwareScanResultsController.cs
@@ -33,7 +33,6 @@ public class MalwareScanResultsController(IIdempotencyEventRepository idempotenc
             {
                 if (eventData is SubscriptionValidationEventData subscriptionValidationEventData)
                 {
-                    // TODO: validate that eventGridEvent WebHook subscription is actually from an Altinn Azure Defender EventGrid
                     var responseData = new
                     {
                         ValidationResponse = subscriptionValidationEventData.ValidationCode

--- a/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
+++ b/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
@@ -22,6 +22,9 @@ public class MalwareScanningResultHandler(
     IFileTransferStatusRepository fileTransferStatusRepository,
     IFileTransferRepository fileTransferRepository,
     EventBusMiddleware eventBus,
+    IResourceRepository resourceRepository,
+    IServiceOwnerRepository serviceOwnerRepository,
+    IBrokerStorageService brokerStorageService,
     ILogger<MalwareScanningResultHandler> logger,
     IBackgroundJobClient backgroundJobClient) : IHandler<ScanResultData, Task>
 {
@@ -39,6 +42,16 @@ public class MalwareScanningResultHandler(
         {
             return Errors.FileTransferNotFound;
         }
+        var resource = await resourceRepository.GetResource(fileTransfer.ResourceId, cancellationToken);
+        if (resource is null)
+        {
+            return Errors.InvalidResourceDefinition;
+        }
+        var serviceOwner = await serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId);
+        if (serviceOwner is null)
+        {
+            return Errors.ServiceOwnerNotConfigured;
+        }
 
         return await TransactionWithRetriesPolicy.Execute(async (cancellationToken) =>
         {
@@ -51,6 +64,7 @@ public class MalwareScanningResultHandler(
                 {
                     backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, fileTransferIdFromUri, recipient.Actor.ActorExternalId, Guid.NewGuid()));
                 }
+                await brokerStorageService.SetContentHashForExistingBlob(serviceOwner, fileTransfer, cancellationToken);
             }
             else
             {

--- a/src/Altinn.Broker.Core/Services/IBrokerStorageService.cs
+++ b/src/Altinn.Broker.Core/Services/IBrokerStorageService.cs
@@ -15,4 +15,5 @@ public interface IBrokerStorageService
 
     Task<Stream> DownloadFile(ServiceOwnerEntity serviceOwnerEntity, FileTransferEntity fileTransfer, CancellationToken cancellationToken);
     Task DeleteFile(ServiceOwnerEntity serviceOwnerEntity, FileTransferEntity fileTransferEntity, CancellationToken cancellationToken);
+    Task SetContentHashForExistingBlob(ServiceOwnerEntity serviceOwnerEntity, FileTransferEntity fileTransferEntity, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
## Description
Fixed an issue where the malware scan service was failing due to ETag changes when adding the MD5 hash in a separate final commit. We do this in order to support very big files (100TB+) because we need to calculate the MD5 ourselves due to file size constraints in storage account. 

The problem occurred because the malware scan starts after the initial commit but before the MD5 hash is added, causing it to detect a file change and not send the webhook on completion. 

## Related Issue(s)
- [#4191](https://github.com/Altinn/altinn-support-private/issues/4191)

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced scan result processing with improved validations to ensure proper handling of file data.
  - Updated file upload operations to set and maintain accurate file metadata, bolstering file integrity during transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->