### PR TITLE
Test FileTransfer stuck

### DIFF
--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -380,5 +380,57 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
         );
     }
 
+    /// <summary>
+    /// Test endpoint to verify Slack notification for stuck file transfers
+    /// </summary>
+    /// <remarks>
+    /// This endpoint is for testing purposes only and should be removed in production.
+    /// It triggers a test Slack notification to verify the notification system is working.
+    /// </remarks>
+    /// <response code="200">Test notification sent successfully</response>
+    /// <response code="500">Failed to send test notification</response>
+    [HttpPost]
+    [Route("test-slack-notification")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    // [Authorize(Policy = AuthorizationConstants.Sender)] // Temporarily disabled for testing
+    public async Task<ActionResult> TestSlackNotification(
+        [FromServices] SlackStuckFileTransferNotifier slackNotifier,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Testing Slack notification for stuck file transfers");
+        
+        try
+        {
+            // Create a test FileTransferStatusEntity
+            var testStatus = new FileTransferStatusEntity
+            {
+                FileTransferId = Guid.NewGuid(),
+                Status = FileTransferStatus.UploadProcessing,
+                Date = DateTime.UtcNow.AddMinutes(-20), // Simulate a file stuck for 20 minutes
+                DetailedStatus = "Test notification - file stuck in UploadProcessing"
+            };
+            
+            var success = await slackNotifier.NotifyFileStuckWithStatus(testStatus);
+            
+            if (success)
+            {
+                logger.LogInformation("Test Slack notification sent successfully");
+                return Ok(new { message = "Test notification sent successfully", fileTransferId = testStatus.FileTransferId });
+            }
+            else
+            {
+                logger.LogError("Failed to send test Slack notification");
+                return StatusCode(500, new { message = "Failed to send test notification" });
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Exception occurred while sending test Slack notification");
+            return StatusCode(500, new { message = "Exception occurred while sending test notification", error = ex.Message });
+        }
+    }
+
     private ObjectResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);
 }

--- a/src/Altinn.Broker.API/Controllers/TestController.cs
+++ b/src/Altinn.Broker.API/Controllers/TestController.cs
@@ -1,0 +1,62 @@
+using Altinn.Broker.Application;
+using Altinn.Broker.Core.Domain;
+using Altinn.Broker.Core.Domain.Enums;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.Broker.API.Controllers;
+
+[ApiController]
+[Route("test")]
+public class TestController(ILogger<TestController> logger) : Controller
+{
+    /// <summary>
+    /// Test endpoint to verify Slack notification for stuck file transfers
+    /// </summary>
+    /// <remarks>
+    /// This endpoint is for testing purposes only and should be removed in production.
+    /// It triggers a test Slack notification to verify the notification system is working.
+    /// </remarks>
+    /// <response code="200">Test notification sent successfully</response>
+    /// <response code="500">Failed to send test notification</response>
+    [HttpPost]
+    [Route("slack-notification")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> TestSlackNotification(
+        [FromServices] SlackStuckFileTransferNotifier slackNotifier,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Testing Slack notification for stuck file transfers");
+        
+        try
+        {
+            // Create a test FileTransferStatusEntity
+            var testStatus = new FileTransferStatusEntity
+            {
+                FileTransferId = Guid.NewGuid(),
+                Status = FileTransferStatus.UploadProcessing,
+                Date = DateTime.UtcNow.AddMinutes(-20), // Simulate a file stuck for 20 minutes
+                DetailedStatus = "Test notification - file stuck in UploadProcessing"
+            };
+            
+            var success = await slackNotifier.NotifyFileStuckWithStatus(testStatus);
+            
+            if (success)
+            {
+                logger.LogInformation("Test Slack notification sent successfully");
+                return Ok(new { message = "Test notification sent successfully", fileTransferId = testStatus.FileTransferId });
+            }
+            else
+            {
+                logger.LogError("Failed to send test Slack notification");
+                return StatusCode(500, new { message = "Failed to send test notification" });
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Exception occurred while sending test Slack notification");
+            return StatusCode(500, new { message = "Exception occurred while sending test notification", error = ex.Message });
+        }
+    }
+} 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #740 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint for testing Slack notifications related to stuck file transfers. This allows users to simulate and verify notification delivery for troubleshooting purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->