### PR TITLE
Fixed 503 status response not using problemdetails schema

### DIFF
--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -16,10 +16,8 @@ using Altinn.Broker.API.Helpers;
 using Altinn.Broker.Mappers;
 using Altinn.Broker.Models;
 
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Altinn.Authorization.ProblemDetails;
 
 namespace Altinn.Broker.Controllers;
 
@@ -50,7 +48,7 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status503ServiceUnavailable)]
     public async Task<ActionResult<Guid>> InitializeFileTransfer(FileTransferInitalizeExt initializeExt, [FromServices] InitializeFileTransferHandler handler, CancellationToken cancellationToken)
     {
         LogContextHelpers.EnrichLogsWithInitializeFile(initializeExt);
@@ -95,7 +93,7 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
-    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status503ServiceUnavailable)]
     [Authorize(Policy = AuthorizationConstants.Sender)]
     public async Task<ActionResult> UploadStreamed(
         Guid fileTransferId,
@@ -146,7 +144,7 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status503ServiceUnavailable)]
     [Route("upload")]
     [RequestFormLimits(MultipartBodyLengthLimit = int.MaxValue)]
     [Authorize(Policy = AuthorizationConstants.Sender)]
@@ -326,10 +324,10 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
     /// <response code="404">The requested file transfer was not found</response>
     [HttpGet]
     [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK, "application/octet-stream")]
-    [ProducesResponseType(typeof(AltinnProblemDetails), StatusCodes.Status400BadRequest, "application/json")]
-    [ProducesResponseType(typeof(AltinnProblemDetails), StatusCodes.Status401Unauthorized, "application/json")]
-    [ProducesResponseType(typeof(AltinnProblemDetails), StatusCodes.Status403Forbidden, "application/json")]
-    [ProducesResponseType(typeof(AltinnProblemDetails), StatusCodes.Status404NotFound, "application/json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest, "application/json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden, "application/json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/json")]
     [Route("{fileTransferId}/download")]
     [Authorize(Policy = AuthorizationConstants.Recipient)]
     public async Task<ActionResult> DownloadFile(

--- a/src/Altinn.Broker.API/Helpers/ProblemDetailsHelper.cs
+++ b/src/Altinn.Broker.API/Helpers/ProblemDetailsHelper.cs
@@ -18,6 +18,8 @@ public static class ProblemDetailsHelper
         { HttpStatusCode.NotFound, ("https://tools.ietf.org/html/rfc9110#section-15.5.5", "Not Found") },
         { HttpStatusCode.Conflict, ("https://tools.ietf.org/html/rfc9110#section-15.5.10", "Conflict") },
         { HttpStatusCode.InternalServerError, ("https://tools.ietf.org/html/rfc9110#section-15.6.1", "Internal Server Error") },
+        { HttpStatusCode.BadGateway, ("https://tools.ietf.org/html/rfc9110#section-15.6.3", "Bad Gateway") },
+        { HttpStatusCode.ServiceUnavailable, ("https://tools.ietf.org/html/rfc9110#section-15.6.4", "Service Unavailable") },
     };
 
     public static ObjectResult ToProblemResult(Error error)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
503 errors did not have content in swagger. This PR makes 503 errors follow the problemDetails schema.

## Related Issue(s)
- #807 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized error response format across file transfer endpoints to ensure consistent, well-structured error messages when operations fail or encounter issues.
  * Improved error handling for service unavailability and gateway-related errors with clearer, more informative error details for better troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->