### PR TITLE
Downgrade azure cli to 2.70 because of bug in version 2.71

### DIFF
--- a/.github/actions/update-infrastructure/action.yml
+++ b/.github/actions/update-infrastructure/action.yml
@@ -64,6 +64,16 @@ runs:
         tenant-id: ${{ inputs.AZURE_TENANT_ID }}
         subscription-id: ${{ inputs.AZURE_SUBSCRIPTION_ID }}
 
+    - name: Downgrade Azure CLI to 2.70.0
+      shell: bash
+      run: |
+        # Obtain the currently installed distribution
+        AZ_DIST=$(lsb_release -cs)
+        # Store an Azure CLI version of choice
+        AZ_VER=2.70.0
+        # Install a specific version
+        sudo apt-get install -y --allow-downgrades azure-cli=${AZ_VER}-1~${AZ_DIST}
+
     - name: Generate postgresql password
       id: pwd-generator
       shell: pwsh

--- a/.github/actions/update-infrastructure/action.yml
+++ b/.github/actions/update-infrastructure/action.yml
@@ -72,6 +72,7 @@ runs:
         # Store an Azure CLI version of choice
         AZ_VER=2.70.0
         # Install a specific version
+        sudo apt-get update
         sudo apt-get install -y --allow-downgrades azure-cli=${AZ_VER}-1~${AZ_DIST}
 
     - name: Generate postgresql password


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Azure Cli version 2.71 introduced a new bug that leads to deployments failing. This pr changes a bicep script to downgrade azure cli to version 2.70 as a temporary workaround. This workaround should be reversed when a new azure cli version with the bug fixed is available.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the workflow to ensure the Azure CLI is set to version 2.70.0 during infrastructure updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->