### PR TITLE
Slacknotification to correct channel for stuck filetransfers

### DIFF
--- a/src/Altinn.Broker.Application/StuckFileTransfer/SlackStuckFileTransferNotifier.cs
+++ b/src/Altinn.Broker.Application/StuckFileTransfer/SlackStuckFileTransferNotifier.cs
@@ -1,23 +1,22 @@
 using Altinn.Broker.Core.Domain;
+using Altinn.Broker.Core.Options;
+
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 using Slack.Webhooks;
 
 namespace Altinn.Broker.Application;
-public class SlackStuckFileTransferNotifier
+public class SlackStuckFileTransferNotifier(
+    ILogger<SlackStuckFileTransferNotifier> logger, 
+    ISlackClient slackClient,
+    IHostEnvironment hostEnvironment,
+    SlackSettings slackSettings)
 {
-    private readonly ILogger<SlackStuckFileTransferNotifier> _logger;
-    private readonly ISlackClient _slackClient;
-    private const string TestChannel = "#test-varslinger";
-    private readonly IHostEnvironment _hostEnvironment;
-
-    public SlackStuckFileTransferNotifier(ILogger<SlackStuckFileTransferNotifier> logger, ISlackClient slackClient, IHostEnvironment hostEnvironment)
-    {
-        _logger = logger;
-        _slackClient = slackClient;
-        _hostEnvironment = hostEnvironment;
-    }
+    private readonly ILogger<SlackStuckFileTransferNotifier> _logger = logger;
+    private readonly ISlackClient _slackClient = slackClient;
+    private readonly IHostEnvironment _hostEnvironment = hostEnvironment;
+    private string Channel => slackSettings.NotificationChannel;
 
     public async Task<bool> NotifyFileStuckWithStatus(
         FileTransferStatusEntity fileTransferStatus)
@@ -52,7 +51,7 @@ public class SlackStuckFileTransferNotifier
         var slackMessage = new SlackMessage
         {
             Text = message,
-            Channel = TestChannel,
+            Channel = Channel,
         };
         return await _slackClient.PostAsync(slackMessage);
     }

--- a/tests/Altinn.Broker.Tests/StuckFileTransferHandlerTests.cs
+++ b/tests/Altinn.Broker.Tests/StuckFileTransferHandlerTests.cs
@@ -1,5 +1,6 @@
 using Altinn.Broker.Application;
 using Altinn.Broker.Core.Domain;
+using Altinn.Broker.Core.Options;
 using Altinn.Broker.Core.Repositories;
 
 using Microsoft.Extensions.Hosting;
@@ -25,7 +26,8 @@ public class StuckFileTransferHandlerTests
         var notifierLogger = new Mock<ILogger<SlackStuckFileTransferNotifier>>();
         var hostEnvironment = new Mock<IHostEnvironment>();
         hostEnvironment.SetupGet(e => e.EnvironmentName).Returns("Test");
-        var slackNotifier = new SlackStuckFileTransferNotifier(notifierLogger.Object, slackClient.Object, hostEnvironment.Object);
+        var slackSettings = new SlackSettings(hostEnvironment.Object);
+        var slackNotifier = new SlackStuckFileTransferNotifier(notifierLogger.Object, slackClient.Object, hostEnvironment.Object, slackSettings);
         var handler = new StuckFileTransferHandler(fileTransferStatusRepository.Object, slackNotifier, monitorLogger.Object);
         var cancellationToken = new CancellationToken();
         fileTransferStatusRepository.Setup(r => r
@@ -54,7 +56,8 @@ public class StuckFileTransferHandlerTests
         var notifierLogger = new Mock<ILogger<SlackStuckFileTransferNotifier>>();
         var hostEnvironment = new Mock<IHostEnvironment>();
         hostEnvironment.SetupGet(e => e.EnvironmentName).Returns("Test");
-        var slackNotifier = new SlackStuckFileTransferNotifier(notifierLogger.Object, slackClient.Object, hostEnvironment.Object);
+        var slackSettings = new SlackSettings(hostEnvironment.Object);
+        var slackNotifier = new SlackStuckFileTransferNotifier(notifierLogger.Object, slackClient.Object, hostEnvironment.Object, slackSettings);
         var handler = new StuckFileTransferHandler(fileTransferStatusRepository.Object, slackNotifier, monitorLogger.Object);
         var cancellationToken = new CancellationToken();
         var fileTransferId = Guid.NewGuid();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Slacknotifications for stuck filetransfers are currently always sendt to the test-varslinger channel. This PR makes the notification get sendt to mf-varsling-ciritical for the production environment.

## Related Issue(s)
- #738 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved how Slack notification channels are configured for stuck file transfer alerts, allowing dynamic channel selection instead of using a fixed test channel.

- **Tests**
  - Updated tests to support the new configuration approach for Slack notification channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->