### PR TITLE
⚠️ Add permission roles for switch to RBAC permission model

### DIFF
--- a/.azure/applications/migration/main.bicep
+++ b/.azure/applications/migration/main.bicep
@@ -15,12 +15,14 @@ resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@
   location: location
 }
 
-module addKeyvaultRead '../../modules/keyvault/addReaderRoles.bicep' = {
+module keyvaultAddReaderRolesMigrationIdentity '../../modules/keyvault/addReaderRoles.bicep' = {
   name: 'kvreader-${namePrefix}-migration'
   params: {
     keyvaultName: keyVaultName
     tenantId: userAssignedIdentity.properties.tenantId
-    principalIds: [userAssignedIdentity.properties.principalId]
+    principals: [
+      { objectId: userAssignedIdentity.properties.principalId, principalType: 'ServicePrincipal' }
+    ]
   }
 }
 
@@ -75,7 +77,7 @@ resource containerAppEnv 'Microsoft.App/managedEnvironments@2024-03-01' existing
 module containerAppJob '../../modules/migrationJob/main.bicep' = {
   name: containerAppJobName
   dependsOn: [
-    addKeyvaultRead
+    keyvaultAddReaderRolesMigrationIdentity
   ]
   params: {
     name: containerAppJobName

--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -29,6 +29,17 @@ param keyVaultSku KeyVaultSku
 
 var resourceGroupName = '${namePrefix}-rg'
 
+module grantTestClientSecretsOfficerRole '../modules/keyvault/addSecretsOfficerRole.bicep' = if (environment == 'test') {
+  scope: resourceGroup
+  name: 'kv-secrets-officer-test-client'
+  dependsOn: [ environmentKeyVault ]
+  params: {
+    keyvaultName: sourceKeyVaultName
+    principalObjectId: test_client_id
+    principalType: 'Group'
+  }
+}
+
 var secrets = [
   {
     name: 'maskinporten-client-id'

--- a/.azure/modules/keyvault/addReaderRoles.bicep
+++ b/.azure/modules/keyvault/addReaderRoles.bicep
@@ -1,10 +1,13 @@
 param keyvaultName string
-param principalIds array
+param principals array
 param tenantId string = subscription().tenantId
 
+var secretsUserRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
+var keyVaultReaderRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '21090545-7ca7-4776-b22c-e363652d74d2')
+
 var readerAccessPoliciesArray = [
-  for principalId in principalIds: {
-    objectId: principalId
+  for principals in principals: {
+    objectId: principals.objectId
     tenantId: tenantId
     permissions: {
       certificates: ['get', 'list']
@@ -23,3 +26,23 @@ resource keyvault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
     }
   }
 }
+
+resource secretsUsers 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for p in principals: {
+  name: guid(subscription().id, keyvault.id, p.objectId, secretsUserRoleId)
+  scope: keyvault
+  properties: {
+    roleDefinitionId: secretsUserRoleId
+    principalId: p.objectId
+    principalType: p.principalType
+  }
+}]
+
+resource kvReaders 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for p in principals: {
+  name: guid(subscription().id, keyvault.id, p.objectId, keyVaultReaderRoleId)
+  scope: keyvault
+  properties: {
+    roleDefinitionId: keyVaultReaderRoleId
+    principalId: p.objectId
+    principalType: p.principalType
+  }
+}]

--- a/.azure/modules/keyvault/addSecretsOfficerRole.bicep
+++ b/.azure/modules/keyvault/addSecretsOfficerRole.bicep
@@ -1,0 +1,19 @@
+param keyvaultName string
+param principalType string = 'Group'
+param principalObjectId string
+
+var secretsOfficerRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')
+
+resource kv 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
+  name: keyvaultName
+}
+
+resource secretsOfficer 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, kv.id, principalObjectId, secretsOfficerRoleId)
+  scope: kv
+  properties: {
+    roleDefinitionId: secretsOfficerRoleId
+    principalId: principalObjectId
+    principalType: principalType
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently the keyvault uses access policies for permission model. This is considered legacy, instead the RBAC permission model should be used.

This PR adds bicep codes to grant the migration identity and app identity the roles key vault reader and vault secrets user for RBAC access. These roles should give the same permissions as they had for access policy. The test_client is given key vault secret officer role in test environment to match the permission it was given by access policies.

⚠️ post-deploy:
After the change has been deployed to each environement, check that the correct permissions have been given and switch permission model to RBAC.

## Related Issue(s)
- https://github.com/Altinn/altinn-correspondence/issues/1101

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)