### PR TITLE
Increased max size for scanned files

### DIFF
--- a/src/Altinn.Broker.API/Controllers/ResourceController.cs
+++ b/src/Altinn.Broker.API/Controllers/ResourceController.cs
@@ -28,7 +28,7 @@ public class ResourceController : Controller
     /// <li>Grace period cannot exceed 24 hours</li>
     /// <li>Max file transfer size cannot be negative</li>
     /// <li>Max file transfer size cannot be zero</li>
-    /// <li>Max file transfer size cannot be set higher than the 2GB in production unless the resource has been pre-approved for disabled virus scan. Contact us @ Slack</li>
+    /// <li>Max file transfer size cannot be set higher than 50GB in production unless the resource has been pre-approved for disabled virus scan. Contact us @ Slack</li>
     /// <li>Max file transfer size cannot be set higher than 100GB in production because it has not yet been tested for it. Contact us @ Slack if you need it</li>
     /// <li>Invalid file transfer time to live format. Should follow ISO8601 standard for duration. Example: 'P30D' for 30 days</li>
     /// <li>Time to live cannot exceed 365 days</li>

--- a/src/Altinn.Broker.Application/ApplicationConstants.cs
+++ b/src/Altinn.Broker.Application/ApplicationConstants.cs
@@ -3,7 +3,7 @@ namespace Altinn.Broker.Application.Settings;
 public static class ApplicationConstants
 {
     public const long MaxFileUploadSize = 32L * 50000 * 1024 * 1024;
-    public const long MaxVirusScanUploadSize = 50L * 1024 * 1024 * 1024;
+    public const long MaxVirusScanUploadSize = 50L * 1000 * 1000 * 1000;
     public const string DefaultGracePeriod = "PT2H";
     public const string MaxGracePeriod = "PT24H";
 }

--- a/src/Altinn.Broker.Application/ApplicationConstants.cs
+++ b/src/Altinn.Broker.Application/ApplicationConstants.cs
@@ -3,7 +3,7 @@ namespace Altinn.Broker.Application.Settings;
 public static class ApplicationConstants
 {
     public const long MaxFileUploadSize = 32L * 50000 * 1024 * 1024;
-    public const long MaxVirusScanUploadSize = 2L * 1024 * 1024 * 1024;
+    public const long MaxVirusScanUploadSize = 50L * 1024 * 1024 * 1024;
     public const string DefaultGracePeriod = "PT2H";
     public const string MaxGracePeriod = "PT24H";
 }

--- a/src/Altinn.Broker.Application/Errors.cs
+++ b/src/Altinn.Broker.Application/Errors.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 
 namespace Altinn.Broker.Application;
 
@@ -18,7 +18,7 @@ public static class Errors
     public static Error FileTransferNotPublished = new Error(10, "A file transfer can only be confirmed to be downloaded when it is published. See file transfer status.", HttpStatusCode.BadRequest);
     public static Error MaxUploadSizeCannotBeNegative = new Error(11, "Max file transfer size cannot be negative", HttpStatusCode.BadRequest);
     public static Error MaxUploadSizeCannotBeZero = new Error(12, "Max file transfer size cannot be zero", HttpStatusCode.BadRequest);
-    public static Error MaxUploadSizeForVirusScan = new Error(13, "Max file transfer size cannot be set higher than the 2GB in production unless the resource has been pre-approved for disabled virus scan. Contact us @ Slack.", HttpStatusCode.BadRequest);
+    public static Error MaxUploadSizeForVirusScan = new Error(13, "Max file transfer size cannot be set higher than 50GB in production unless the resource has been pre-approved for disabled virus scan. Contact us @ Slack.", HttpStatusCode.BadRequest);
     public static Error InvalidTimeToLiveFormat = new Error(14, "Invalid file transfer time to live format. Should follow ISO8601 standard for duration. Example: 'P30D' for 30 days.", HttpStatusCode.BadRequest);
     public static Error TimeToLiveCannotExceed365Days = new Error(15, "Time to live cannot exceed 365 days", HttpStatusCode.BadRequest);
     public static Error FileSizeTooBig = new Error(16, "File size exceeds maximum", HttpStatusCode.BadRequest);

--- a/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
@@ -134,15 +134,16 @@ public class UploadFileHandler(
             }, logger, cancellationToken);
         }
 
-        if (hostEnvironment.IsDevelopment() && generalSettings.Value.SimulateMalwareScan)
-        {
-            await SimulateMalwareScanResult(request.FileTransferId);
-            backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Sender));
-            foreach (var recipient in fileTransfer.RecipientCurrentStatuses)
-            {
-                backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), recipient.Actor.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Recipient));
-            }
-        }
+        // Temporarily disabled to force real malware scanning during testing.
+        // if (hostEnvironment.IsDevelopment() && generalSettings.Value.SimulateMalwareScan)
+        // {
+        //     await SimulateMalwareScanResult(request.FileTransferId);
+        //     backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Sender));
+        //     foreach (var recipient in fileTransfer.RecipientCurrentStatuses)
+        //     {
+        //         backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), recipient.Actor.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Recipient));
+        //     }
+        // }
         return fileTransfer.FileTransferId;
     }
 

--- a/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
@@ -134,16 +134,15 @@ public class UploadFileHandler(
             }, logger, cancellationToken);
         }
 
-        // Temporarily disabled to force real malware scanning during testing.
-        // if (hostEnvironment.IsDevelopment() && generalSettings.Value.SimulateMalwareScan)
-        // {
-        //     await SimulateMalwareScanResult(request.FileTransferId);
-        //     backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Sender));
-        //     foreach (var recipient in fileTransfer.RecipientCurrentStatuses)
-        //     {
-        //         backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), recipient.Actor.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Recipient));
-        //     }
-        // }
+        if (hostEnvironment.IsDevelopment() && generalSettings.Value.SimulateMalwareScan)
+        {
+            await SimulateMalwareScanResult(request.FileTransferId);
+            backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Sender));
+            foreach (var recipient in fileTransfer.RecipientCurrentStatuses)
+            {
+                backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), recipient.Actor.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Recipient));
+            }
+        }
         return fileTransfer.FileTransferId;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Increases the max size for files with virus scan from 2 to 50gb.

## Related Issue(s)
- #895 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the maximum allowed file transfer size in production from 2GB to 50GB.
  * Updated user-facing error messages and guidance to reflect the new 50GB limit.

* **Changes**
  * Disabled simulated malware-scan publish events in development simulation flows, so simulated post-upload notifications are no longer emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->