### PR TITLE
Handle file expiry edge case

### DIFF
--- a/src/Altinn.Broker.Application/PurgeFileTransfer/PurgeFileTransferHandler.cs
+++ b/src/Altinn.Broker.Application/PurgeFileTransfer/PurgeFileTransferHandler.cs
@@ -28,6 +28,14 @@ public class PurgeFileTransferHandler(IFileTransferRepository fileTransferReposi
         {
             logger.LogInformation("FileTransfer has already been set to purged");
         }
+        if (
+            fileTransfer.FileTransferStatusEntity.Status == Core.Domain.Enums.FileTransferStatus.AllConfirmedDownloaded 
+            && request.PurgeTrigger == PurgeTrigger.FileTransferExpiry
+            && resource!.PurgeFileTransferAfterAllRecipientsConfirmed)
+        {
+            logger.LogInformation("File transfer will be purged as part of the PurgeFileTransferAfterAllRecipientsConfirmed process.");
+            return Task.CompletedTask;
+        }
         await brokerStorageService.DeleteFile(serviceOwner, fileTransfer, cancellationToken); // This must be idempotent - i.e not fail on file not existing
         if (request.PurgeTrigger != PurgeTrigger.MalwareScanFailed)
         {

--- a/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -100,6 +100,10 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                     Created = DateTime.UtcNow,
                     ServiceOwnerId = $"0192:991825827",
                     OrganizationNumber = "991825827",
+                    MaxFileTransferSize = 1000000,
+                    FileTransferTimeToLive = TimeSpan.FromHours(48),
+                    PurgeFileTransferAfterAllRecipientsConfirmed = true,
+                    PurgeFileTransferGracePeriod = TimeSpan.FromHours(24)
                 });
             services.AddSingleton(altinnResourceRepository.Object);
 


### PR DESCRIPTION
## Description
Handle edge case where a file is downloaded right before its expiry, but where a grace period should still be applied.

## Related Issue(s)
- #763 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of file transfers with a purge grace period, ensuring files are not deleted prematurely when specific conditions are met.

* **Tests**
  * Added and updated tests to verify correct file transfer purge behavior for resources with a grace period and confirmation requirements.

* **Chores**
  * Enhanced test setup with additional resource properties to support new test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->