### PR TITLE
specify application/json media type in error responses for /download

### DIFF
--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -19,6 +19,7 @@ using Altinn.Broker.Models;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Altinn.Authorization.ProblemDetails;
 
 namespace Altinn.Broker.Controllers;
 
@@ -324,12 +325,11 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
     /// </ul></response>
     /// <response code="404">The requested file transfer was not found</response>
     [HttpGet]
-    [Produces("application/octet-stream")]
-    [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK, "application/octet-stream")]
+    [ProducesResponseType(typeof(AltinnProblemDetails), StatusCodes.Status400BadRequest, "application/json")]
+    [ProducesResponseType(typeof(AltinnProblemDetails), StatusCodes.Status401Unauthorized, "application/json")]
+    [ProducesResponseType(typeof(AltinnProblemDetails), StatusCodes.Status403Forbidden, "application/json")]
+    [ProducesResponseType(typeof(AltinnProblemDetails), StatusCodes.Status404NotFound, "application/json")]
     [Route("{fileTransferId}/download")]
     [Authorize(Policy = AuthorizationConstants.Recipient)]
     public async Task<ActionResult> DownloadFile(


### PR DESCRIPTION
## Description
The swagger documentation said to expect an application/octet-stream media type for error responses from the /download endpoint. This should be application/json. This PR explicitly sets the different response types for success and error.

## Related Issue(s)
- #806 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API response documentation for consistency, including error response schemas and file download endpoint specifications.

* **Refactor**
  * Restructured internal API response type definitions to align success and error response handling, with no changes to public API signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->