### PR TITLE
No interim commits for malware scanned transfers

### DIFF
--- a/src/Altinn.Broker.Integrations/Azure/AzureStorageService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureStorageService.cs
@@ -113,7 +113,9 @@ public class AzureStorageService(IOptions<AzureStorageOptions> azureStorageOptio
                     }
                 }
 
-                if (uploadTasks.Count >= azureStorageOptions.Value.BlocksBeforeCommit)
+                // Use interim commits to prevent too many uncommitted blocks for very large files
+                // No interim commits with malware-scanned uploads as scan starts at first commit
+                if (!fileTransferEntity.UseVirusScan && uploadTasks.Count >= azureStorageOptions.Value.BlocksBeforeCommit)
                 {
                     await Task.WhenAll(uploadTasks);
                     var isFirstCommitForThisCall = !createdBlobByThisAttempt;


### PR DESCRIPTION
## Description
When doing multi-terabyte uploads we need to use interim commits to avoid errors when the uncommitted block count becomes too big. Not really necessary for 50gb so disable use of interim commits entirely for malware scanned files as the malware scan is triggered by the interim commit.

## Related Issue(s)
- #{issue number}

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload handling for virus-scanned transfers by adjusting when interim block commits occur, ensuring scanned uploads properly stage blocks without premature intermediate commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->