### PR TITLE
remove local variable initialization

### DIFF
--- a/tests/Altinn.Broker.UseCaseTests/legacy_case_initialize.js
+++ b/tests/Altinn.Broker.UseCaseTests/legacy_case_initialize.js
@@ -63,7 +63,6 @@ async function TC1_InitializeLegacyFileTransfer() {
     const token = await getLegacyMaskinportenToken();
     check(token, { 'Legacy token obtained': t => typeof t === 'string' && t.length > 0 });
 
-    const recipient = recipient;
     const payload = buildLegacyInitializeFileTransferPayload(recipient);
 
     const headers = {
@@ -282,7 +281,6 @@ async function TC7_LegacyVerifyUpdatedStatus(filetransferId) {
 async function TC8_LegacyGetFileOverviews(filetransferId1) {
     const token = await getLegacyMaskinportenToken();
     const headersJson = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', Accept: 'application/json' };
-    const recipient = recipient;
     const payload = buildLegacyInitializeFileTransferPayload(recipient);
 
     const responseInitialize2 = http.post(`${baseUrl}/broker/api/v1/legacy/file`, JSON.stringify(payload), { headers: headersJson });


### PR DESCRIPTION
## Description
Legacy tests failed with: ReferenceError: Cannot access a variable before initialization.
Removed excessive local variable initialization.

## Related Issue(s)
- https://github.com/Altinn/altinn-correspondence/issues/1604

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed redundant code in test declarations to improve maintainability.

---

**Note:** This release contains no user-visible changes or public API modifications. Changes are internal test maintenance only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->