### PR TITLE
Fix/ignore duplicate malwarescanresults

### DIFF
--- a/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
+++ b/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
@@ -53,7 +53,12 @@ public class MalwareScanningResultHandler(
 
         return await TransactionWithRetriesPolicy.Execute(async (cancellationToken) =>
         {
-            await idempotencyEventRepository.AddIdempotencyEventAsync($"{fileTransferId}_{data.ETag}", cancellationToken);
+            var isFirstDelivery = await idempotencyEventRepository.TryAddIdempotencyEventAsync($"{fileTransferId}_{data.ETag}", cancellationToken);
+            if (!isFirstDelivery)
+            {
+                logger.LogInformation("Ignoring duplicate malware scan result for {fileTransferId} with ETag {etag}", fileTransferId, data.ETag);
+                return Task.CompletedTask;
+            }
             if (data.ScanResultType.Equals("No threats found", StringComparison.InvariantCultureIgnoreCase))
             {
                 logger.LogInformation("Non-malicious result for {fileTransferId} with result type {scanResultType}", fileTransferId, data.ScanResultType);

--- a/src/Altinn.Broker.Core/Repositories/IIdempotencyEventRepository.cs
+++ b/src/Altinn.Broker.Core/Repositories/IIdempotencyEventRepository.cs
@@ -3,4 +3,5 @@
 public interface IIdempotencyEventRepository
 {
     Task AddIdempotencyEventAsync(string id, CancellationToken cancellationToken);
+    Task<bool> TryAddIdempotencyEventAsync(string id, CancellationToken cancellationToken);
 }

--- a/tests/Altinn.Broker.Tests/MalwareScanResultControllerTests.cs
+++ b/tests/Altinn.Broker.Tests/MalwareScanResultControllerTests.cs
@@ -77,6 +77,22 @@ public class MalwareScanResultControllerTests : IClassFixture<CustomWebApplicati
     }
 
     [Fact]
+    public async Task MalwareScanDuplicateEvent_ThrowsNoException()
+    {
+        // Arrange
+        var fileTransferId = await UploadAndCheckFileTransfer();
+        var jsonBody = GetMalwareScanResultJson("Data/MalwareScanResult_NoThreatFound.json", fileTransferId);
+
+        // Act
+        var first = await SendMalvareScanResult(jsonBody, shouldSucceed: true);
+        var second = await SendMalvareScanResult(jsonBody, shouldSucceed: true);
+
+        //Assert
+        Assert.True(first.IsSuccessStatusCode);
+        Assert.True(second.IsSuccessStatusCode);
+    }
+
+    [Fact]
     public async Task MalwareScanWebhookSubscription_OK()
     {
         // Webhook


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Duplicate malware scan results are occasionally retrieved from azure events. They are not processed twice because of the idempotencyEventRepository but duplicates do currently lead to an exception and a 500 response to the webhook. Azure events are at-least-once on a best effort basis (see [Azure event: delivery and retry](https://learn.microsoft.com/nb-no/azure/event-grid/delivery-and-retry)) so we should expect occational duplicates. Azure should retry on 500 responses so duplicates may currently lead to several exceptions because of the retries and not just one.

This PR handles duplicates by logging and ignoring them with a 200 response. This is done because the malwarescan result has already been received and processed. This prevents exceptions from being thrown when azure sends a malwarescan result twice for whatever reason.

## Related Issue(s)
- #772 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
