### PR TITLE
Fix flaky tests caused by failure to get distributed lock

### DIFF
--- a/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
@@ -113,6 +114,8 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
             {
                 services.UseMemoryStorage();
             });
+            services.RemoveAll<IRecurringJobManager>();
+            services.AddSingleton(new Mock<IRecurringJobManager>().Object);
             if (result.Outcome == OutcomeType.Failure)
             {
                 throw new InvalidOperationException("Hangfire could not be installed");


### PR DESCRIPTION
## Description
Our tests frequently fail with an error like:
`Hangfire.Storage.DistributedLockTimeoutException : Timeout expired. The timeout elapsed prior to obtaining a distributed lock on the 'lock:recurring-job:Update IP restrictions to apimIp and current EventGrid IPs' resource.`

We do not need Hangfire's recurring job manager, hence I replace it with a no-op mock.

## Related Issue(s)
- [#1053](https://github.com/Altinn/altinn-correspondence/issues/1053)

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by replacing the existing job manager service with a mocked version during test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->