### PR TITLE
Fix Maskinporten systemuser token

### DIFF
--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -23,7 +23,6 @@ namespace Altinn.Broker.Controllers;
 
 [ApiController]
 [Route("broker/api/v1/filetransfer")]
-[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
 public class FileTransferController(ILogger<FileTransferController> logger) : Controller
 {
 

--- a/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
+++ b/src/Altinn.Broker.API/Controllers/LegacyFileController.cs
@@ -24,7 +24,6 @@ namespace Altinn.Broker.Controllers;
 /// </summary>
 [ApiController]
 [Route("broker/api/v1/legacy/file")]
-[Authorize(AuthenticationSchemes = AuthorizationConstants.LegacyAndMaskinporten)]
 [Authorize(Policy = AuthorizationConstants.Legacy)]
 [ApiExplorerSettings(IgnoreApi = true)]
 public class LegacyFileController(ILogger<LegacyFileController> logger) : Controller

--- a/src/Altinn.Broker.API/Controllers/ResourceController.cs
+++ b/src/Altinn.Broker.API/Controllers/ResourceController.cs
@@ -4,7 +4,6 @@ using Altinn.Broker.Application.ConfigureResource;
 using Altinn.Broker.Application.GetResource;
 using Altinn.Broker.Models;
 
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -12,7 +11,6 @@ namespace Altinn.Broker.Controllers;
 
 [ApiController]
 [Route("broker/api/v1/resource")]
-[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
 [Authorize(Policy = AuthorizationConstants.ServiceOwner)]
 public class ResourceController : Controller
 {

--- a/src/Altinn.Broker.API/Controllers/ServiceOwnerController.cs
+++ b/src/Altinn.Broker.API/Controllers/ServiceOwnerController.cs
@@ -6,7 +6,6 @@ using Altinn.Broker.Core.Repositories;
 using Altinn.Broker.Core.Services;
 using Altinn.Broker.Models.ServiceOwner;
 
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -14,7 +13,6 @@ namespace Altinn.Broker.Controllers;
 
 [ApiController]
 [Route("broker/api/v1/serviceowner")]
-[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
 [Authorize(Policy = AuthorizationConstants.ServiceOwner)]
 public class ServiceOwnerController(IServiceOwnerRepository serviceOwnerRepository, IHostEnvironment hostEnvironment, IResourceManager resourceManager) : Controller
 {


### PR DESCRIPTION
## Description
Authentication schemes defined on the controller and method will override the authentication scheme defined with the authorization policy. Hence remove it.

Furthermore, Maskinporten tokens are level 3 and should be validated as such.

## Related Issue(s)
- #755 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authorization now enforces minimum authentication level obligations, including organization-specific requirements when applicable.
  * Improved subject handling with person enrichment when available and sensible defaults for machine-to-machine tokens.

* **Refactor**
  * Controllers now rely on policy-based authorization aligned with application defaults; explicit authentication scheme bindings removed. No endpoint or route changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->