### PR TITLE
⚠️ Remove the length restriction for file transfer property value and key in db

### DIFF
--- a/src/Altinn.Broker.Persistence/Migrations/V0017__remove_property_length_limit.sql
+++ b/src/Altinn.Broker.Persistence/Migrations/V0017__remove_property_length_limit.sql
@@ -1,0 +1,7 @@
+-- Remove DB-level length limits for file transfer properties.
+
+ALTER TABLE broker.file_transfer_property
+    ALTER COLUMN key TYPE character varying;
+
+ALTER TABLE broker.file_transfer_property
+    ALTER COLUMN value TYPE character varying;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Altinn 2 had no restrictions on property value and key. The files from the legacy solution sometimes fails if they values that are longer than the restriction. For this reason this PR removes the length restriction on these fields in the db. The api level validation for the value and key length for the altinn 3 endpoints are kept.

⚠️ PR includes a database migration

## Related Issue(s)
- #819 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)