### PR TITLE
⚠️ Fix check recipient towards accesslist

### DIFF
--- a/src/Altinn.Broker.API/appsettings.Development.json
+++ b/src/Altinn.Broker.API/appsettings.Development.json
@@ -25,7 +25,7 @@
   "MaskinportenSettings": {
     "Environment": "test",
     "ClientId": "",
-    "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:authorization/authorize.admin",
+    "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:serviceowner altinn:authorization/authorize.admin altinn:resourceregistry/resource.admin",
     "EncodedJwk": "",
     "ExhangeToAltinnToken": true
   },

--- a/src/Altinn.Broker.Application/Errors.cs
+++ b/src/Altinn.Broker.Application/Errors.cs
@@ -33,6 +33,7 @@ public static class Errors
     public static Error ResourceHasNotBeenConfigured = new Error(25, "The resource has not been configured.", HttpStatusCode.BadRequest);
     public static Error RequiredPartyNotSpecified = new Error(26, "The resource requires the service owner party to be present as part of the transaction.", HttpStatusCode.BadRequest);
     public static Error RequiredPartyInvalidRecipientConfiguration = new Error(27, "When required party is specified and the required party is not the sender, the number of recipients can only be one.", HttpStatusCode.BadRequest);
+    public static Error RecipientNotInAccessList = new Error(28, "All recipients need to be in the access list of the resource.", HttpStatusCode.BadRequest);
 }
 
 public static class StatisticsErrors

--- a/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
+++ b/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
@@ -94,7 +94,7 @@ public class InitializeFileTransferHandler(
         {
             foreach (var recipient in request.RecipientExternalIds)
             {
-                var accessList = await altinnResourceRepository.GetAccessListOfResource(request.ResourceId, recipient, cancellationToken);
+                var accessList = await altinnResourceRepository.GetAccessListOfResource(request.ResourceId, recipient.WithoutPrefix(), cancellationToken);
                 if (accessList is null || accessList.Count == 0)
                 {
                     return Errors.RecipientNotInAccessList;

--- a/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
+++ b/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
@@ -100,7 +100,7 @@ public class InitializeFileTransferHandler(
                     return Errors.RecipientNotInAccessList;
                 }
                 var recipientId = await altinnRegisterService.LookupPartyByUuid(accessList[0], cancellationToken);
-                if (recipientId is null || !recipientId.Contains(recipient.WithoutPrefix()))
+                if (recipientId is null || recipientId != recipient.WithoutPrefix())
                 {
                     return Errors.RecipientNotInAccessList;
                 }

--- a/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
+++ b/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
@@ -46,20 +46,16 @@ public class InitializeFileTransferHandler(
             logger.LogInformation("Sender using legacy format: {sender}", request.SenderExternalId.SanitizeForLogs());
         }
 
-        List<string> mappedRecipients = new List<string>();
         // Log recipients format
         foreach (var recipient in request.RecipientExternalIds)
         {
             if (recipient.StartsWith("urn:altinn:organization:identifier-no:"))
             {
                 logger.LogInformation("Recipient using new URN format: {recipient}", recipient.SanitizeForLogs());
-                mappedRecipients.Add(recipient);
             }
             else if (recipient.StartsWith("0192:"))
             {
-                logger.LogInformation("Recipient using legacy format: {recipient}, mapping to URN", recipient.SanitizeForLogs());
-                var mappedRecipient = recipient.WithoutPrefix().WithUrnPrefix();
-                mappedRecipients.Add(mappedRecipient);
+                logger.LogInformation("Recipient using legacy format: {recipient}", recipient.SanitizeForLogs());
             }
         }
 
@@ -96,7 +92,7 @@ public class InitializeFileTransferHandler(
         }
         if (altinnResource.AccessListEnabled)
         {
-            foreach (var recipient in mappedRecipients)
+            foreach (var recipient in request.RecipientExternalIds)
             {
                 var accessList = await altinnResourceRepository.GetAccessListOfResource(request.ResourceId, recipient, cancellationToken);
                 if (accessList is null || accessList.Count == 0)

--- a/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
+++ b/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
@@ -46,16 +46,20 @@ public class InitializeFileTransferHandler(
             logger.LogInformation("Sender using legacy format: {sender}", request.SenderExternalId.SanitizeForLogs());
         }
 
+        List<string> mappedRecipients = new List<string>();
         // Log recipients format
         foreach (var recipient in request.RecipientExternalIds)
         {
             if (recipient.StartsWith("urn:altinn:organization:identifier-no:"))
             {
                 logger.LogInformation("Recipient using new URN format: {recipient}", recipient.SanitizeForLogs());
+                mappedRecipients.Add(recipient);
             }
             else if (recipient.StartsWith("0192:"))
             {
-                logger.LogInformation("Recipient using legacy format: {recipient}", recipient.SanitizeForLogs());
+                logger.LogInformation("Recipient using legacy format: {recipient}, mapping to URN", recipient.SanitizeForLogs());
+                var mappedRecipient = recipient.WithoutPrefix().WithUrnPrefix();
+                mappedRecipients.Add(mappedRecipient);
             }
         }
 
@@ -92,7 +96,7 @@ public class InitializeFileTransferHandler(
         }
         if (altinnResource.AccessListEnabled)
         {
-            foreach (var recipient in request.RecipientExternalIds)
+            foreach (var recipient in mappedRecipients)
             {
                 var accessList = await altinnResourceRepository.GetAccessListOfResource(request.ResourceId, recipient, cancellationToken);
                 if (accessList is null || accessList.Count == 0)

--- a/src/Altinn.Broker.Core/Domain/ResourceEntity.cs
+++ b/src/Altinn.Broker.Core/Domain/ResourceEntity.cs
@@ -15,4 +15,5 @@ public class ResourceEntity
     public int? ExternalServiceEditionCodeLegacy { get; set; }
     public bool ApprovedForDisabledVirusScan { get; set; } = false;
     public bool? RequiredParty { get; set; }
+    public bool AccessListEnabled { get; set; } = false;
 }

--- a/src/Altinn.Broker.Core/Repositories/IAltinnResourceRepoistory.cs
+++ b/src/Altinn.Broker.Core/Repositories/IAltinnResourceRepoistory.cs
@@ -10,4 +10,6 @@ public interface IAltinnResourceRepository
     /// This returns the name from HasCompetentAuthority.Name (e.g., "Digitaliseringsdirektoratet", "NAV", etc.)
     /// </summary>
     Task<string?> GetServiceOwnerNameOfResource(string resourceId, CancellationToken cancellationToken = default);
+
+    Task<List<string>?> GetAccessListOfResource(string resourceId, string party, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Broker.Core/Services/IAltinnRegisterService.cs
+++ b/src/Altinn.Broker.Core/Services/IAltinnRegisterService.cs
@@ -2,4 +2,5 @@
 public interface IAltinnRegisterService
 {
     Task<string?> LookUpOrganizationId(string organizationId, CancellationToken cancellationToken);
+    Task<string?> LookupPartyByUuid(string partyUuid, CancellationToken cancellationToken);
 }

--- a/src/Altinn.Broker.Integrations/Altinn/Register/AltinnRegisterService.cs
+++ b/src/Altinn.Broker.Integrations/Altinn/Register/AltinnRegisterService.cs
@@ -46,4 +46,21 @@ public class AltinnRegisterService : IAltinnRegisterService
         }
         return party.PartyId.ToString();
     }
+
+    public async Task<string?> LookupPartyByUuid(string partyUuid, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync($"register/api/v1/parties/byuuid/{partyUuid}", cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("Error when looking up party by uuid in Altinn Register. Statuscode was: {statusCode}, error was: {error}", response.StatusCode, await response.Content.ReadAsStringAsync());
+            return null;
+        }
+        var party = await response.Content.ReadFromJsonAsync<Party>();
+        if (party is null)
+        {
+            _logger.LogError("Unexpected json response when looking up party by uuid in Altinn Register");
+            return null;
+        }
+        return party.OrgNumber;
+    }
 }

--- a/src/Altinn.Broker.Integrations/Altinn/ResourceRegistry/AltinnResourceRegistryRepository.cs
+++ b/src/Altinn.Broker.Integrations/Altinn/ResourceRegistry/AltinnResourceRegistryRepository.cs
@@ -88,7 +88,7 @@ public class AltinnResourceRegistryRepository : IAltinnResourceRepository
 
     public async Task<List<string>?> GetAccessListOfResource(string resourceId, string party, CancellationToken cancellationToken = default)
     {
-        var url = $"resourceregistry/api/v1/access-lists/memberships?resource=urn:altinn:resource:{resourceId}&party={party}";
+        var url = $"resourceregistry/api/v1/access-lists/memberships?resource=urn:altinn:resource:{resourceId}&party=urn:altinn:organization:identifier-no:{party}";
         var response = await _client.GetAsync(url, cancellationToken);
         return response.StatusCode switch
         {

--- a/src/Altinn.Broker.Integrations/Altinn/ResourceRegistry/GetResourceResponse.cs
+++ b/src/Altinn.Broker.Integrations/Altinn/ResourceRegistry/GetResourceResponse.cs
@@ -53,7 +53,10 @@ internal class GetResourceResponse
     public bool? EnterpriseUserEnabled { get; set; }
 
     [JsonPropertyName("resourceType")]
-    public required string ResourceType { get; set; }
+    public string? ResourceType { get; set; }
+
+    [JsonPropertyName("accessListMode")]
+    public string? AccessListMode { get; set; }
 }
 
 internal class HasCompetentAuthority
@@ -72,4 +75,22 @@ public class Keyword
 {
     public required string Word { get; set; }
     public required string Language { get; set; }
+}
+
+internal class AccessListMembershipResponse
+{
+    [JsonPropertyName("data")]
+    public List<AccessListMembership>? Data { get; set; }
+}
+
+internal class AccessListMembership
+{
+    [JsonPropertyName("party")]
+    public string? Party { get; set; }
+
+    [JsonPropertyName("resource")]
+    public string? Resource { get; set; }
+
+    [JsonPropertyName("since")]
+    public DateTimeOffset? Since { get; set; }
 }

--- a/src/Altinn.Broker.Integrations/DependencyInjection.cs
+++ b/src/Altinn.Broker.Integrations/DependencyInjection.cs
@@ -53,6 +53,10 @@ public static class DependencyInjection
             services.AddHttpClient<IAuthorizationService, AltinnAuthorizationService>((client) => client.BaseAddress = new Uri(altinnOptions.PlatformGatewayUrl))
                     .AddMaskinportenHttpMessageHandler<SettingsJwkClientDefinition, IAuthorizationService>()
                     .AddStandardRetryPolicy();
+            services.RegisterMaskinportenClientDefinition<SettingsJwkClientDefinition>(typeof(IAltinnResourceRepository).FullName, maskinportenSettings);
+            services.AddHttpClient<IAltinnResourceRepository, AltinnResourceRegistryRepository>((client) => client.BaseAddress = new Uri(altinnOptions.PlatformGatewayUrl))
+                    .AddMaskinportenHttpMessageHandler<SettingsJwkClientDefinition, IAltinnResourceRepository>()
+                    .AddStandardRetryPolicy();
         }
         var generalSettings = new GeneralSettings();
         configuration.GetSection(nameof(GeneralSettings)).Bind(generalSettings);

--- a/tests/Altinn.Broker.Tests/Data/R__Prepare_Test_Data.sql
+++ b/tests/Altinn.Broker.Tests/Data/R__Prepare_Test_Data.sql
@@ -60,3 +60,20 @@ INSERT INTO broker.altinn_resource (
     true
 )
 ON CONFLICT (resource_id_pk) DO NOTHING;
+
+INSERT INTO broker.altinn_resource (
+    resource_id_pk,
+    created,
+    max_file_transfer_size,
+    file_transfer_time_to_live,
+    organization_number,
+    service_owner_id_fk
+) VALUES (
+    'ttd-broker-tilgangsliste',
+    NOW(),
+    null,
+    null,
+    '991825827',
+    '0192:991825827'
+)
+ON CONFLICT (resource_id_pk) DO NOTHING;

--- a/tests/Altinn.Broker.Tests/Factories/FileTransferInitializeExtTestFactory.cs
+++ b/tests/Altinn.Broker.Tests/Factories/FileTransferInitializeExtTestFactory.cs
@@ -58,6 +58,16 @@ internal static class FileTransferInitializeExtTestFactory
         SendersFileTransferReference = "test-data"
     };
 
+    internal static FileTransferInitalizeExt BasicFileTransfer_With_AccessList_Resource_And_No_Recipients() => new FileTransferInitalizeExt()
+    {
+        ResourceId = TestConstants.RESOURCE_WITH_ACCESS_LIST,
+        Checksum = null,
+        FileName = "input.txt",
+        PropertyList = [],
+        Sender = "0192:991825827",
+        SendersFileTransferReference = "test-data"
+    };
+
     internal static FileTransferInitalizeExt BasicFileTransfer_ManifestShim() {
         var basicFileTransfer = BasicFileTransfer();
         basicFileTransfer.ResourceId = TestConstants.RESOURCE_WITH_MANIFEST_SHIM;

--- a/tests/Altinn.Broker.Tests/Factories/FileTransferInitializeExtTestFactory.cs
+++ b/tests/Altinn.Broker.Tests/Factories/FileTransferInitializeExtTestFactory.cs
@@ -64,6 +64,7 @@ internal static class FileTransferInitializeExtTestFactory
         Checksum = null,
         FileName = "input.txt",
         PropertyList = [],
+        Recipients = new List<string>(),
         Sender = "0192:991825827",
         SendersFileTransferReference = "test-data"
     };

--- a/tests/Altinn.Broker.Tests/FileTransferControllerTests.cs
+++ b/tests/Altinn.Broker.Tests/FileTransferControllerTests.cs
@@ -1152,4 +1152,57 @@ public class FileTransferControllerTests : IClassFixture<CustomWebApplicationFac
         Assert.NotNull(parsedResponse);
         Assert.Equal(FileTransferStatusExt.Initialized, parsedResponse.FileTransferStatus);
     }
+
+    [Fact]
+    public async Task InitializeFileTransfer_WithRecipientNotInAccessList_ReturnsBadRequest()
+    {
+        // Arrange
+        var file = FileTransferInitializeExtTestFactory.BasicFileTransfer_With_AccessList_Resource_And_No_Recipients();
+        file.Recipients.Add("0192:999999999");
+
+        // Act
+        var initializeFileTransferResponse = await _senderClient.PostAsJsonAsync("broker/api/v1/filetransfer", file);
+
+        // Assert
+        Assert.False(initializeFileTransferResponse.IsSuccessStatusCode);
+        var parsedError = await initializeFileTransferResponse.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(parsedError);
+        Assert.Equal(Errors.RecipientNotInAccessList.Message, parsedError.Detail);
+    }
+
+    [Fact]
+    public async Task InitializeFileTransfer_WithRecipientInAccessList_Succeeds()
+    {
+        // Arrange
+        var file = FileTransferInitializeExtTestFactory.BasicFileTransfer_With_AccessList_Resource_And_No_Recipients();
+        file.Recipients.Add("0192:311764837");
+
+        // Act
+        var initializeFileTransferResponse = await _senderClient.PostAsJsonAsync("broker/api/v1/filetransfer", file);
+
+        // Assert
+
+        Assert.True(initializeFileTransferResponse.IsSuccessStatusCode);
+        var parsedResponse = await initializeFileTransferResponse.Content.ReadFromJsonAsync<FileTransferOverviewExt>();
+        Assert.NotNull(parsedResponse);
+        Assert.Equal(FileTransferStatusExt.Initialized, parsedResponse.FileTransferStatus);
+    }
+
+    [Fact]
+    public async Task InitializeFileTransfer_WithNotAllRecipientsInAccessList_ReturnsBadRequest()
+    {
+        // Arrange
+        var file = FileTransferInitializeExtTestFactory.BasicFileTransfer_With_AccessList_Resource_And_No_Recipients();
+        file.Recipients.Add("0192:311764837");
+        file.Recipients.Add("0192:999999999");
+
+        // Act
+        var initializeFileTransferResponse = await _senderClient.PostAsJsonAsync("broker/api/v1/filetransfer", file);
+
+        // Assert
+        Assert.False(initializeFileTransferResponse.IsSuccessStatusCode);
+        var parsedError = await initializeFileTransferResponse.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(parsedError);
+        Assert.Equal(Errors.RecipientNotInAccessList.Message, parsedError.Detail);
+    }
 }

--- a/tests/Altinn.Broker.Tests/FileTransferControllerTests.cs
+++ b/tests/Altinn.Broker.Tests/FileTransferControllerTests.cs
@@ -9,6 +9,7 @@ using System.Xml;
 using Altinn.Broker.API.Models;
 using Altinn.Broker.Application;
 using Altinn.Broker.Application.PurgeFileTransfer;
+using Altinn.Broker.Common.Constants;
 using Altinn.Broker.Core.Models;
 using Altinn.Broker.Enums;
 using Altinn.Broker.Models;
@@ -1153,12 +1154,14 @@ public class FileTransferControllerTests : IClassFixture<CustomWebApplicationFac
         Assert.Equal(FileTransferStatusExt.Initialized, parsedResponse.FileTransferStatus);
     }
 
-    [Fact]
-    public async Task InitializeFileTransfer_WithRecipientNotInAccessList_ReturnsBadRequest()
+    [Theory]
+    [InlineData("0192:999999999")]
+    [InlineData(UrnConstants.OrganizationNumberAttribute + ":999999999")]
+    public async Task InitializeFileTransfer_WithRecipientNotInAccessList_ReturnsBadRequest(string recipient)
     {
         // Arrange
         var file = FileTransferInitializeExtTestFactory.BasicFileTransfer_With_AccessList_Resource_And_No_Recipients();
-        file.Recipients.Add("0192:999999999");
+        file.Recipients.Add(recipient);
 
         // Act
         var initializeFileTransferResponse = await _senderClient.PostAsJsonAsync("broker/api/v1/filetransfer", file);
@@ -1170,12 +1173,14 @@ public class FileTransferControllerTests : IClassFixture<CustomWebApplicationFac
         Assert.Equal(Errors.RecipientNotInAccessList.Message, parsedError.Detail);
     }
 
-    [Fact]
-    public async Task InitializeFileTransfer_WithRecipientInAccessList_Succeeds()
+    [Theory]
+    [InlineData("0192:311764837")]
+    [InlineData(UrnConstants.OrganizationNumberAttribute + ":311764837")]
+    public async Task InitializeFileTransfer_WithRecipientInAccessList_Succeeds(string recipient)
     {
         // Arrange
         var file = FileTransferInitializeExtTestFactory.BasicFileTransfer_With_AccessList_Resource_And_No_Recipients();
-        file.Recipients.Add("0192:311764837");
+        file.Recipients.Add(recipient);
 
         // Act
         var initializeFileTransferResponse = await _senderClient.PostAsJsonAsync("broker/api/v1/filetransfer", file);
@@ -1188,13 +1193,15 @@ public class FileTransferControllerTests : IClassFixture<CustomWebApplicationFac
         Assert.Equal(FileTransferStatusExt.Initialized, parsedResponse.FileTransferStatus);
     }
 
-    [Fact]
-    public async Task InitializeFileTransfer_WithNotAllRecipientsInAccessList_ReturnsBadRequest()
+    [Theory]
+    [InlineData("0192:311764837", "0192:999999999")]
+    [InlineData(UrnConstants.OrganizationNumberAttribute + ":311764837", UrnConstants.OrganizationNumberAttribute + ":999999999")]
+    public async Task InitializeFileTransfer_WithNotAllRecipientsInAccessList_ReturnsBadRequest(string recipientInAccessList, string recipientNotInAccessList)
     {
         // Arrange
         var file = FileTransferInitializeExtTestFactory.BasicFileTransfer_With_AccessList_Resource_And_No_Recipients();
-        file.Recipients.Add("0192:311764837");
-        file.Recipients.Add("0192:999999999");
+        file.Recipients.Add(recipientInAccessList);
+        file.Recipients.Add(recipientNotInAccessList);
 
         // Act
         var initializeFileTransferResponse = await _senderClient.PostAsJsonAsync("broker/api/v1/filetransfer", file);

--- a/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -147,6 +147,14 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                     ServiceOwnerId = "0192:991825827",
                     OrganizationNumber = "991825827",
                 });
+            altinnResourceRepository.Setup(x => x.GetResource(It.Is(TestConstants.RESOURCE_WITH_MANIFEST_SHIM, StringComparer.Ordinal), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new ResourceEntity
+                {
+                    Id = TestConstants.RESOURCE_WITH_MANIFEST_SHIM,
+                    Created = DateTime.UtcNow,
+                    ServiceOwnerId = "0192:991825827",
+                    OrganizationNumber = "991825827",
+                });
             altinnResourceRepository.Setup(x => x.GetResource(It.Is(TestConstants.RESOURCE_FOR_TEST_REQUIREDPARTY, StringComparer.Ordinal), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => new ResourceEntity
                 {
@@ -156,7 +164,27 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                     OrganizationNumber = "991825827",
                     RequiredParty = true
                 });
+            altinnResourceRepository.Setup(x => x.GetResource(It.Is(TestConstants.RESOURCE_WITH_ACCESS_LIST, StringComparer.Ordinal), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new ResourceEntity
+                {
+                    Id = TestConstants.RESOURCE_WITH_ACCESS_LIST,
+                    Created = DateTime.UtcNow,
+                    ServiceOwnerId = "0192:991825827",
+                    OrganizationNumber = "991825827",
+                    AccessListEnabled = true
+                });
+            altinnResourceRepository.Setup(x => x.GetAccessListOfResource(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((List<string>?)null);
+            altinnResourceRepository.Setup(x => x.GetAccessListOfResource(It.Is(TestConstants.RESOURCE_WITH_ACCESS_LIST, StringComparer.Ordinal), It.Is("0192:311764837", StringComparer.Ordinal), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<string> { "gl908ae2-ci9f-481m-9700-1t7brok12345" });
             services.AddSingleton(altinnResourceRepository.Object);
+
+            var altinnRegisterService = new Mock<IAltinnRegisterService>();
+            altinnRegisterService.Setup(x => x.LookupPartyByUuid(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string?)null);
+            altinnRegisterService.Setup(x => x.LookupPartyByUuid(It.Is("gl908ae2-ci9f-481m-9700-1t7brok12345", StringComparer.Ordinal), It.IsAny<CancellationToken>()))
+                .ReturnsAsync("311764837");
+            services.AddSingleton(altinnRegisterService.Object);
 
             var authorizationService = new Mock<IAuthorizationService>();
             authorizationService.Setup(x => x.CheckAccessAsSender(It.IsAny<ClaimsPrincipal>(), It.Is<string>(resource => resource == TestConstants.RESOURCE_WITH_NO_ACCESS), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);

--- a/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -175,7 +175,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                 });
             altinnResourceRepository.Setup(x => x.GetAccessListOfResource(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((List<string>?)null);
-            altinnResourceRepository.Setup(x => x.GetAccessListOfResource(It.Is(TestConstants.RESOURCE_WITH_ACCESS_LIST, StringComparer.Ordinal), It.Is("0192:311764837", StringComparer.Ordinal), It.IsAny<CancellationToken>()))
+            altinnResourceRepository.Setup(x => x.GetAccessListOfResource(It.Is(TestConstants.RESOURCE_WITH_ACCESS_LIST, StringComparer.Ordinal), It.Is("311764837", StringComparer.Ordinal), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<string> { "gl908ae2-ci9f-481m-9700-1t7brok12345" });
             services.AddSingleton(altinnResourceRepository.Object);
 

--- a/tests/Altinn.Broker.Tests/Helpers/TestConstants.cs
+++ b/tests/Altinn.Broker.Tests/Helpers/TestConstants.cs
@@ -17,6 +17,8 @@ internal class TestConstants
     internal const string RESOURCE_FOR_TEST_REQUIREDPARTY = "ttd-brokertestressurs";
     internal const string RESOURCE_WITH_NO_ACCESS = "altinn-broker-test-resource-failed-access";
 
+    internal const string RESOURCE_WITH_ACCESS_LIST = "ttd-broker-tilgangsliste";
+
     internal const string RESOURCE_WITH_MANIFEST_SHIM = "manifest-shim-resource";
 
     internal const string RESOURCE_WITH_UNCONFIGURED_SERVICEOWNER = "altinn-broker-test-resource-with-unconfigured-serviceowner";


### PR DESCRIPTION
## Description
Fix PR which checks recipient towards accesslist

## Related Issue(s)
- #878 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

## Pre-deploy
- [x] Update scopes on prod client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced access-list validation for file transfers when a resource has access-list enabled; recipients must be verified.

* **Bug Fixes**
  * Initialization returns a clear error when one or more recipients are not permitted by the resource access list.

* **Configuration**
  * Resources can be configured to enable access-list enforcement.

* **Tests**
  * Added integration tests covering success and failure scenarios for access-list validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->