### PR TITLE
Slack exceptions in app insights

### DIFF
--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -17,7 +17,6 @@ using Altinn.Broker.Enums;
 using Altinn.Broker.Helpers;
 using Altinn.Broker.Mappers;
 using Altinn.Broker.Models;
-using Hangfire;
 
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -379,13 +378,6 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
             (_) => Ok(null),
             Problem
         );
-    }
-
-    [HttpGet("throw")]
-    [AllowAnonymous]
-    public IActionResult ThrowTestException()
-    {
-        throw new Exception("Dette er en test-exception fra /filetransfer/throw-endepunktet for å teste logging og Slack-varsling.");
     }
 
     [HttpGet("test-hangfire-fail")]

--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -380,5 +380,12 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
         );
     }
 
+    [HttpGet("throw")]
+    [AllowAnonymous]
+    public IActionResult ThrowTestException()
+    {
+        throw new Exception("Dette er en test-exception fra /filetransfer/throw-endepunktet for å teste logging og Slack-varsling.");
+    }
+
     private ObjectResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);
 }

--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -379,5 +379,6 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
             Problem
         );
     }
+    
     private ObjectResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);
 }

--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -17,6 +17,7 @@ using Altinn.Broker.Enums;
 using Altinn.Broker.Helpers;
 using Altinn.Broker.Mappers;
 using Altinn.Broker.Models;
+using Hangfire;
 
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -385,6 +386,20 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
     public IActionResult ThrowTestException()
     {
         throw new Exception("Dette er en test-exception fra /filetransfer/throw-endepunktet for å teste logging og Slack-varsling.");
+    }
+
+    [HttpGet("test-hangfire-fail")]
+    [AllowAnonymous]
+    public IActionResult TriggerFailingHangfireJob([FromServices] IBackgroundJobClient backgroundJobClient)
+    {
+        backgroundJobClient.Enqueue(() => FileTransferController.FailJob());
+        return Accepted("Hangfire test-jobb som feiler er trigget.");
+    }
+
+    [NonAction]
+    public static void FailJob()
+    {
+        throw new Exception("Dette er en test-exception fra en Hangfire-jobb for å teste logging og Slack-varsling.");
     }
 
     private ObjectResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);

--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -379,20 +379,5 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
             Problem
         );
     }
-
-    [HttpGet("test-hangfire-fail")]
-    [AllowAnonymous]
-    public IActionResult TriggerFailingHangfireJob([FromServices] IBackgroundJobClient backgroundJobClient)
-    {
-        backgroundJobClient.Enqueue(() => FileTransferController.FailJob());
-        return Accepted("Hangfire test-jobb som feiler er trigget.");
-    }
-
-    [NonAction]
-    public static void FailJob()
-    {
-        throw new Exception("Dette er en test-exception fra en Hangfire-jobb for å teste logging og Slack-varsling.");
-    }
-
     private ObjectResult Problem(Error error) => Problem(detail: error.Message, statusCode: (int)error.StatusCode);
 }

--- a/src/Altinn.Broker.API/Controllers/HealthController.cs
+++ b/src/Altinn.Broker.API/Controllers/HealthController.cs
@@ -30,4 +30,10 @@ public class HealthController(NpgsqlDataSource databaseConnectionProvider) : Con
 
         return Ok("Environment properly configured");
     }
+
+    [HttpGet("throw")]
+    public IActionResult ThrowTestException()
+    {
+        throw new Exception("Dette er en test-exception fra /health/throw-endepunktet for å teste logging og Slack-varsling.");
+    }
 }

--- a/src/Altinn.Broker.API/Controllers/HealthController.cs
+++ b/src/Altinn.Broker.API/Controllers/HealthController.cs
@@ -30,10 +30,4 @@ public class HealthController(NpgsqlDataSource databaseConnectionProvider) : Con
 
         return Ok("Environment properly configured");
     }
-
-    [HttpGet("throw")]
-    public IActionResult ThrowTestException()
-    {
-        throw new Exception("Dette er en test-exception fra /health/throw-endepunktet for å teste logging og Slack-varsling.");
-    }
 }

--- a/src/Altinn.Broker.Integrations/Slack/SlackExceptionNotificationHandler.cs
+++ b/src/Altinn.Broker.Integrations/Slack/SlackExceptionNotificationHandler.cs
@@ -20,7 +20,6 @@ public class SlackExceptionNotificationHandler : IExceptionHandler
     private readonly IProblemDetailsService _problemDetailsService;
     private readonly IHostEnvironment _hostEnvironment;
     private readonly SlackSettings _slackSettings;
-    private string Channel => _slackSettings.NotificationChannel;
 
     public SlackExceptionNotificationHandler(
         ILogger<SlackExceptionNotificationHandler> logger,
@@ -45,11 +44,23 @@ public class SlackExceptionNotificationHandler : IExceptionHandler
 
         _logger.LogError(
             exception,
-            null);
+            "Unhandled exception occurred. Type: {ExceptionType}, Message: {Message}, Path: {Path}, Environment: {Environment}, System: {System}, StackTrace: {StackTrace}, ExceptionSource: {ExceptionSource}, ExceptionMessage: {ExceptionMessage}, SentToSlack: {SentToSlack}, SlackMessage: {SlackMessage}",
+            exception.GetType().Name,
+            exception.Message,
+            httpContext.Request.Path,
+            _hostEnvironment.EnvironmentName,
+            "Broker",
+            exception.StackTrace ?? "No stack trace available",
+            "HTTP",
+            exception.Message,
+            true, // Slack notification attempted
+            exceptionMessage
+        );
 
         try
         {
             await SendSlackNotificationWithMessage(exceptionMessage);
+
             var statusCode = HttpStatusCode.InternalServerError;
             var problemDetails = new ProblemDetails
             {
@@ -74,7 +85,17 @@ public class SlackExceptionNotificationHandler : IExceptionHandler
         {
             _logger.LogError(
                 slackEx,
-                null);
+                "Failed to send Slack notification. OriginalExceptionType: {OriginalExceptionType}, SlackExceptionType: {SlackExceptionType}, Environment: {Environment}, System: {System}, StackTrace: {StackTrace}, ExceptionSource: {ExceptionSource}, ExceptionMessage: {ExceptionMessage}, SentToSlack: {SentToSlack}, SlackMessage: {SlackMessage}",
+                exception.GetType().Name,
+                slackEx.GetType().Name,
+                _hostEnvironment.EnvironmentName,
+                "Broker",
+                slackEx.StackTrace ?? "No stack trace available",
+                "SlackNotification",
+                slackEx.Message,
+                false, // Slack notification failed
+                exceptionMessage
+            );
             return true;
         }
     }
@@ -92,19 +113,43 @@ public class SlackExceptionNotificationHandler : IExceptionHandler
 
         _logger.LogError(
             exception,
-            "Job {JobId} failed on retry {RetryCount}", jobId, retryCount);
+            "Background job failed. JobId: {JobId}, JobName: {JobName}, RetryCount: {RetryCount}, ExceptionType: {ExceptionType}, Environment: {Environment}, System: {System}, StackTrace: {StackTrace}, ExceptionSource: {ExceptionSource}, ExceptionMessage: {ExceptionMessage}, SentToSlack: {SentToSlack}, SlackMessage: {SlackMessage}",
+            jobId,
+            jobName,
+            retryCount,
+            exception.GetType().Name,
+            _hostEnvironment.EnvironmentName,
+            "Broker",
+            exception.StackTrace ?? "No stack trace available",
+            "BackgroundJob",
+            exception.Message,
+            true, // Slack notification attempted
+            exceptionMessage
+        );
 
         try
         {
             await SendSlackNotificationWithMessage(exceptionMessage);
-
             return true;
         }
         catch (Exception ex)
         {
             _logger.LogError(
                 ex,
-                null);
+                "Failed to send Slack notification for background job. OriginalExceptionType: {OriginalExceptionType}, SlackExceptionType: {SlackExceptionType}, JobId: {JobId}, JobName: {JobName}, RetryCount: {RetryCount}, Environment: {Environment}, System: {System}, StackTrace: {StackTrace}, ExceptionSource: {ExceptionSource}, ExceptionMessage: {ExceptionMessage}, SentToSlack: {SentToSlack}, SlackMessage: {SlackMessage}",
+                exception.GetType().Name,
+                ex.GetType().Name,
+                jobId,
+                jobName,
+                retryCount,
+                _hostEnvironment.EnvironmentName,
+                "Broker",
+                ex.StackTrace ?? "No stack trace available",
+                "SlackNotification",
+                ex.Message,
+                false, // Slack notification failed
+                exceptionMessage
+            );
             return false;
         }
     }
@@ -142,7 +187,7 @@ public class SlackExceptionNotificationHandler : IExceptionHandler
         var slackMessage = new SlackMessage
         {
             Text = message,
-            Channel = Channel
+            Channel = _slackSettings.NotificationChannel
         };
         await _slackClient.PostAsync(slackMessage);
     }

--- a/src/Altinn.Broker.Integrations/Slack/SlackExceptionNotificationHandler.cs
+++ b/src/Altinn.Broker.Integrations/Slack/SlackExceptionNotificationHandler.cs
@@ -40,14 +40,15 @@ public class SlackExceptionNotificationHandler : IExceptionHandler
         Exception exception,
         CancellationToken cancellationToken)
     {
-        var exceptionMessage = FormatExceptionMessage(exception, httpContext);
+        var sanitizedPath = httpContext.Request.Path.ToString().Replace("\r", "").Replace("\n", "");
+        var exceptionMessage = FormatExceptionMessage(exception, sanitizedPath);
 
         _logger.LogError(
             exception,
             "Unhandled exception occurred. Type: {ExceptionType}, Message: {Message}, Path: {Path}, Environment: {Environment}, System: {System}, StackTrace: {StackTrace}, ExceptionSource: {ExceptionSource}, ExceptionMessage: {ExceptionMessage}, SentToSlack: {SentToSlack}, SlackMessage: {SlackMessage}",
             exception.GetType().Name,
             exception.Message,
-            httpContext.Request.Path,
+            sanitizedPath,
             _hostEnvironment.EnvironmentName,
             "Broker",
             exception.StackTrace ?? "No stack trace available",
@@ -154,14 +155,14 @@ public class SlackExceptionNotificationHandler : IExceptionHandler
         }
     }
 
-    private string FormatExceptionMessage(Exception exception, HttpContext context)
+    private string FormatExceptionMessage(Exception exception, string sanitizedPath)
     {
         return $":warning: *Unhandled Exception*\n" +
                $"*Environment:* {_hostEnvironment.EnvironmentName}\n" +
                $"*System:* Broker\n" +
                $"*Type:* {exception.GetType().Name}\n" +
                $"*Message:* {exception.Message}\n" +
-               $"*Path:* {context.Request.Path}\n" +
+               $"*Path:* {sanitizedPath}\n" +
                $"*Time:* {DateTime.UtcNow:u}\n" +
                $"*Stacktrace:* \n{exception.StackTrace}";
     }


### PR DESCRIPTION
## Description
Reintroducing the functionality that all exceptions that are posted to slack also is saved in app insights.

## Related Issue(s)
- #757 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced error logging and message formatting for Slack exception notifications, providing more detailed and structured information in logs.
  * Improved sanitization of HTTP request paths in error messages for better readability and security.

* **Refactor**
  * Internal adjustments to how Slack notification channels are referenced and how exception messages are formatted. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->