### PR TITLE
exclude statusMessage from broker report

### DIFF
--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -66,6 +66,7 @@ var containerAppEnvVars = [
   { name: 'AzureStorageOptions__ConcurrentUploadThreads', value: '3' }
   { name: 'AzureStorageOptions__BlocksBeforeCommit', value: '1000' }
   { name: 'ReportStorageOptions__ConnectionString', secretRef: 'storage-connection-string' }
+  { name: 'ReportResourceIdFilter', secretRef: 'report-resource-id-filter' }
   { name: 'OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION', value: 'true' }
 ]
 
@@ -144,6 +145,11 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
           identity: principal_id
           keyVaultUrl: '${keyVaultUrl}/secrets/storage-connection-string'
           name: 'storage-connection-string'
+        }
+        {
+          identity: principal_id
+          keyVaultUrl: '${keyVaultUrl}/secrets/report-resource-id-filter'
+          name: 'report-resource-id-filter'
         }
       ]
     }

--- a/src/Altinn.Broker.API/Program.cs
+++ b/src/Altinn.Broker.API/Program.cs
@@ -102,6 +102,7 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
     services.Configure<MaskinportenSettings>(config.GetSection(key: nameof(MaskinportenSettings)));
     services.Configure<AzureStorageOptions>(config.GetSection(key: nameof(AzureStorageOptions)));
     services.Configure<ReportStorageOptions>(config.GetSection(key: nameof(ReportStorageOptions)));
+    services.Configure<ReportFilterOptions>(config);
     services.Configure<GeneralSettings>(config.GetSection(key: nameof(GeneralSettings)));
 
     services.AddApplicationHandlers();

--- a/src/Altinn.Broker.Application/GenerateReport/GenerateDailySummaryReportHandler.cs
+++ b/src/Altinn.Broker.Application/GenerateReport/GenerateDailySummaryReportHandler.cs
@@ -229,7 +229,6 @@ public class GenerateDailySummaryReportHandler(
         try
         {
             var resourceIdFilter = ParseResourceIdFilter(reportFilterOptions.Value.ReportResourceIdFilter);
-            logger.LogInformation("Using resource ID filter for report generation: {filter}", resourceIdFilter != null ? string.Join(", ", resourceIdFilter) : "None");
             var aggregatedData = await fileTransferRepository.GetAggregatedDailySummaryData(cancellationToken, resourceIdFilter);
             
             if (!aggregatedData.Any())

--- a/src/Altinn.Broker.Application/GenerateReport/GenerateDailySummaryReportHandler.cs
+++ b/src/Altinn.Broker.Application/GenerateReport/GenerateDailySummaryReportHandler.cs
@@ -229,6 +229,7 @@ public class GenerateDailySummaryReportHandler(
         try
         {
             var resourceIdFilter = ParseResourceIdFilter(reportFilterOptions.Value.ReportResourceIdFilter);
+            logger.LogInformation("Using resource ID filter for report generation: {filter}", resourceIdFilter != null ? string.Join(", ", resourceIdFilter) : "None");
             var aggregatedData = await fileTransferRepository.GetAggregatedDailySummaryData(cancellationToken, resourceIdFilter);
             
             if (!aggregatedData.Any())

--- a/src/Altinn.Broker.Application/GenerateReport/GenerateDailySummaryReportHandler.cs
+++ b/src/Altinn.Broker.Application/GenerateReport/GenerateDailySummaryReportHandler.cs
@@ -19,7 +19,7 @@ public class GenerateDailySummaryReportHandler(
     IServiceOwnerRepository serviceOwnerRepository,
     IResourceRepository resourceRepository,
     IAltinnResourceRepository altinnResourceRepository,
-    IOptions<ReportStorageOptions> reportStorageOptions,
+    IOptions<ReportFilterOptions> reportFilterOptions,
     IBrokerStorageService brokerStorageService,
     ILogger<GenerateDailySummaryReportHandler> logger,
     IHostEnvironment hostEnvironment)
@@ -32,7 +32,8 @@ public class GenerateDailySummaryReportHandler(
         {
             logger.LogInformation("Starting daily summary report generation with Altinn2Included={altinn2Included}", request.Altinn2Included);
 
-            var aggregatedData = await fileTransferRepository.GetAggregatedDailySummaryData(cancellationToken);
+            var resourceIdFilter = ParseResourceIdFilter(reportFilterOptions.Value.ReportResourceIdFilter);
+            var aggregatedData = await fileTransferRepository.GetAggregatedDailySummaryData(cancellationToken, resourceIdFilter);
             logger.LogInformation("Retrieved {count} aggregated records for daily summary report", aggregatedData.Count);
 
             if (aggregatedData.Count == 0)
@@ -227,7 +228,8 @@ public class GenerateDailySummaryReportHandler(
 
         try
         {
-            var aggregatedData = await fileTransferRepository.GetAggregatedDailySummaryData(cancellationToken);
+            var resourceIdFilter = ParseResourceIdFilter(reportFilterOptions.Value.ReportResourceIdFilter);
+            var aggregatedData = await fileTransferRepository.GetAggregatedDailySummaryData(cancellationToken, resourceIdFilter);
             
             if (!aggregatedData.Any())
             {
@@ -267,6 +269,17 @@ public class GenerateDailySummaryReportHandler(
             logger.LogError(ex, "Failed to generate daily summary report for download");
             return StatisticsErrors.ReportGenerationFailed;
         }
+    }
+
+    private static string[]? ParseResourceIdFilter(string? csv)
+    {
+        if (string.IsNullOrWhiteSpace(csv))
+            return null;
+
+        var ids = csv
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return ids.Length > 0 ? ids : null;
     }
 }
 

--- a/src/Altinn.Broker.Application/GenerateReport/GenerateDailySummaryReportHandler.cs
+++ b/src/Altinn.Broker.Application/GenerateReport/GenerateDailySummaryReportHandler.cs
@@ -274,12 +274,12 @@ public class GenerateDailySummaryReportHandler(
     private static string[]? ParseResourceIdFilter(string? csv)
     {
         if (string.IsNullOrWhiteSpace(csv))
-            return null;
+            return [];
 
         var ids = csv
             .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
-        return ids.Length > 0 ? ids : null;
+        return ids.Length > 0 ? ids : [];
     }
 }
 

--- a/src/Altinn.Broker.Core/Options/ReportFilterOptions.cs
+++ b/src/Altinn.Broker.Core/Options/ReportFilterOptions.cs
@@ -1,0 +1,12 @@
+namespace Altinn.Broker.Core.Options;
+
+public class ReportFilterOptions
+{
+    /// <summary>
+    /// Comma-separated list of resource IDs for which file transfers with
+    /// statusMessage=true should be excluded from the daily summary report.
+    /// When null or empty, no filtering is applied.
+    /// Sourced from an Azure Key Vault secret.
+    /// </summary>
+    public string? ReportResourceIdFilter { get; set; }
+}

--- a/src/Altinn.Broker.Core/Repositories/IFileTransferRepository.cs
+++ b/src/Altinn.Broker.Core/Repositories/IFileTransferRepository.cs
@@ -34,7 +34,7 @@ public interface IFileTransferRepository
 
     Task<List<Guid>> GetFileTransfersByResourceId(string resourceId, DateTimeOffset minAge, CancellationToken cancellationToken);
     Task<int> HardDeleteFileTransfersByIds(IEnumerable<Guid> fileTransferIds, CancellationToken cancellationToken);
-    Task<List<AggregatedDailySummaryData>> GetAggregatedDailySummaryData(CancellationToken cancellationToken);
+    Task<List<AggregatedDailySummaryData>> GetAggregatedDailySummaryData(CancellationToken cancellationToken, string[]? resourceIdFilter = null);
 }
 
 public class AggregatedDailySummaryData

--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
@@ -880,9 +880,21 @@ LEFT JOIN LATERAL (
         return await commandExecutor.ExecuteWithRetry(command.ExecuteNonQueryAsync, cancellationToken);
     }
 
-    public async Task<List<AggregatedDailySummaryData>> GetAggregatedDailySummaryData(CancellationToken cancellationToken)
+    public async Task<List<AggregatedDailySummaryData>> GetAggregatedDailySummaryData(CancellationToken cancellationToken, string[]? resourceIdFilter = null)
     {
-        const string query = @"
+        bool hasResourceFilter = resourceIdFilter is { Length: > 0 };
+
+        string statusMessageFilterClause = hasResourceFilter
+            ? @"WHERE NOT EXISTS (
+                SELECT 1 FROM broker.file_transfer_property ftp
+                WHERE ftp.file_transfer_id_fk = f.file_transfer_id_pk
+                  AND ftp.key = 'statusMessage'
+                  AND ftp.value = 'true'
+                  AND f.resource_id = ANY(@resourceIds)
+            )"
+            : "";
+
+        string query = $@"
             WITH latest_recipient_status AS (
                 SELECT DISTINCT ON (afs.file_transfer_id_fk, afs.actor_id_fk)
                     afs.file_transfer_id_fk,
@@ -916,6 +928,7 @@ LEFT JOIN LATERAL (
             LEFT JOIN broker.altinn_resource r ON r.resource_id_pk = f.resource_id
             LEFT JOIN latest_recipient_status lrs ON lrs.file_transfer_id_fk = f.file_transfer_id_pk
             LEFT JOIN broker.actor recipient ON recipient.actor_id_pk = lrs.actor_id_fk
+            {statusMessageFilterClause}
             GROUP BY 
                 DATE(f.created),
                 EXTRACT(YEAR FROM f.created),
@@ -940,6 +953,13 @@ LEFT JOIN LATERAL (
 
         await using var command = dataSource.CreateCommand(query);
         command.CommandTimeout = 600;
+        if (hasResourceFilter)
+        {
+            command.Parameters.Add(new NpgsqlParameter("@resourceIds", NpgsqlDbType.Array | NpgsqlDbType.Text)
+            {
+                Value = resourceIdFilter
+            });
+        }
         
         return await commandExecutor.ExecuteWithRetry(async (ct) =>
         {

--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
@@ -882,7 +882,7 @@ LEFT JOIN LATERAL (
 
     public async Task<List<AggregatedDailySummaryData>> GetAggregatedDailySummaryData(CancellationToken cancellationToken, string[]? resourceIdFilter = null)
     {
-        bool hasResourceFilter = resourceIdFilter is { Length: > 0 };
+        bool hasResourceFilter = resourceIdFilter != null && resourceIdFilter.Length > 0;
 
         string statusMessageFilterClause = hasResourceFilter
             ? @"WHERE NOT EXISTS (

--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
@@ -888,8 +888,8 @@ LEFT JOIN LATERAL (
             ? @"WHERE NOT EXISTS (
                 SELECT 1 FROM broker.file_transfer_property ftp
                 WHERE ftp.file_transfer_id_fk = f.file_transfer_id_pk
-                  AND ftp.key = 'statusMessage'
-                  AND ftp.value = 'true'
+                  AND LOWER(ftp.key) = 'statusmessage'
+                  AND LOWER(ftp.value) = 'true'
                   AND f.resource_id = ANY(@resourceIds)
             )"
             : "";


### PR DESCRIPTION
## Description
Added a report resource filter secret in key vault which stores resources whose statusMessages should be exempt from the broker report. Updated query to not return the resources with statusMessage.

## Related Issue(s)
- #888 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily summary reports can be filtered by a comma-separated list of resource IDs to exclude specific file transfers.
  * The filter is configurable via a new Key Vault-backed secret and is loaded at application startup.

* **Bug Fixes**
  * Report generation now applies the configured resource ID filter when assembling daily summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->