### PR TITLE
increase polling time for usecase tests

### DIFF
--- a/tests/Altinn.Broker.UseCaseTests/case_initialize.js
+++ b/tests/Altinn.Broker.UseCaseTests/case_initialize.js
@@ -174,7 +174,7 @@ async function TC3_PollAndVerifyUpload(filetransferId) {
         });
     }
     check(isPublished(statusValue), { 'fileTransferStatus is Published (num|string)': v => v === true });
-    check(published, { 'File transfer reached published status within 10s': p => p === true });
+    check(published, { 'File transfer reached published status within 30s': p => p === true });
     console.log(`TC3: Poll and verify upload completed`);
 }
 
@@ -355,7 +355,7 @@ async function TC8_InitializeAndUpload() {
         check(overviewResponse, { 'TC8 overview 200': r => r.status === 200 });
     }
     check(isPublished(statusValue), { 'TC8 status Published (num|string)': v => v === true });
-    check(published, { 'TC8 reached Published within 10s': p => p === true });
+    check(published, { 'TC8 reached Published within 30s': p => p === true });
 
     console.log('TC8: InitializeAndUpload completed');
     return { initializeAndUploadFileTransferId };

--- a/tests/Altinn.Broker.UseCaseTests/legacy_case_initialize.js
+++ b/tests/Altinn.Broker.UseCaseTests/legacy_case_initialize.js
@@ -171,7 +171,7 @@ async function TC3_LegacyPollAndVerifyUpload(filetransferId) {
             'fileStatus Published': r => isPublished(r.json('fileStatus'))
         });
     }
-    check(published, { 'File transfer reached published status within 10s': p => p === true });
+    check(published, { 'File transfer reached published status within 30s': p => p === true });
     console.log(`TC3: Poll and verify upload completed`);
 }
 


### PR DESCRIPTION
## Description
Some usecase tests would fail due to the file not being published. Increased the polling time for the test from 10s to 30s.

## Related Issue(s)
- #840 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased polling interval between attempts from 1s to 3s to reduce flakiness.
  * Added an initial wait before each polling attempt and removed the short end-of-loop pause.
  * Extended assertion timeouts/messages for published-status checks from 10s to 30s to allow longer processing windows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->