### PR TITLE
Optimize StuckFileTransferHandler and handle stuck UploadStarted

### DIFF
--- a/src/Altinn.Broker.Application/StuckFileTransfer/StuckFileTransferHandler.cs
+++ b/src/Altinn.Broker.Application/StuckFileTransfer/StuckFileTransferHandler.cs
@@ -1,42 +1,63 @@
 using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Domain.Enums;
+using Altinn.Broker.Core.Helpers;
 using Altinn.Broker.Core.Repositories;
+using Altinn.Broker.Core.Services;
+using Altinn.Broker.Core.Services.Enums;
+
+using Hangfire;
+
 using Microsoft.Extensions.Logging;
 
 namespace Altinn.Broker.Application;
 
-public class StuckFileTransferHandler
+public class StuckFileTransferHandler(
+    IFileTransferStatusRepository fileTransferStatusRepository,
+    IFileTransferRepository fileTransferRepository,
+    IBackgroundJobClient backgroundJobClient,
+    SlackStuckFileTransferNotifier slackNotifier,
+    ILogger<StuckFileTransferHandler> logger)
 {
-    private readonly IFileTransferStatusRepository _fileTransferStatusRepository;
-    private readonly ILogger<StuckFileTransferHandler> _logger;
-    private readonly SlackStuckFileTransferNotifier _slackNotifier;
-    private readonly int _stuckThresholdMinutes = 15;
-
-    public StuckFileTransferHandler(
-        IFileTransferStatusRepository fileTransferStatusRepository,
-        SlackStuckFileTransferNotifier slackNotifier,
-        ILogger<StuckFileTransferHandler> logger)
-    {
-        _fileTransferStatusRepository = fileTransferStatusRepository;
-        _slackNotifier = slackNotifier;
-        _logger = logger;
-    }
+    private readonly int _stuckInUploadProcessingThresholdMinutes = 15;
+    private readonly int _stuckInUploadStartingThresholdMinutes = 60 * 24;
 
     public async Task CheckForStuckFileTransfers(CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Checking for file transfers stuck in upload processing or upload started");
-        List<FileTransferStatusEntity> stuckFileTransfers = await _fileTransferStatusRepository.GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(
-            new List<FileTransferStatus> { FileTransferStatus.UploadProcessing, FileTransferStatus.UploadStarted }, 
-            DateTime.UtcNow.AddMinutes(-_stuckThresholdMinutes), 
+        logger.LogInformation("Checking for file transfers stuck in upload started");
+
+        var stuckInUploadStarted = await fileTransferStatusRepository.GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(
+            new List<FileTransferStatus> { FileTransferStatus.UploadStarted },
+            DateTime.UtcNow.AddMinutes(-_stuckInUploadStartingThresholdMinutes),
             cancellationToken);
 
-        foreach (FileTransferStatusEntity status in stuckFileTransfers)
+        foreach (FileTransferStatusEntity fileTransferStatus in stuckInUploadStarted)
         {
-            _logger.LogWarning("File transfer {fileTransferId} has been stuck in {status} for more than {thresholdMinutes} minutes", status.FileTransferId, status.Status, _stuckThresholdMinutes);
-            var succesfullNotification = await _slackNotifier.NotifyFileStuckWithStatus(status);
+            var fileTransfer = await fileTransferRepository.GetFileTransfer(fileTransferStatus.FileTransferId, cancellationToken);
+            if (fileTransfer is null)
+            {
+                throw new Exception("File transfer with id {fileTransferId} was not found in the database, even though it has a status entry.");
+            }
+            await TransactionWithRetriesPolicy.Execute(async (cancellationToken) =>
+            {
+                logger.LogError("File transfer {fileTransferId} has been stuck in UploadStarted for more than {thresholdMinutes} minutes. Marking as failed.", fileTransferStatus.FileTransferId, _stuckInUploadStartingThresholdMinutes);
+                await fileTransferStatusRepository.InsertFileTransferStatus(fileTransferStatus.FileTransferId, FileTransferStatus.Failed, timestamp: DateTime.UtcNow, "File transfer was stuck in UploadStarted as it failed upload mid-request.", cancellationToken);
+                backgroundJobClient.Enqueue<IEventBus>((eventBus) => eventBus.Publish(AltinnEventType.UploadFailed, fileTransfer.ResourceId, fileTransfer.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Sender, CancellationToken.None));
+                return Task.CompletedTask;
+            }, logger, cancellationToken);
+        }
+
+        logger.LogInformation("Checking for file transfers stuck in upload processing");
+        var stuckInUploadProcessing = await fileTransferStatusRepository.GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(
+            new List<FileTransferStatus> { FileTransferStatus.UploadProcessing },
+            DateTime.UtcNow.AddMinutes(-_stuckInUploadProcessingThresholdMinutes),
+            cancellationToken);
+        foreach (FileTransferStatusEntity status in stuckInUploadProcessing)
+        {
+            logger.LogWarning("File transfer {fileTransferId} has been stuck in UploadProcessing for more than {thresholdMinutes} minutes", status.FileTransferId, _stuckInUploadProcessingThresholdMinutes);
+            var succesfullNotification = await slackNotifier.NotifyFileStuckWithStatus(status);
             if (!succesfullNotification)
             {
-                _logger.LogError("Failed to send Slack notification for file transfer {fileTransferId}", status.FileTransferId);
+                logger.LogError("Failed to send Slack notification for file transfer {fileTransferId}", status.FileTransferId);
             }
         }
     }

--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferStatusRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferStatusRepository.cs
@@ -99,7 +99,7 @@ public class FileTransferStatusRepository(NpgsqlDataSource dataSource, ExecuteDB
 			LEFT JOIN broker.file_transfer_status_description ftsd on ftsd.file_transfer_status_description_id_pk = ft.latest_file_status_id 
             WHERE ft.latest_file_status_id = ANY(@statusFilters)
             AND ft.latest_file_status_date < @minStatusDate
-        )";
+        ";
 
         await using var command = dataSource.CreateCommand(query);
         command.Parameters.AddWithValue("@statusFilters", statusFilters.Select(s => (int)s).ToArray());

--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferStatusRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferStatusRepository.cs
@@ -116,7 +116,7 @@ public class FileTransferStatusRepository(NpgsqlDataSource dataSource, ExecuteDB
                     FileTransferId = reader.GetGuid(reader.GetOrdinal("file_transfer_id_pk")),
                     Status = (FileTransferStatus)reader.GetInt32(reader.GetOrdinal("latest_file_status_id")),
                     Date = reader.GetDateTime(reader.GetOrdinal("latest_file_status_date")),
-                    DetailedStatus = reader.GetString(reader.GetOrdinal("file_transfer_status_detailed_description"))
+                    DetailedStatus = reader.GetString(reader.GetOrdinal("file_transfer_status_description"))
                 });
             }
             return fileTransferStatuses;

--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferStatusRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferStatusRepository.cs
@@ -94,16 +94,12 @@ public class FileTransferStatusRepository(NpgsqlDataSource dataSource, ExecuteDB
     public async Task<List<FileTransferStatusEntity>> GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(List<FileTransferStatus> statusFilters, DateTime minStatusDate, CancellationToken cancellationToken)
     {
         var query = @"
-            SELECT file_transfer_id_fk, file_transfer_status_description_id_fk, 
-                file_transfer_status_date, file_transfer_status_detailed_description
-            FROM broker.file_transfer_status fis
-            WHERE fis.file_transfer_status_description_id_fk = ANY(@statusFilters)
-            AND fis.file_transfer_status_date < @minStatusDate
-            AND fis.file_transfer_status_date = (
-                SELECT MAX(file_transfer_status_date)
-                FROM broker.file_transfer_status
-                WHERE file_transfer_id_fk = fis.file_transfer_id_fk
-            )";
+            SELECT ft.file_transfer_id_pk, ft.latest_file_status_id, ft.latest_file_status_date, ftsd.file_transfer_status_description
+            FROM broker.file_transfer ft 
+			LEFT JOIN broker.file_transfer_status_description ftsd on ftsd.file_transfer_status_description_id_pk = ft.latest_file_status_id 
+            WHERE ft.latest_file_status_id = ANY(@statusFilters)
+            AND ft.latest_file_status_date < @minStatusDate
+        )";
 
         await using var command = dataSource.CreateCommand(query);
         command.Parameters.AddWithValue("@statusFilters", statusFilters.Select(s => (int)s).ToArray());
@@ -117,12 +113,10 @@ public class FileTransferStatusRepository(NpgsqlDataSource dataSource, ExecuteDB
             {
                 fileTransferStatuses.Add(new FileTransferStatusEntity()
                 {
-                    FileTransferId = reader.GetGuid(reader.GetOrdinal("file_transfer_id_fk")),
-                    Status = (FileTransferStatus)reader.GetInt32(reader.GetOrdinal("file_transfer_status_description_id_fk")),
-                    Date = reader.GetDateTime(reader.GetOrdinal("file_transfer_status_date")),
-                    DetailedStatus = reader.IsDBNull(reader.GetOrdinal("file_transfer_status_detailed_description")) 
-                        ? null 
-                        : reader.GetString(reader.GetOrdinal("file_transfer_status_detailed_description"))
+                    FileTransferId = reader.GetGuid(reader.GetOrdinal("file_transfer_id_pk")),
+                    Status = (FileTransferStatus)reader.GetInt32(reader.GetOrdinal("latest_file_status_id")),
+                    Date = reader.GetDateTime(reader.GetOrdinal("latest_file_status_date")),
+                    DetailedStatus = reader.GetString(reader.GetOrdinal("file_transfer_status_detailed_description"))
                 });
             }
             return fileTransferStatuses;

--- a/tests/Altinn.Broker.Tests/StuckFileTransferHandlerTests.cs
+++ b/tests/Altinn.Broker.Tests/StuckFileTransferHandlerTests.cs
@@ -3,6 +3,8 @@ using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Options;
 using Altinn.Broker.Core.Repositories;
 
+using Hangfire;
+
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -21,6 +23,8 @@ public class StuckFileTransferHandlerTests
     {
         // Arrange
         var fileTransferStatusRepository = new Mock<IFileTransferStatusRepository>();
+        var fileTransferRepository = new Mock<IFileTransferRepository>();
+        var backgroundJobClient = new Mock<IBackgroundJobClient>();
         var slackClient = new Mock<ISlackClient>();
         var monitorLogger = new Mock<ILogger<StuckFileTransferHandler>>();
         var notifierLogger = new Mock<ILogger<SlackStuckFileTransferNotifier>>();
@@ -28,7 +32,7 @@ public class StuckFileTransferHandlerTests
         hostEnvironment.SetupGet(e => e.EnvironmentName).Returns("Test");
         var slackSettings = new SlackSettings(hostEnvironment.Object);
         var slackNotifier = new SlackStuckFileTransferNotifier(notifierLogger.Object, slackClient.Object, hostEnvironment.Object, slackSettings);
-        var handler = new StuckFileTransferHandler(fileTransferStatusRepository.Object, slackNotifier, monitorLogger.Object);
+        var handler = new StuckFileTransferHandler(fileTransferStatusRepository.Object, fileTransferRepository.Object, backgroundJobClient.Object, slackNotifier, monitorLogger.Object);
         var cancellationToken = new CancellationToken();
         fileTransferStatusRepository.Setup(r => r
             .GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(It.IsAny<List<Core.Domain.Enums.FileTransferStatus>>(), It.IsAny<DateTime>(), cancellationToken))
@@ -51,6 +55,8 @@ public class StuckFileTransferHandlerTests
     {
         // Arrange
         var fileTransferStatusRepository = new Mock<IFileTransferStatusRepository>();
+        var fileTransferRepository = new Mock<IFileTransferRepository>();
+        var backgroundJobClient = new Mock<IBackgroundJobClient>();
         var slackClient = new Mock<ISlackClient>();
         var monitorLogger = new Mock<ILogger<StuckFileTransferHandler>>();
         var notifierLogger = new Mock<ILogger<SlackStuckFileTransferNotifier>>();
@@ -58,7 +64,7 @@ public class StuckFileTransferHandlerTests
         hostEnvironment.SetupGet(e => e.EnvironmentName).Returns("Test");
         var slackSettings = new SlackSettings(hostEnvironment.Object);
         var slackNotifier = new SlackStuckFileTransferNotifier(notifierLogger.Object, slackClient.Object, hostEnvironment.Object, slackSettings);
-        var handler = new StuckFileTransferHandler(fileTransferStatusRepository.Object, slackNotifier, monitorLogger.Object);
+        var handler = new StuckFileTransferHandler(fileTransferStatusRepository.Object, fileTransferRepository.Object, backgroundJobClient.Object, slackNotifier, monitorLogger.Object);
         var cancellationToken = new CancellationToken();
         var fileTransferId = Guid.NewGuid();
         var stuckfileTransferStatuses = new List<FileTransferStatusEntity>()

--- a/tests/Altinn.Broker.Tests/StuckFileTransferHandlerTests.cs
+++ b/tests/Altinn.Broker.Tests/StuckFileTransferHandlerTests.cs
@@ -3,8 +3,12 @@ using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Domain.Enums;
 using Altinn.Broker.Core.Options;
 using Altinn.Broker.Core.Repositories;
+using Altinn.Broker.Core.Services;
+using Altinn.Broker.Core.Services.Enums;
 
 using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
 
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -36,7 +40,7 @@ public class StuckFileTransferHandlerTests
         var handler = new StuckFileTransferHandler(fileTransferStatusRepository.Object, fileTransferRepository.Object, backgroundJobClient.Object, slackNotifier, monitorLogger.Object);
         var cancellationToken = new CancellationToken();
         fileTransferStatusRepository.Setup(r => r
-            .GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(It.IsAny<List<Core.Domain.Enums.FileTransferStatus>>(), It.IsAny<DateTime>(), cancellationToken))
+            .GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(It.IsAny<List<FileTransferStatus>>(), It.IsAny<DateTime>(), cancellationToken))
             .ReturnsAsync(new List<FileTransferStatusEntity>());
 
         // Act
@@ -73,12 +77,21 @@ public class StuckFileTransferHandlerTests
             new FileTransferStatusEntity()
             {
                 FileTransferId = fileTransferId,
-                Status = Core.Domain.Enums.FileTransferStatus.UploadProcessing,
+                Status = FileTransferStatus.UploadProcessing,
                 Date = DateTime.UtcNow.AddMinutes(-16)
             }
         };
         fileTransferStatusRepository.Setup(r => r
-            .GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(It.IsAny<List<FileTransferStatus>>(), It.IsAny<DateTime>(), cancellationToken))
+            .GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(
+                It.Is<List<FileTransferStatus>>(s => s.Count == 1 && s[0] == FileTransferStatus.UploadStarted),
+                It.IsAny<DateTime>(),
+                cancellationToken))
+            .ReturnsAsync(new List<FileTransferStatusEntity>());
+        fileTransferStatusRepository.Setup(r => r
+            .GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(
+                It.Is<List<FileTransferStatus>>(s => s.Count == 1 && s[0] == FileTransferStatus.UploadProcessing),
+                It.IsAny<DateTime>(),
+                cancellationToken))
             .ReturnsAsync(stuckfileTransferStatuses);
         fileTransferRepository.Setup(r => r.GetFileTransfer(fileTransferId, cancellationToken)).ReturnsAsync(new FileTransferEntity()
         {
@@ -117,5 +130,95 @@ public class StuckFileTransferHandlerTests
             m.Text.Contains(fileTransferId.ToString()) && 
             m.Text.Contains("UploadProcessing"))), 
             Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckForStuckFileTransfers_WhenStuckInUploadStarted_InsertsFailedAndEnqueuesUploadFailedEvent()
+    {
+        // Arrange
+        var fileTransferStatusRepository = new Mock<IFileTransferStatusRepository>();
+        var fileTransferRepository = new Mock<IFileTransferRepository>();
+        var backgroundJobClient = new Mock<IBackgroundJobClient>();
+        var slackClient = new Mock<ISlackClient>();
+        var monitorLogger = new Mock<ILogger<StuckFileTransferHandler>>();
+        var notifierLogger = new Mock<ILogger<SlackStuckFileTransferNotifier>>();
+        var hostEnvironment = new Mock<IHostEnvironment>();
+        hostEnvironment.SetupGet(e => e.EnvironmentName).Returns("Test");
+        var slackSettings = new SlackSettings(hostEnvironment.Object);
+        var slackNotifier = new SlackStuckFileTransferNotifier(notifierLogger.Object, slackClient.Object, hostEnvironment.Object, slackSettings);
+        var handler = new StuckFileTransferHandler(fileTransferStatusRepository.Object, fileTransferRepository.Object, backgroundJobClient.Object, slackNotifier, monitorLogger.Object);
+        var cancellationToken = new CancellationToken();
+        var fileTransferId = Guid.NewGuid();
+        var stuckInUploadStartedStatuses = new List<FileTransferStatusEntity>
+        {
+            new()
+            {
+                FileTransferId = fileTransferId,
+                Status = FileTransferStatus.UploadStarted,
+                Date = DateTime.UtcNow.AddDays(-2)
+            }
+        };
+        fileTransferStatusRepository.Setup(r => r
+            .GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(
+                It.Is<List<FileTransferStatus>>(s => s.Count == 1 && s[0] == FileTransferStatus.UploadStarted),
+                It.IsAny<DateTime>(),
+                cancellationToken))
+            .ReturnsAsync(stuckInUploadStartedStatuses);
+        fileTransferStatusRepository.Setup(r => r
+            .GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(
+                It.Is<List<FileTransferStatus>>(s => s.Count == 1 && s[0] == FileTransferStatus.UploadProcessing),
+                It.IsAny<DateTime>(),
+                cancellationToken))
+            .ReturnsAsync(new List<FileTransferStatusEntity>());
+        fileTransferStatusRepository.Setup(r => r.InsertFileTransferStatus(
+                fileTransferId,
+                FileTransferStatus.Failed,
+                It.IsAny<DateTimeOffset>(),
+                It.Is<string>(d => d.Contains("UploadStarted")),
+                cancellationToken))
+            .Returns(Task.CompletedTask);
+        var fileTransferEntity = new FileTransferEntity
+        {
+            FileTransferId = fileTransferId,
+            ResourceId = "test-resource",
+            Sender = new ActorEntity { ActorExternalId = "0192:123456789" },
+            Created = DateTime.UtcNow.AddHours(-1),
+            ExpirationTime = DateTime.UtcNow,
+            FileName = "testfile.txt",
+            FileTransferStatusEntity = stuckInUploadStartedStatuses.First(),
+            RecipientCurrentStatuses = new List<ActorFileTransferStatusEntity>()
+        };
+        fileTransferRepository.Setup(r => r.GetFileTransfer(fileTransferId, cancellationToken)).ReturnsAsync(fileTransferEntity);
+        Job? capturedJob = null;
+        backgroundJobClient.Setup(c => c.Create(It.IsAny<Job>(), It.IsAny<IState>()))
+            .Callback<Job, IState>((job, _) => capturedJob = job)
+            .Returns("job-id");
+
+        // Act
+        await handler.CheckForStuckFileTransfers(cancellationToken);
+
+        // Assert
+        fileTransferStatusRepository.Verify(r => r.InsertFileTransferStatus(
+            fileTransferId,
+            FileTransferStatus.Failed,
+            It.IsAny<DateTimeOffset>(),
+            It.Is<string>(d => d.Contains("UploadStarted")),
+            cancellationToken), Times.Once);
+        backgroundJobClient.Verify(c => c.Create(It.IsAny<Job>(), It.IsAny<IState>()), Times.Once);
+        Assert.NotNull(capturedJob);
+        Assert.Equal(typeof(IEventBus), capturedJob!.Type);
+        Assert.Equal(nameof(IEventBus.Publish), capturedJob.Method.Name);
+        Assert.Equal(AltinnEventType.UploadFailed, capturedJob.Args[0]);
+        Assert.Equal("test-resource", capturedJob.Args[1]);
+        Assert.Equal(fileTransferId.ToString(), capturedJob.Args[2]);
+        Assert.Equal("0192:123456789", capturedJob.Args[3]);
+        Assert.Equal(AltinnEventSubjectRole.Sender, capturedJob.Args[5]);
+        monitorLogger.Verify(l => l.Log(
+            LogLevel.Error,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains(fileTransferId.ToString()) && v.ToString()!.Contains("UploadStarted")),
+            It.IsAny<Exception>(),
+            (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()), Times.Once);
+        slackClient.Verify(s => s.PostAsync(It.IsAny<SlackMessage>()), Times.Never);
     }
 }

--- a/tests/Altinn.Broker.Tests/StuckFileTransferHandlerTests.cs
+++ b/tests/Altinn.Broker.Tests/StuckFileTransferHandlerTests.cs
@@ -1,5 +1,6 @@
 using Altinn.Broker.Application;
 using Altinn.Broker.Core.Domain;
+using Altinn.Broker.Core.Domain.Enums;
 using Altinn.Broker.Core.Options;
 using Altinn.Broker.Core.Repositories;
 
@@ -45,7 +46,7 @@ public class StuckFileTransferHandlerTests
         monitorLogger.Verify(l => l.Log(
             LogLevel.Information,
             It.IsAny<EventId>(),
-            It.Is<It.IsAnyType>((v, t) => v.ToString() == "Checking for file transfers stuck in upload processing or upload started"),
+            It.Is<It.IsAnyType>((v, t) => v.ToString() == "Checking for file transfers stuck in upload started"),
             It.IsAny<Exception>(),
             (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()), Times.Once);
     }
@@ -77,8 +78,29 @@ public class StuckFileTransferHandlerTests
             }
         };
         fileTransferStatusRepository.Setup(r => r
-            .GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(It.IsAny<List<Core.Domain.Enums.FileTransferStatus>>(), It.IsAny<DateTime>(), cancellationToken))
+            .GetCurrentFileTransferStatusesOfStatusAndOlderThanDate(It.IsAny<List<FileTransferStatus>>(), It.IsAny<DateTime>(), cancellationToken))
             .ReturnsAsync(stuckfileTransferStatuses);
+        fileTransferRepository.Setup(r => r.GetFileTransfer(fileTransferId, cancellationToken)).ReturnsAsync(new FileTransferEntity()
+        {
+            FileTransferId = fileTransferId,
+            ResourceId = "test-resource",
+            Sender = new ActorEntity() { ActorExternalId = "0192:123456789" },
+            Created = DateTime.UtcNow.AddHours(-1),
+            ExpirationTime = DateTime.UtcNow,
+            FileName = "testfile.txt",
+            FileTransferStatusEntity = stuckfileTransferStatuses.First(),
+            RecipientCurrentStatuses = new List<ActorFileTransferStatusEntity>()
+            {
+                new ActorFileTransferStatusEntity()
+                {
+                    Actor = new ActorEntity() {
+                        ActorExternalId = "0192:987654321"
+                    },
+                    Status = ActorFileTransferStatus.Initialized,
+                    Date = DateTime.UtcNow.AddMinutes(-16)
+                }
+            }
+        });
 
         // Act
         await handler.CheckForStuckFileTransfers(cancellationToken);


### PR DESCRIPTION
## Description
The query was too slow so used the new denormalized fields for latest status instead to make it near-instant. Also added handling of stuck UploadStarted as this may occur "naturally" if a request is cancelled. 

## Related Issue(s)
- #913 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stuck file transfers: separate timeouts for "upload started" vs "upload processing", faster detection for processing-stage stalls, clearer logging, reliable marking of failed transfers, and ensured upload-failed events are enqueued. Slack alerts are now targeted to processing-stage issues only.

* **Refactor**
  * Status lookup streamlined to use latest-status fields for more consistent and performant stale-transfer detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->