### PR TITLE
Fixed condition that lead to file transfers not being purged on expiry

### DIFF
--- a/src/Altinn.Broker.Application/PurgeFileTransfer/PurgeFileTransferHandler.cs
+++ b/src/Altinn.Broker.Application/PurgeFileTransfer/PurgeFileTransferHandler.cs
@@ -26,7 +26,8 @@ public class PurgeFileTransferHandler(IFileTransferRepository fileTransferReposi
 
         if (fileTransfer.FileTransferStatusEntity.Status == Core.Domain.Enums.FileTransferStatus.Purged)
         {
-            logger.LogInformation("FileTransfer has already been set to purged");
+            logger.LogWarning("FileTransfer has already been set to purged");
+            return Task.CompletedTask;
         }
         if (
             fileTransfer.FileTransferStatusEntity.Status == Core.Domain.Enums.FileTransferStatus.AllConfirmedDownloaded 


### PR DESCRIPTION
## Description
The existing logic did not include the condition that the resource was of the specified type leading to expiry jobs being deleted that should not have been.

Fixed original issue with test-specific code. Also added handling of double-attempt at purging file transfers. But we cannot rely solely on this as PurgeFileTransferAllRecipientsHaveBeenConfirmed may lead to extending the deadline in case of a grace period and confirmation that occurs right before expiry.

## Related Issue(s)
- #859

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file transfer purge handling to properly exit when already in purged state.

* **Refactor**
  * Optimized cleanup behavior based on deployment environment to enhance system efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->