### PR TITLE
retrieve env variables

### DIFF
--- a/tests/Altinn.Broker.UseCaseTests/case_initialize.js
+++ b/tests/Altinn.Broker.UseCaseTests/case_initialize.js
@@ -7,9 +7,8 @@ import { getSenderAltinnToken, getRecipientAltinnToken } from './helpers/altinnT
 
 const baseUrl = __ENV.base_url;
 const resourceId = 'bruksmonster-broker';
-const prodSender = __ENV.sender;
-const prodRecipient = __ENV.recipient;
-const isProduction = (baseUrl.toLowerCase().includes('platform.altinn.no') ? true : false);
+const sender = __ENV.sender;
+const recipient = __ENV.recipient;
 
 export const options = {
     thresholds: {
@@ -69,7 +68,6 @@ async function TC1_InitializeFileTransfer() {
     const token = await getSenderAltinnToken();
     check(token, { 'Sender Altinn token obtained': t => typeof t === 'string' && t.length > 0 });
 
-    const recipient = isProduction ? prodRecipient : "311167898"
     const payload = buildInitializeFileTransferPayload(recipient);
 
     const headers = {
@@ -288,8 +286,7 @@ async function TC8_InitializeAndUpload() {
     const senderToken = await getSenderAltinnToken();
     check(senderToken, { 'Sender token for TC8 obtained': t => typeof t === 'string' && t.length > 0 });
 
-    const recipientOrg = isProduction ? prodRecipient : '311167898';
-    const meta = buildInitializeFileTransferPayload(recipientOrg);
+    const meta = buildInitializeFileTransferPayload(recipient);
 
     // Build multipart/form-data with nested form keys for Metadata and a file part for FileTransfer
     const formBody = {

--- a/tests/Altinn.Broker.UseCaseTests/helpers/brokerPayloadBuilder.js
+++ b/tests/Altinn.Broker.UseCaseTests/helpers/brokerPayloadBuilder.js
@@ -12,7 +12,7 @@ export function buildInitializeFileTransferPayload(recipientOrgNo) {
         resourceId: "bruksmonster-broker",
         fileName: 'usecase-broker-test-file.txt',
         sendersFileTransferReference: nowRef,
-        sender: isProduction ? `0192:${sender}` : '0192:313896013',
+        sender: `0192:${sender}`,
         recipients: [recipient],
         propertyList: {
             testTag: TEST_TAG_A3,
@@ -30,7 +30,7 @@ export function buildLegacyInitializeFileTransferPayload(recipientOrgNo) {
         resourceId: "bruksmonster-broker",
         fileName: 'usecase-broker-test-file.txt',
         sendersFileTransferReference: nowRef,
-        sender: isProduction ? `0192:${sender}` : '0192:313896013',
+        sender:`0192:${sender}`,
         recipients: [recipient],
         propertyList: {
             testTag: TEST_TAG_LEGACY,

--- a/tests/Altinn.Broker.UseCaseTests/helpers/maskinportenJwtBuilder.js
+++ b/tests/Altinn.Broker.UseCaseTests/helpers/maskinportenJwtBuilder.js
@@ -5,7 +5,6 @@ const sender = __ENV.sender;
 const recipient = __ENV.recipient;
 
 export async function buildMaskinportenJwt({ clientId, kid, pem, scope, tokenUrl, isSender }) {
-    const isProduction = !tokenUrl.includes('test');
     const now = Math.floor(Date.now() / 1000);
     const header = { alg: 'RS256', typ: 'JWT', kid };
     const payload = {
@@ -19,7 +18,7 @@ export async function buildMaskinportenJwt({ clientId, kid, pem, scope, tokenUrl
                 systemuser_org:
                     {
                         authority : "iso6523-actorid-upis",
-                        ID: isProduction ? (isSender ? sender : recipient) : (isSender ? "313896013" : "311167898")
+                        ID:  isSender ? sender : recipient  
                     }
             }
         ],

--- a/tests/Altinn.Broker.UseCaseTests/legacy_case_initialize.js
+++ b/tests/Altinn.Broker.UseCaseTests/legacy_case_initialize.js
@@ -6,12 +6,11 @@ import { cleanupUseCaseTestData } from './helpers/cleanupUseCaseTestsData.js';
 import { getLegacyMaskinportenToken } from './helpers/maskinportenTokenService.js';
 
 const baseUrl = __ENV.base_url;
-const isProduction = (baseUrl.toLowerCase().includes('platform.altinn.no') ? true : false);
-const prodRecipient = __ENV.recipient;
-const prodSender = __ENV.sender;
+const recipient = __ENV.recipient;
+const sender = __ENV.sender;
 // Legacy controller expects onBehalfOfConsumer as a string (org number)
-const onBehalfOfConsumerSender = isProduction ? prodSender : "313896013";
-const onBehalfOfConsumerRecipient = isProduction ? prodRecipient : "311167898"
+const onBehalfOfConsumerSender = sender;
+const onBehalfOfConsumerRecipient = recipient;
 export const options = {
     thresholds: {
         checks: ["rate==1"],
@@ -64,7 +63,7 @@ async function TC1_InitializeLegacyFileTransfer() {
     const token = await getLegacyMaskinportenToken();
     check(token, { 'Legacy token obtained': t => typeof t === 'string' && t.length > 0 });
 
-    const recipient = isProduction ? prodRecipient : "311167898"
+    const recipient = recipient;
     const payload = buildLegacyInitializeFileTransferPayload(recipient);
 
     const headers = {
@@ -283,7 +282,7 @@ async function TC7_LegacyVerifyUpdatedStatus(filetransferId) {
 async function TC8_LegacyGetFileOverviews(filetransferId1) {
     const token = await getLegacyMaskinportenToken();
     const headersJson = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', Accept: 'application/json' };
-    const recipient = isProduction ? prodRecipient : '311167898';
+    const recipient = recipient;
     const payload = buildLegacyInitializeFileTransferPayload(recipient);
 
     const responseInitialize2 = http.post(`${baseUrl}/broker/api/v1/legacy/file`, JSON.stringify(payload), { headers: headersJson });


### PR DESCRIPTION
## Description
use case tests failed due to not getting the env variables

## Related Issue(s)
- https://github.com/Altinn/altinn-correspondence/issues/1604

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened error handling in test execution with explicit exception catching and failure reporting to ensure all test failures are properly captured.
  * Enhanced test configuration flexibility by introducing environment-based constants for sender and recipient identifiers, allowing dynamic configuration without code modifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->