### PR TITLE
polly retries for network calls

### DIFF
--- a/src/Altinn.Broker.Application/Altinn.Broker.Application.csproj
+++ b/src/Altinn.Broker.Application/Altinn.Broker.Application.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="Hangfire.Core" Version="1.8.20" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Slack.Webhooks" Version="1.1.5" />

--- a/src/Altinn.Broker.Core/Altinn.Broker.Core.csproj
+++ b/src/Altinn.Broker.Core/Altinn.Broker.Core.csproj
@@ -9,12 +9,13 @@
     <PackageReference Include="Azure.ResourceManager.Network" Version="1.11.0" />
     <PackageReference Include="Hangfire.Core" Version="1.8.20" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.12" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.6" />
     <PackageReference Include="Npgsql" Version="9.0.3" />
-    <PackageReference Include="Polly" Version="8.5.2" />
+    <PackageReference Include="Polly" Version="8.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Altinn.Broker.Common\Altinn.Broker.Common.csproj" />

--- a/src/Altinn.Broker.Core/Helpers/HttpClientBuilderExtensions.cs
+++ b/src/Altinn.Broker.Core/Helpers/HttpClientBuilderExtensions.cs
@@ -24,7 +24,7 @@ public static class HttpClientBuilderExtensions
     }
 
     /// <summary>
-    /// A standard retry policy for HTTP operations; 3 retry attempts with exponential backoff (50ms, 100ms, 200ms)
+    /// A standard retry policy for HTTP operations; 3 retry attempts with exponential backoff (100ms, 200ms, 400ms)
     /// </summary>
     public static IAsyncPolicy<HttpResponseMessage> GetStandardRetryPolicy(ILogger logger)
     {

--- a/src/Altinn.Broker.Core/Helpers/HttpClientBuilderExtensions.cs
+++ b/src/Altinn.Broker.Core/Helpers/HttpClientBuilderExtensions.cs
@@ -1,0 +1,72 @@
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Polly;
+
+namespace Altinn.Broker.Core.Helpers;
+
+/// <summary>
+/// Extension methods for configuring HttpClient with retry policies
+/// </summary>
+public static class HttpClientBuilderExtensions
+{
+    /// <summary>
+    /// Adds standard retry policy to HttpClient
+    /// </summary>
+    public static IHttpClientBuilder AddStandardRetryPolicy(this IHttpClientBuilder builder)
+    {
+        return builder.AddPolicyHandler((services, request) =>
+        {
+            var loggerFactory = services.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger("HttpRetryPolicies");
+            return GetStandardRetryPolicy(logger);
+        });
+    }
+
+    /// <summary>
+    /// A standard retry policy for HTTP operations; 3 retry attempts with exponential backoff (50ms, 100ms, 200ms)
+    /// </summary>
+    public static IAsyncPolicy<HttpResponseMessage> GetStandardRetryPolicy(ILogger logger)
+    {
+        return Policy
+            .HandleResult<HttpResponseMessage>(r => !r.IsSuccessStatusCode && IsTransientFailure(r.StatusCode))
+            .Or<HttpRequestException>()
+            .Or<TaskCanceledException>()
+            .WaitAndRetryAsync(
+                retryCount: 3,
+                sleepDurationProvider: retryAttempt => TimeSpan.FromMilliseconds(Math.Pow(2, retryAttempt) * 50),
+                onRetry: (outcome, timespan, retryCount, context) =>
+                {
+                    var exception = outcome.Exception;
+                    var result = outcome.Result;
+                    
+                    if (exception != null)
+                    {
+                        logger.LogWarning("HTTP request attempt {RetryCount} failed with exception: {Exception}. Retrying in {Delay}ms", 
+                            retryCount, exception.Message, timespan.TotalMilliseconds);
+                    }
+                    else if (result != null)
+                    {
+                        logger.LogWarning("HTTP request attempt {RetryCount} failed with status {StatusCode}. Retrying in {Delay}ms", 
+                            retryCount, result.StatusCode, timespan.TotalMilliseconds);
+                    }
+                });
+    }
+
+    /// <summary>
+    /// Determines if an HTTP status code indicates a transient failure
+    /// </summary>
+    private static bool IsTransientFailure(HttpStatusCode statusCode)
+    {
+        return statusCode switch
+        {
+            HttpStatusCode.RequestTimeout => true,
+            HttpStatusCode.TooManyRequests => true,
+            HttpStatusCode.InternalServerError => true,
+            HttpStatusCode.BadGateway => true,
+            HttpStatusCode.ServiceUnavailable => true,
+            HttpStatusCode.GatewayTimeout => true,
+            _ => false
+        };
+    }
+} 

--- a/tests/Altinn.Broker.Tests/HttpRetryPolicyTests.cs
+++ b/tests/Altinn.Broker.Tests/HttpRetryPolicyTests.cs
@@ -1,0 +1,239 @@
+using System.Net;
+using Altinn.Broker.Core.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Altinn.Broker.Tests;
+
+public class HttpRetryPolicyTests
+{
+    private readonly Mock<ILogger> _mockLogger;
+    private readonly Mock<HttpMessageHandler> _mockHttpMessageHandler;
+    private readonly HttpClient _httpClient;
+
+    public HttpRetryPolicyTests()
+    {
+        _mockLogger = new Mock<ILogger>();
+        _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        _httpClient = new HttpClient(_mockHttpMessageHandler.Object)
+        {
+            BaseAddress = new Uri("https://example.com")
+        };
+    }
+
+    [Fact]
+    public async Task StandardRetryPolicy_ShouldRetryOnTransientFailures()
+    {
+        // Arrange
+        var policy = HttpClientBuilderExtensions.GetStandardRetryPolicy(_mockLogger.Object);
+        var callCount = 0;
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() =>
+            {
+                callCount++;
+                if (callCount < 3)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+        // Act
+        var result = await policy.ExecuteAsync(async () =>
+        {
+            return await _httpClient.GetAsync("/test");
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(3, callCount);
+        
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task StandardRetryPolicy_ShouldFailAfterMaxRetries()
+    {
+        // Arrange
+        var policy = HttpClientBuilderExtensions.GetStandardRetryPolicy(_mockLogger.Object);
+        var callCount = 0;
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() =>
+            {
+                callCount++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            });
+
+        // Act
+        var result = await policy.ExecuteAsync(async () =>
+        {
+            return await _httpClient.GetAsync("/test");
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, result.StatusCode);
+        Assert.Equal(4, callCount);
+    }
+
+    [Fact]
+    public async Task StandardRetryPolicy_ShouldNotRetryOnNonTransientFailures()
+    {
+        // Arrange
+        var policy = HttpClientBuilderExtensions.GetStandardRetryPolicy(_mockLogger.Object);
+        var callCount = 0;
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() =>
+            {
+                callCount++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)); // Non-transient failure
+            });
+
+        // Act
+        var result = await policy.ExecuteAsync(async () =>
+        {
+            return await _httpClient.GetAsync("/test");
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
+        Assert.Equal(1, callCount);
+        
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.RequestTimeout)]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    public async Task StandardRetryPolicy_ShouldRetryOnSpecificTransientFailures(HttpStatusCode statusCode)
+    {
+        // Arrange
+        var policy = HttpClientBuilderExtensions.GetStandardRetryPolicy(_mockLogger.Object);
+        var callCount = 0;
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() =>
+            {
+                callCount++;
+                if (callCount < 2)
+                {
+                    return Task.FromResult(new HttpResponseMessage(statusCode));
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+        // Act
+        var result = await policy.ExecuteAsync(async () =>
+        {
+            return await _httpClient.GetAsync("/test");
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(2, callCount);
+    }
+
+    [Fact]
+    public async Task StandardRetryPolicy_ShouldRetryOnHttpRequestException()
+    {
+        // Arrange
+        var policy = HttpClientBuilderExtensions.GetStandardRetryPolicy(_mockLogger.Object);
+        var callCount = 0;
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() =>
+            {
+                callCount++;
+                if (callCount < 2)
+                {
+                    throw new HttpRequestException("Network error");
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+        // Act
+        var result = await policy.ExecuteAsync(async () =>
+        {
+            return await _httpClient.GetAsync("/test");
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(2, callCount);
+    }
+
+    [Fact]
+    public async Task StandardRetryPolicy_ShouldRetryOnTaskCanceledException()
+    {
+        // Arrange
+        var policy = HttpClientBuilderExtensions.GetStandardRetryPolicy(_mockLogger.Object);
+        var callCount = 0;
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() =>
+            {
+                callCount++;
+                if (callCount < 2)
+                {
+                    throw new TaskCanceledException("Request timeout");
+                }
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+        // Act
+        var result = await policy.ExecuteAsync(async () =>
+        {
+            return await _httpClient.GetAsync("/test");
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(2, callCount);
+    }
+} 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Httpclient calls might occationaly fail from transient issues. This PR adds a extension method to httpClientBuilder which adds a retry policy for transient failures. Currently it is set to retry up to 3 times with a backoff (100ms, 200ms, 400ms). The httpClients in the integration project are registered to use the retrypolicy in the dependencyInjection.

## Related Issue(s)
- [#700](https://github.com/Altinn/altinn-correspondence/issues/700)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a standard retry policy for HTTP clients to improve resilience against transient errors.
  - Enhanced Slack integration to use an HTTP client with retry capabilities.

- **Bug Fixes**
  - Improved handling of transient HTTP and network errors by automatically retrying failed requests.

- **Tests**
  - Added comprehensive tests to verify the behavior of the new HTTP retry policy.

- **Chores**
  - Updated several dependency versions for improved stability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->