### PR TITLE
Retry transient npgsql exceptions for DB operations

### DIFF
--- a/src/Altinn.Broker.Core/Helpers/TransactionWithRetriesPolicy.cs
+++ b/src/Altinn.Broker.Core/Helpers/TransactionWithRetriesPolicy.cs
@@ -38,6 +38,7 @@ public static class TransactionWithRetriesPolicy
         .Or<PostgresException>()
         .Or<BackgroundJobClientException>()
         .Or<PostgreSqlDistributedLockException>()
+        .Or<NpgsqlException>(ex => ex.IsTransient)
         .WaitAndRetryAsync(
             8,
             retryAttempt => TimeSpan.FromMilliseconds(Math.Min(5 * Math.Pow(2, retryAttempt), 640)),

--- a/src/Altinn.Broker.Core/Helpers/TransactionWithRetriesPolicy.cs
+++ b/src/Altinn.Broker.Core/Helpers/TransactionWithRetriesPolicy.cs
@@ -38,7 +38,6 @@ public static class TransactionWithRetriesPolicy
         .Or<PostgresException>()
         .Or<BackgroundJobClientException>()
         .Or<PostgreSqlDistributedLockException>()
-        .Or<NpgsqlException>(ex => ex.IsTransient)
         .WaitAndRetryAsync(
             8,
             retryAttempt => TimeSpan.FromMilliseconds(Math.Min(5 * Math.Pow(2, retryAttempt), 640)),

--- a/src/Altinn.Broker.Persistence/DependencyInjection.cs
+++ b/src/Altinn.Broker.Persistence/DependencyInjection.cs
@@ -1,4 +1,5 @@
 ﻿using Altinn.Broker.Core.Repositories;
+using Altinn.Broker.Persistence.Helpers;
 using Altinn.Broker.Persistence.Options;
 using Altinn.Broker.Persistence.Repositories;
 
@@ -16,6 +17,7 @@ public static class DependencyInjection
     public static void AddPersistence(this IServiceCollection services, IConfiguration config)
     {
         services.AddSingleton(BuildAzureNpgsqlDataSource(config));
+        services.AddSingleton<ExecuteDBCommandWithRetries>();
         services.AddSingleton<IActorRepository, ActorRepository>();
         services.AddSingleton<IFileTransferRepository, FileTransferRepository>();
         services.AddSingleton<IFileTransferStatusRepository, FileTransferStatusRepository>();

--- a/src/Altinn.Broker.Persistence/Helpers/ExecuteDBCommandWithRetries.cs
+++ b/src/Altinn.Broker.Persistence/Helpers/ExecuteDBCommandWithRetries.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Polly;
+using Polly.Retry;
+
+namespace Altinn.Broker.Persistence.Helpers;
+
+/// <summary>
+/// Helper class to execute database commands with retry logic for transient failures
+/// </summary>
+public class ExecuteDBCommandWithRetries(ILogger<ExecuteDBCommandWithRetries> logger)
+{
+    private readonly ILogger<ExecuteDBCommandWithRetries> _logger = logger;
+
+    /// <summary>
+    /// Executes a database command with retry logic for transient failures
+    /// </summary>
+    /// <typeparam name="T">Return type of the operation</typeparam>
+    /// <param name="operation">The operation to execute</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Result of the operation</returns>
+    public async Task<T> ExecuteWithRetry<T>(Func<CancellationToken, Task<T>> operation, CancellationToken cancellationToken = default)
+    {
+        var result = await CreateRetryPolicy().ExecuteAndCaptureAsync(operation, cancellationToken);
+        
+        if (result.Outcome == OutcomeType.Failure)
+        {
+            _logger.LogError("Exception during database command retries: {message}\n{stackTrace}", 
+                result.FinalException.Message, 
+                result.FinalException.StackTrace);
+            throw result.FinalException;
+        }
+        
+        return result.Result;
+    }
+
+    /// <summary>
+    /// Executes a database command that returns no result with retry logic for transient failures
+    /// </summary>
+    /// <param name="operation">The operation to execute</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    public async Task ExecuteWithRetry(Func<CancellationToken, Task> operation, CancellationToken cancellationToken = default)
+    {
+        var policy = CreateRetryPolicy();
+        var result = await policy.ExecuteAndCaptureAsync(operation, cancellationToken);
+        
+        if (result.Outcome == OutcomeType.Failure)
+        {
+            _logger.LogError("Exception during database command retries: {message}\n{stackTrace}", 
+                result.FinalException.Message, 
+                result.FinalException.StackTrace);
+            throw result.FinalException;
+        }
+    }
+
+    private AsyncRetryPolicy CreateRetryPolicy()
+    {
+        return Policy
+            .Handle<NpgsqlException>(ex => ex.IsTransient)
+            .Or<PostgresException>()
+            .WaitAndRetryAsync(
+                3,
+                retryAttempt => TimeSpan.FromMilliseconds(100),
+                (exception, timeSpan, retryCount, context) =>
+                {
+                    _logger.LogWarning("Database command attempt {RetryCount} failed with exception: {ExceptionMessage}. Retrying in {RetryTimeSpan}ms...",
+                        retryCount,
+                        exception.Message,
+                        timeSpan.TotalMilliseconds);
+                });
+    }
+} 

--- a/src/Altinn.Broker.Persistence/Helpers/ExecuteDBCommandWithRetries.cs
+++ b/src/Altinn.Broker.Persistence/Helpers/ExecuteDBCommandWithRetries.cs
@@ -56,8 +56,7 @@ public class ExecuteDBCommandWithRetries(ILogger<ExecuteDBCommandWithRetries> lo
     private AsyncRetryPolicy CreateRetryPolicy()
     {
         return Policy
-            .Handle<NpgsqlException>(ex => ex.IsTransient)
-            .Or<PostgresException>()
+            .Handle<NpgsqlException>(ex => ex.IsTransient && ex is not PostgresException)
             .WaitAndRetryAsync(
                 3,
                 retryAttempt => TimeSpan.FromMilliseconds(100),

--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
@@ -3,6 +3,7 @@
 using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Domain.Enums;
 using Altinn.Broker.Core.Repositories;
+using Altinn.Broker.Persistence.Helpers;
 
 using Npgsql;
 
@@ -12,12 +13,10 @@ using Serilog.Context;
 
 namespace Altinn.Broker.Persistence.Repositories;
 
-public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepository actorRepository) : IFileTransferRepository
+public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepository actorRepository, ExecuteDBCommandWithRetries commandExecutor) : IFileTransferRepository
 {
     public async Task<FileTransferEntity?> GetFileTransfer(Guid fileTransferId, CancellationToken cancellationToken)
     {
-        FileTransferEntity fileTransfer;
-
         await using var command = dataSource.CreateCommand(
             @"
                 SELECT 
@@ -65,10 +64,16 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
                     ) fs_latest ON f.file_transfer_id_pk = fs_latest.file_transfer_id_fk
                 WHERE 
                     f.file_transfer_id_pk = @fileTransferId;");
+        
+        command.Parameters.AddWithValue("@fileTransferId", fileTransferId);
+        
+        return await commandExecutor.ExecuteWithRetry(async (ct) => 
         {
-            command.Parameters.AddWithValue("@fileTransferId", fileTransferId);
-            await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
-            if (await reader.ReadAsync(cancellationToken))
+            FileTransferEntity? fileTransfer = null;
+            
+            await using var reader = await command.ExecuteReaderAsync(ct);
+            
+            if (await reader.ReadAsync(ct))
             {
                 fileTransfer = new FileTransferEntity
                 {
@@ -95,18 +100,16 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
                         ActorId = reader.GetInt64(reader.GetOrdinal("sender_actor_id_fk")),
                         ActorExternalId = reader.GetString(reader.GetOrdinal("senderActorExternalReference"))
                     },
-                    RecipientCurrentStatuses = await GetLatestRecipientFileTransferStatuses(fileTransferId, cancellationToken),
-                    PropertyList = await GetMetadata(fileTransferId, cancellationToken),
+                    RecipientCurrentStatuses = await GetLatestRecipientFileTransferStatuses(fileTransferId, ct),
+                    PropertyList = await GetMetadata(fileTransferId, ct),
                     UseVirusScan = reader.GetBoolean(reader.GetOrdinal("use_virus_scan"))
                 };
+                
+                EnrichLogs(fileTransfer);
             }
-            else
-            {
-                return null;
-            }
-        }
-        EnrichLogs(fileTransfer);
-        return fileTransfer;
+
+            return fileTransfer;
+        }, cancellationToken);
     }
 
     private static void EnrichLogs(FileTransferEntity fileTransferEntity)
@@ -124,8 +127,7 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
      * */
     private async Task<List<ActorFileTransferStatusEntity>> GetLatestRecipientFileTransferStatuses(Guid fileTransferId, CancellationToken cancellationToken)
     {
-        var fileTransferStatuses = new List<ActorFileTransferStatusEntity>();
-        await using (var command = dataSource.CreateCommand(
+        await using var command = dataSource.CreateCommand(
             @"
             SELECT afs.actor_id_fk, MAX(afs.actor_file_transfer_status_description_id_fk) as actor_file_transfer_status_description_id_fk, MAX(afs.actor_file_transfer_status_date) as actor_file_transfer_status_date, a.actor_external_id 
             FROM broker.file_transfer 
@@ -133,12 +135,16 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
             LEFT JOIN broker.actor a on a.actor_id_pk = afs.actor_id_fk 
             WHERE file_transfer_id_pk = @fileTransferId 
             GROUP BY afs.actor_id_fk, a.actor_external_id
-        "))
+        ");
+        
+        command.Parameters.AddWithValue("@fileTransferId", fileTransferId);
+        
+        return await commandExecutor.ExecuteWithRetry(async (ct) =>
         {
-            command.Parameters.AddWithValue("@fileTransferId", fileTransferId);
-            var commandText = command.CommandText;
-            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-            while (await reader.ReadAsync(cancellationToken))
+            var fileTransferStatuses = new List<ActorFileTransferStatusEntity>();
+            await using var reader = await command.ExecuteReaderAsync(ct);
+                
+            while (await reader.ReadAsync(ct))
             {
                 fileTransferStatuses.Add(new ActorFileTransferStatusEntity()
                 {
@@ -152,8 +158,9 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
                     }
                 });
             }
-        }
-        return fileTransferStatuses;
+
+            return fileTransferStatuses;
+        }, cancellationToken);
     }
 
     public async Task<Guid> AddFileTransfer(ResourceEntity resource, StorageProviderEntity storageProviderEntity, string fileName, string sendersFileTransferReference, string senderExternalId, List<string> recipientIds, DateTimeOffset expirationTime, Dictionary<string, string> propertyList, string? checksum, bool useVirusScan, CancellationToken cancellationToken = default)
@@ -171,6 +178,7 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
         {
             actorId = actor.ActorId;
         }
+            
         var fileTransferId = Guid.NewGuid();
         await using NpgsqlCommand command = dataSource.CreateCommand(
             "INSERT INTO broker.file_transfer (file_transfer_id_pk, resource_id, filename, checksum, file_transfer_size, external_file_transfer_reference, sender_actor_id_fk, created, storage_provider_id_fk, expiration_time, hangfire_job_id, use_virus_scan) " +
@@ -189,7 +197,7 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
         command.Parameters.AddWithValue("@expirationTime", expirationTime);
         command.Parameters.AddWithValue("@useVirusScan", useVirusScan);
 
-        await command.ExecuteNonQueryAsync(cancellationToken);
+        await commandExecutor.ExecuteWithRetry(command.ExecuteNonQueryAsync, cancellationToken);
 
         await SetMetadata(fileTransferId, propertyList, cancellationToken);
         return fileTransferId;
@@ -269,18 +277,19 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
         if (fileTransferSearch.FileTransferStatus.HasValue)
             command.Parameters.AddWithValue("@fileTransferStatus", (int)fileTransferSearch.FileTransferStatus);
 
-
-
-        var fileTransfers = new List<Guid>();
-        await using (var reader = await command.ExecuteReaderAsync(cancellationToken))
+        return await commandExecutor.ExecuteWithRetry(async (ct) =>
         {
-            while (await reader.ReadAsync(cancellationToken))
+            var fileTransfers = new List<Guid>();
+            
+            await using var reader = await command.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct))
             {
                 var fileTransferId = reader.GetGuid(0);
                 fileTransfers.Add(fileTransferId);
             }
-        }
-        return fileTransfers;
+            
+            return fileTransfers;
+        }, cancellationToken);
     }
 
     public async Task<List<Guid>> GetFileTransfersAssociatedWithActor(FileTransferSearchEntity fileTransferSearch, CancellationToken cancellationToken)
@@ -327,29 +336,30 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
 
         commandString = string.Format(commandString, statusCondition, dateCondition);
 
-        await using (var command = dataSource.CreateCommand(commandString))
-        {
-            command.Parameters.AddWithValue("@actorId", fileTransferSearch.Actor.ActorId);
-            command.Parameters.AddWithValue("@resourceId", fileTransferSearch.ResourceId);
-            command.Parameters.AddWithValue("@actorExternalId", fileTransferSearch.Actor.ActorExternalId);
-            if (fileTransferSearch.From.HasValue)
-                command.Parameters.AddWithValue("@From", fileTransferSearch.From);
-            if (fileTransferSearch.To.HasValue)
-                command.Parameters.AddWithValue("@To", fileTransferSearch.To);
-            if (fileTransferSearch.Status.HasValue)
-                command.Parameters.AddWithValue("@fileTransferStatus", (int)fileTransferSearch.Status);
+        await using var command = dataSource.CreateCommand(commandString);
+        command.Parameters.AddWithValue("@actorId", fileTransferSearch.Actor.ActorId);
+        command.Parameters.AddWithValue("@resourceId", fileTransferSearch.ResourceId);
+        command.Parameters.AddWithValue("@actorExternalId", fileTransferSearch.Actor.ActorExternalId);
+        if (fileTransferSearch.From.HasValue)
+            command.Parameters.AddWithValue("@From", fileTransferSearch.From);
+        if (fileTransferSearch.To.HasValue)
+            command.Parameters.AddWithValue("@To", fileTransferSearch.To);
+        if (fileTransferSearch.Status.HasValue)
+            command.Parameters.AddWithValue("@fileTransferStatus", (int)fileTransferSearch.Status);
 
+        return await commandExecutor.ExecuteWithRetry(async (ct) =>
+        {
             var files = new List<Guid>();
-            await using (var reader = await command.ExecuteReaderAsync(cancellationToken))
+            
+            await using var reader = await command.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct))
             {
-                while (await reader.ReadAsync(cancellationToken))
-                {
-                    var fileTransferId = reader.GetGuid(0);
-                    files.Add(fileTransferId);
-                }
+                var fileTransferId = reader.GetGuid(0);
+                files.Add(fileTransferId);
             }
+            
             return files;
-        }
+        }, cancellationToken);
     }
 
     public async Task<List<Guid>> GetFileTransfersForRecipientWithRecipientStatus(FileTransferSearchEntity fileTransferSearch, CancellationToken cancellationToken)
@@ -397,31 +407,33 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
 
         commandString = string.Format(commandString, statusCondition, dateCondition);
 
-        await using (var command = dataSource.CreateCommand(commandString))
+        await using var command = dataSource.CreateCommand(commandString);
+        command.Parameters.AddWithValue("@recipientId", fileTransferSearch.Actor.ActorId);
+        command.Parameters.AddWithValue("@resourceId", fileTransferSearch.ResourceId);
+        command.Parameters.AddWithValue("@recipientFileStatus", (int)fileTransferSearch.RecipientStatus);
+
+        if (fileTransferSearch.From.HasValue)
+            command.Parameters.AddWithValue("@from", fileTransferSearch.From);
+        if (fileTransferSearch.To.HasValue)
+            command.Parameters.AddWithValue("@to", fileTransferSearch.To);
+        if (fileTransferSearch.Status.HasValue)
+            command.Parameters.AddWithValue("@fileStatus", (int)fileTransferSearch.Status);
+
+        return await commandExecutor.ExecuteWithRetry(async (ct) =>
         {
-            command.Parameters.AddWithValue("@recipientId", fileTransferSearch.Actor.ActorId);
-            command.Parameters.AddWithValue("@resourceId", fileTransferSearch.ResourceId);
-            command.Parameters.AddWithValue("@recipientFileStatus", (int)fileTransferSearch.RecipientStatus);
-
-            if (fileTransferSearch.From.HasValue)
-                command.Parameters.AddWithValue("@from", fileTransferSearch.From);
-            if (fileTransferSearch.To.HasValue)
-                command.Parameters.AddWithValue("@to", fileTransferSearch.To);
-            if (fileTransferSearch.Status.HasValue)
-                command.Parameters.AddWithValue("@fileStatus", (int)fileTransferSearch.Status);
-
             var files = new List<Guid>();
-            await using (var reader = await command.ExecuteReaderAsync(cancellationToken))
+            
+            await using var reader = await command.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct))
             {
-                while (await reader.ReadAsync(cancellationToken))
-                {
-                    var fileTransferId = reader.GetGuid(0);
-                    files.Add(fileTransferId);
-                }
+                var fileTransferId = reader.GetGuid(0);
+                files.Add(fileTransferId);
             }
+            
             return files;
-        }
+        }, cancellationToken);
     }
+    
     public async Task SetStorageDetails(Guid fileTransferId, long storageProviderId, string fileLocation, long filesize, CancellationToken cancellationToken)
     {
         await using (var command = dataSource.CreateCommand(
@@ -436,26 +448,26 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
             command.Parameters.AddWithValue("@storageProviderId", storageProviderId);
             command.Parameters.AddWithValue("@fileLocation", fileLocation);
             command.Parameters.AddWithValue("@filesize", filesize);
-            await command.ExecuteNonQueryAsync(cancellationToken);
+            await commandExecutor.ExecuteWithRetry(command.ExecuteNonQueryAsync, cancellationToken);
         }
     }
 
     private async Task<Dictionary<string, string>> GetMetadata(Guid fileTransferId, CancellationToken cancellationToken)
     {
-        await using var command = dataSource.CreateCommand(
-            "SELECT * " +
-            "FROM broker.file_transfer_property " +
-            "WHERE file_transfer_id_fk = @fileTransferId");
-        command.Parameters.AddWithValue("@fileTransferId", fileTransferId);
-        var property = new Dictionary<string, string>();
-        await using (var reader = await command.ExecuteReaderAsync(cancellationToken))
+        await using var command = dataSource.CreateCommand("SELECT property_name, property_value FROM broker.file_transfer_property WHERE file_transfer_id_fk = @filetransferId");
+        command.Parameters.AddWithValue("@filetransferId", fileTransferId);
+        
+        return await commandExecutor.ExecuteWithRetry(async (ct) =>
         {
-            while (await reader.ReadAsync(cancellationToken))
+            var metadata = new Dictionary<string, string>();
+            await using var reader = await command.ExecuteReaderAsync(ct);
+                
+            while (await reader.ReadAsync(ct))
             {
-                property.Add(reader.GetString(reader.GetOrdinal("key")), reader.GetString(reader.GetOrdinal("value")));
+                metadata.Add(reader.GetString(reader.GetOrdinal("property_name")), reader.GetString(reader.GetOrdinal("property_value")));
             }
-        }
-        return property;
+            return metadata;
+        }, cancellationToken);
     }
 
     private async Task SetMetadata(Guid fileTransferId, Dictionary<string, string> property, CancellationToken cancellationToken)
@@ -503,7 +515,7 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
         {
             command.Parameters.AddWithValue("@fileTransferId", fileTransferId);
             command.Parameters.AddWithValue("@checksum", checksum);
-            command.ExecuteNonQuery();
+            await commandExecutor.ExecuteWithRetry(command.ExecuteNonQueryAsync, cancellationToken);
         }
     }
     public async Task SetFileTransferHangfireJobId(Guid fileTransferId, string hangfireJobId, CancellationToken cancellationToken)
@@ -516,7 +528,7 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
         {
             command.Parameters.AddWithValue("@fileTransferId", fileTransferId);
             command.Parameters.AddWithValue("@hangfireJobId", hangfireJobId is null ? DBNull.Value : hangfireJobId);
-            command.ExecuteNonQuery();
+            await commandExecutor.ExecuteWithRetry(command.ExecuteNonQueryAsync, cancellationToken);
         }
     }
 }

--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
@@ -454,7 +454,7 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
 
     private async Task<Dictionary<string, string>> GetMetadata(Guid fileTransferId, CancellationToken cancellationToken)
     {
-        await using var command = dataSource.CreateCommand("SELECT property_name, property_value FROM broker.file_transfer_property WHERE file_transfer_id_fk = @filetransferId");
+        await using var command = dataSource.CreateCommand("SELECT key, value FROM broker.file_transfer_property WHERE file_transfer_id_fk = @filetransferId");
         command.Parameters.AddWithValue("@filetransferId", fileTransferId);
         
         return await commandExecutor.ExecuteWithRetry(async (ct) =>
@@ -464,7 +464,7 @@ public class FileTransferRepository(NpgsqlDataSource dataSource, IActorRepositor
                 
             while (await reader.ReadAsync(ct))
             {
-                metadata.Add(reader.GetString(reader.GetOrdinal("property_name")), reader.GetString(reader.GetOrdinal("property_value")));
+                metadata.Add(reader.GetString(reader.GetOrdinal("key")), reader.GetString(reader.GetOrdinal("value")));
             }
             return metadata;
         }, cancellationToken);

--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferStatusRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferStatusRepository.cs
@@ -1,11 +1,12 @@
 ﻿using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Domain.Enums;
 using Altinn.Broker.Core.Repositories;
+using Altinn.Broker.Persistence.Helpers;
 
 using Npgsql;
 
 namespace Altinn.Broker.Persistence.Repositories;
-public class FileTransferStatusRepository(NpgsqlDataSource dataSource) : IFileTransferStatusRepository
+public class FileTransferStatusRepository(NpgsqlDataSource dataSource, ExecuteDBCommandWithRetries commandExecutor) : IFileTransferStatusRepository
 {
     public async Task InsertFileTransferStatus(Guid fileTransferId, FileTransferStatus status, string? detailedFileTransferStatus = null, CancellationToken cancellationToken = default)
     {
@@ -16,7 +17,8 @@ public class FileTransferStatusRepository(NpgsqlDataSource dataSource) : IFileTr
         command.Parameters.AddWithValue("@statusId", (int)status);
         command.Parameters.AddWithValue("@detailedFileTransferStatus", detailedFileTransferStatus is null ? DBNull.Value : detailedFileTransferStatus);
 
-        var fileTransferStatusId = await command.ExecuteScalarAsync(cancellationToken);
+        var fileTransferStatusId = await commandExecutor.ExecuteWithRetry(command.ExecuteScalarAsync, cancellationToken);
+            
         if (fileTransferStatusId == null)
         {
             throw new InvalidOperationException("No file_transfer_status_id_pk was returned after insert.");
@@ -30,10 +32,12 @@ public class FileTransferStatusRepository(NpgsqlDataSource dataSource) : IFileTr
             "FROM broker.file_transfer_status fis " +
             "WHERE fis.file_transfer_id_fk = @fileTransferId");
         command.Parameters.AddWithValue("@fileTransferId", fileTransferId);
-        var fileTransferStatuses = new List<FileTransferStatusEntity>();
-        await using (var reader = await command.ExecuteReaderAsync(cancellationToken))
+        
+        return await commandExecutor.ExecuteWithRetry(async (ct) =>
         {
-            while (await reader.ReadAsync(cancellationToken))
+            var fileTransferStatuses = new List<FileTransferStatusEntity>();
+            await using var reader = await command.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct))
             {
                 fileTransferStatuses.Add(new FileTransferStatusEntity()
                 {
@@ -43,8 +47,8 @@ public class FileTransferStatusRepository(NpgsqlDataSource dataSource) : IFileTr
                     DetailedStatus = reader.IsDBNull(reader.GetOrdinal("file_transfer_status_detailed_description")) ? null : reader.GetString(reader.GetOrdinal("file_transfer_status_detailed_description"))
                 });
             }
-        }
-        return fileTransferStatuses;
+            return fileTransferStatuses;
+        }, cancellationToken);
     }
 
     public async Task<List<FileTransferStatusEntity>> GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(FileTransferStatus statusFilter, DateTime minStatusDate, CancellationToken cancellationToken)
@@ -62,15 +66,14 @@ public class FileTransferStatusRepository(NpgsqlDataSource dataSource) : IFileTr
             )";
 
         await using var command = dataSource.CreateCommand(query);
-
         command.Parameters.AddWithValue("@statusFilter", (int)statusFilter);
         command.Parameters.AddWithValue("@minStatusDate", minStatusDate);
 
-        var fileTransferStatuses = new List<FileTransferStatusEntity>();
-
-        await using (var reader = await command.ExecuteReaderAsync(cancellationToken))
+        return await commandExecutor.ExecuteWithRetry(async (ct) =>
         {
-            while (await reader.ReadAsync(cancellationToken))
+            var fileTransferStatuses = new List<FileTransferStatusEntity>();
+            await using var reader = await command.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct))
             {
                 fileTransferStatuses.Add(new FileTransferStatusEntity()
                 {
@@ -82,8 +85,7 @@ public class FileTransferStatusRepository(NpgsqlDataSource dataSource) : IFileTr
                         : reader.GetString(reader.GetOrdinal("file_transfer_status_detailed_description"))
                 });
             }
-        }
-
-        return fileTransferStatuses;
+            return fileTransferStatuses;
+        }, cancellationToken);
     }
 }

--- a/src/Altinn.Broker.Persistence/Repositories/IdempotencyEventRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/IdempotencyEventRepository.cs
@@ -1,10 +1,11 @@
 ﻿using Altinn.Broker.Core.Repositories;
+using Altinn.Broker.Persistence.Helpers;
 
 using Npgsql;
 
 namespace Altinn.Broker.Persistence.Repositories;
 
-public class IdempotencyEventRepository(NpgsqlDataSource dataSource) : IIdempotencyEventRepository
+public class IdempotencyEventRepository(NpgsqlDataSource dataSource, ExecuteDBCommandWithRetries commandExecutor) : IIdempotencyEventRepository
 {
     public async Task AddIdempotencyEventAsync(string IdempotencyEventId, CancellationToken cancellationToken)
     {
@@ -14,6 +15,6 @@ public class IdempotencyEventRepository(NpgsqlDataSource dataSource) : IIdempote
         command.Parameters.AddWithValue("@idempotency_event_id_pk", IdempotencyEventId);
         command.Parameters.AddWithValue("@created", DateTime.UtcNow);
 
-        await command.ExecuteNonQueryAsync(cancellationToken);
+        await commandExecutor.ExecuteWithRetry(command.ExecuteNonQueryAsync, cancellationToken);
     }
 }

--- a/src/Altinn.Broker.Persistence/Repositories/PartyRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/PartyRepository.cs
@@ -1,10 +1,11 @@
 using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Repositories;
+using Altinn.Broker.Persistence.Helpers;
 
 using Npgsql;
 
 namespace Altinn.Broker.Persistence.Repositories;
-public class PartyRepository(NpgsqlDataSource dataSource) : IPartyRepository
+public class PartyRepository(NpgsqlDataSource dataSource, ExecuteDBCommandWithRetries commandExecutor) : IPartyRepository
 {
     public async Task<PartyEntity?> GetParty(string organizationId, CancellationToken cancellationToken)
     {
@@ -13,18 +14,21 @@ public class PartyRepository(NpgsqlDataSource dataSource) : IPartyRepository
             "WHERE organization_number_pk = @organizationId ");
         command.Parameters.AddWithValue("@organizationId", organizationId);
 
-        using NpgsqlDataReader reader = await command.ExecuteReaderAsync();
-        PartyEntity? partyData = null;
-        while (reader.Read())
+        return await commandExecutor.ExecuteWithRetry(async (ct) =>
         {
-            partyData = new PartyEntity
+            PartyEntity? partyData = null;
+            await using var reader = await command.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct))
             {
-                OrganizationNumber = reader.GetString(reader.GetOrdinal("organization_number_pk")),
-                PartyId = reader.GetString(reader.GetOrdinal("party_id")),
-                Created = reader.GetDateTime(reader.GetOrdinal("created"))
-            };
-        }
-        return partyData;
+                partyData = new PartyEntity
+                {
+                    OrganizationNumber = reader.GetString(reader.GetOrdinal("organization_number_pk")),
+                    PartyId = reader.GetString(reader.GetOrdinal("party_id")),
+                    Created = reader.GetDateTime(reader.GetOrdinal("created"))
+                };
+            }
+            return partyData;
+        }, cancellationToken);
     }
 
     public async Task InitializeParty(string organizationId, string partyId)
@@ -34,8 +38,8 @@ public class PartyRepository(NpgsqlDataSource dataSource) : IPartyRepository
             "VALUES (@organizationId, @partyId, NOW())");
         command.Parameters.AddWithValue("@organizationId", organizationId);
         command.Parameters.AddWithValue("@partyId", partyId);
-        var commandText = command.CommandText;
-        command.ExecuteNonQuery();
+        
+        await commandExecutor.ExecuteWithRetry(command.ExecuteNonQueryAsync);
     }
 }
 

--- a/src/Altinn.Broker.Persistence/Repositories/ServiceOwnerRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/ServiceOwnerRepository.cs
@@ -48,7 +48,7 @@ public class ServiceOwnerRepository(NpgsqlDataSource dataSource, ExecuteDBComman
                         Active = reader.GetBoolean(reader.GetOrdinal("active"))
                     };
 
-                    if (storageProvider.Active && !storageProviders.Any(sp => sp.Id == storageProvider.Id))
+                    if (!storageProviders.Any(sp => sp.Id == storageProvider.Id))
                     {
                         storageProviders.Add(storageProvider);
                     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We have experienced some occasional timeout exceptions when reading from stream with npgsql as well as some other seemingly transient exceptions. This PR adds a retry mechanism for transient npgsql exceptions and postgresexceptions to command executions in repositories. The retries are limited to 3.

The retry mechanism for transient npgsql exceptions was added to the command execution in repositories instead of on transactions because then the whole transaction doesn't have to rollback and be retried on one transient error. Also not all repository calls are used in a transaction with a retry policy.

## Related Issue(s)
- #719 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automatic retry handling for database operations to improve resilience against transient failures.

- **Refactor**
  - Updated all repositories to use a new retry mechanism for executing database commands, enhancing reliability without altering existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->