### PR TITLE
jwk rotation for broker

### DIFF
--- a/.azure/applications/api/main.bicep
+++ b/.azure/applications/api/main.bicep
@@ -97,7 +97,11 @@ module fetchEventGridIpsScript '../../modules/containerApp/fetchEventGridIps.bic
 module containerApp '../../modules/containerApp/main.bicep' = {
   name: containerAppName
   scope: resourceGroup
-  dependsOn: [keyvaultAddReaderRolesAppIdentity, databaseAccess]
+  dependsOn: [
+    keyvaultAddReaderRolesAppIdentity
+    keyvaultAddSecretsOfficerRoleAppIdentity
+    databaseAccess
+  ]
   params: {
     eventGridIps: fetchEventGridIpsScript.outputs.eventGridIps!
     namePrefix: namePrefix

--- a/.azure/applications/api/main.bicep
+++ b/.azure/applications/api/main.bicep
@@ -55,6 +55,16 @@ module keyvaultAddReaderRolesAppIdentity '../../modules/keyvault/addReaderRoles.
   }
 }
 
+module keyvaultAddSecretsOfficerRoleAppIdentity '../../modules/keyvault/addSecretsOfficerRole.bicep' = if (contains(['test', 'staging'], environment)) {
+  name: 'kv-secrets-officer-${namePrefix}-app'
+  scope: resourceGroup
+  params: {
+    keyvaultName: sourceKeyVaultName
+    principalObjectId: appIdentity.outputs.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
 module databaseAccess '../../modules/postgreSql/AddAdministrationAccess.bicep' = {
   name: 'databaseAccess'
   scope: resourceGroup

--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -20,6 +20,14 @@ param containerAppEnvId string
 @secure()
 param apimIp string
 
+var rotationLeaderEnvironments = [
+  'test'
+  'staging'
+]
+var rotationEnabled = contains(rotationLeaderEnvironments, environment)
+var containerAppName = '${namePrefix}-app'
+var containerAppResourceId = resourceId('Microsoft.App/containerApps', containerAppName)
+
 var probes = [
   {
     httpGet: {
@@ -30,7 +38,17 @@ var probes = [
   }
 ]
 
-var containerAppEnvVars = [
+var rotationContainerAppEnvVars = rotationEnabled ? [
+  { name: 'MaskinportenJwkRotationSettings__Enabled', value: string(rotationEnabled) }
+  { name: 'MaskinportenJwkRotationSettings__KeyVaultUrl', value: keyVaultUrl }
+  { name: 'MaskinportenJwkRotationSettings__ContainerAppResourceId', value: containerAppResourceId }
+  { name: 'MaskinportenJwkRotationSettings__AdminClientId', secretRef: 'maskinporten-admin-client-id' }
+  { name: 'MaskinportenJwkRotationSettings__AdminEncodedJwk', secretRef: 'maskinporten-admin-jwk' }
+] : [
+  { name: 'MaskinportenJwkRotationSettings__Enabled', value: string(rotationEnabled) }
+]
+
+var containerAppEnvVars = concat([
   { name: 'ASPNETCORE_ENVIRONMENT', value: environment }
   { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', secretRef: 'application-insights-connection-string' }
   { name: 'DatabaseOptions__ConnectionString', secretRef: 'broker-ado-connection-string' }
@@ -68,7 +86,7 @@ var containerAppEnvVars = [
   { name: 'ReportStorageOptions__ConnectionString', secretRef: 'storage-connection-string' }
   { name: 'ReportResourceIdFilter', secretRef: 'report-resource-id-filter' }
   { name: 'OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION', value: 'true' }
-]
+], rotationContainerAppEnvVars)
 
 var EventGridIpRestrictions = map(eventGridIps, (ipRange, index) => {
   name: 'AzureEventGrid'
@@ -87,8 +105,21 @@ var apimIpRestrictions = empty(apimIp)
     ]
 var ipSecurityRestrictions = concat(apimIpRestrictions, EventGridIpRestrictions)
 
+var rotationKeyvaultSecrets = rotationEnabled ? [
+  {
+    identity: principal_id
+    keyVaultUrl: '${keyVaultUrl}/secrets/maskinporten-admin-client-id'
+    name: 'maskinporten-admin-client-id'
+  }
+  {
+    identity: principal_id
+    keyVaultUrl: '${keyVaultUrl}/secrets/maskinporten-admin-jwk'
+    name: 'maskinporten-admin-jwk'
+  }
+] : []
+
 resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
-  name: '${namePrefix}-app'
+  name: containerAppName
   location: location
   tags: resourceGroup().tags
   identity: {
@@ -105,7 +136,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
         transport: 'Auto'
         ipSecurityRestrictions: ipSecurityRestrictions
       }
-      secrets: [
+      secrets: concat([
         {
           identity: principal_id
           keyVaultUrl: '${keyVaultUrl}/secrets/platform-subscription-key'
@@ -151,7 +182,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
           keyVaultUrl: '${keyVaultUrl}/secrets/report-resource-id-filter'
           name: 'report-resource-id-filter'
         }
-      ]
+      ], rotationKeyvaultSecrets)
     }
 
     environmentId: containerAppEnvId

--- a/src/Altinn.Broker.API/Controllers/MaintenanceController.cs
+++ b/src/Altinn.Broker.API/Controllers/MaintenanceController.cs
@@ -5,6 +5,8 @@ using Microsoft.AspNetCore.Mvc;
 using Altinn.Broker.Application.CleanupUseCaseTests;
 using Altinn.Broker.Core.Helpers;
 using Altinn.Broker.API.Helpers;
+using Altinn.Broker.Application.MaskinportenJwkRotation;
+using Hangfire;
 
 using System.ComponentModel.DataAnnotations;
 
@@ -53,5 +55,46 @@ public class MaintenanceController(ILogger<MaintenanceController> logger) : Cont
         );
     }
 
+    [HttpPost]
+    [Route("maskinporten-jwk-rotation")]
+    [Authorize(Policy = AuthorizationConstants.Maintenance)]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public ActionResult TriggerMaskinportenJwkRotation(
+        [FromServices] IBackgroundJobClient backgroundJobClient,
+        [FromBody] TriggerMaskinportenJwkRotationRequest request)
+    {
+        const string expectedConfirmation = "rotate-maskinporten-jwk";
+        if (!string.Equals(request.Confirmation, expectedConfirmation, StringComparison.Ordinal))
+        {
+            return BadRequest(new
+            {
+                message = $"Confirmation must be '{expectedConfirmation}' to trigger Maskinporten JWK rotation."
+            });
+        }
+
+        var jobId = backgroundJobClient.Enqueue<MaskinportenJwkRotationHandler>(
+            handler => handler.Process(CancellationToken.None));
+
+        _logger.LogWarning(
+            "Manual Maskinporten JWK rotation job {JobId} was enqueued by {User}.",
+            jobId,
+            HttpContext.User.Identity?.Name ?? "unknown");
+
+        return Ok(new
+        {
+            jobId,
+            message = "Maskinporten JWK rotation was enqueued."
+        });
+    }
+
     private ActionResult Problem(Error error) => ProblemDetailsHelper.ToProblemResult(error);
+}
+
+public class TriggerMaskinportenJwkRotationRequest
+{
+    public string Confirmation { get; set; } = string.Empty;
 }

--- a/src/Altinn.Broker.API/Helpers/RecurringJobRegistration.cs
+++ b/src/Altinn.Broker.API/Helpers/RecurringJobRegistration.cs
@@ -1,0 +1,63 @@
+using Altinn.Broker.Application;
+using Altinn.Broker.Application.CleanupUseCaseTests;
+using Altinn.Broker.Application.IpSecurityRestrictionsUpdater;
+using Altinn.Broker.Application.MaskinportenJwkRotation;
+using Altinn.Broker.Application.MonthlyStatistics;
+using Altinn.Broker.Core.Options;
+using Hangfire;
+
+namespace Altinn.Broker.API.Helpers;
+
+public static class RecurringJobRegistration
+{
+    public const string MaskinportenJwkRotationJobId = "Rotate Maskinporten JWK and update Key Vault";
+    // The first weekday of a month can only fall on day 1, 2 or 3. The handler validates the exact date.
+    public const string MaskinportenJwkRotationCronExpression = "0 8 1-3 * *";
+
+    public static void Register(IServiceProvider services, IConfiguration configuration, ILogger logger)
+    {
+        var recurringJobManager = services.GetRequiredService<IRecurringJobManager>();
+
+        recurringJobManager.AddOrUpdate<IpSecurityRestrictionUpdater>(
+            "Update IP restrictions to apimIp and current EventGrid IPs",
+            handler => handler.UpdateIpRestrictions(),
+            Cron.Daily());
+
+        recurringJobManager.AddOrUpdate<StuckFileTransferHandler>(
+            "Check for files stuck in UploadProcessing",
+            handler => handler.CheckForStuckFileTransfers(CancellationToken.None),
+            "*/30 * * * *");
+
+        recurringJobManager.AddOrUpdate<RefreshMonthlyStatisticsRollupHandler>(
+            "Refresh current month statistics rollup",
+            handler => handler.RefreshRollup(CancellationToken.None),
+            Cron.Weekly(DayOfWeek.Monday, 3));
+
+        recurringJobManager.AddOrUpdate<RefreshMonthlyStatisticsRollupHandler>(
+            "Finalize previous month statistics rollup",
+            handler => handler.RefreshPreviousMonthRollup(CancellationToken.None),
+            "0 4 2 * *");
+
+        recurringJobManager.AddOrUpdate<CleanupUseCaseTestsHandler>(
+            "Cleanup use case test data older than 1 day",
+            handler => handler.Process(new CleanupUseCaseTestsRequest { MinAgeDays = 1 }, null, CancellationToken.None),
+            Cron.Daily());
+
+        var settings = configuration.GetSection(nameof(MaskinportenJwkRotationSettings)).Get<MaskinportenJwkRotationSettings>()
+            ?? new MaskinportenJwkRotationSettings();
+
+        if (!settings.Enabled)
+        {
+            recurringJobManager.RemoveIfExists(MaskinportenJwkRotationJobId);
+            logger.LogInformation("Maskinporten JWK rotation job is disabled.");
+            return;
+        }
+
+        recurringJobManager.AddOrUpdate<MaskinportenJwkRotationHandler>(
+            MaskinportenJwkRotationJobId,
+            handler => handler.ProcessScheduled(CancellationToken.None),
+            MaskinportenJwkRotationCronExpression);
+
+        logger.LogInformation("Maskinporten JWK rotation job registered with cron {CronExpression}.", MaskinportenJwkRotationCronExpression);
+    }
+}

--- a/src/Altinn.Broker.API/Program.cs
+++ b/src/Altinn.Broker.API/Program.cs
@@ -6,8 +6,6 @@ using Altinn.Broker.API.Configuration;
 using Altinn.Broker.API.Filters;
 using Altinn.Broker.API.Helpers;
 using Altinn.Broker.Application;
-using Altinn.Broker.Application.IpSecurityRestrictionsUpdater;
-using Altinn.Broker.Application.MonthlyStatistics;
 using Altinn.Broker.Core.Options;
 using Altinn.Broker.Helpers;
 using Altinn.Broker.Integrations;
@@ -17,7 +15,6 @@ using Altinn.Broker.Persistence;
 using Altinn.Broker.Persistence.Options;
 using Altinn.Common.PEP.Authorization;
 using Altinn.Broker.API.Swagger;
-
 using Hangfire;
 
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -25,7 +22,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.IdentityModel.Tokens;
-using Altinn.Broker.Application.CleanupUseCaseTests;
 
 BuildAndRun(args);
 
@@ -70,21 +66,7 @@ static void BuildAndRun(string[] args)
 
     app.UseHangfireDashboard();
 
-    var recurringJobManager = app.Services.GetRequiredService<IRecurringJobManager>();
-    recurringJobManager.AddOrUpdate<IpSecurityRestrictionUpdater>("Update IP restrictions to apimIp and current EventGrid IPs", handler => handler.UpdateIpRestrictions(), Cron.Daily());
-    recurringJobManager.AddOrUpdate<StuckFileTransferHandler>("Check for files stuck in UploadProcessing", handler => handler.CheckForStuckFileTransfers(CancellationToken.None), "*/30 * * * *");
-    recurringJobManager.AddOrUpdate<RefreshMonthlyStatisticsRollupHandler>(
-        "Refresh current month statistics rollup",
-        handler => handler.RefreshRollup(CancellationToken.None),
-        Cron.Weekly(DayOfWeek.Monday, 3));
-    recurringJobManager.AddOrUpdate<RefreshMonthlyStatisticsRollupHandler>(
-        "Finalize previous month statistics rollup",
-        handler => handler.RefreshPreviousMonthRollup(CancellationToken.None),
-        "0 4 2 * *");
-    recurringJobManager.AddOrUpdate<CleanupUseCaseTestsHandler>(
-        "Cleanup use case test data older than 1 day",
-        handler => handler.Process(new CleanupUseCaseTestsRequest { MinAgeDays = 1 }, null, CancellationToken.None), 
-        Cron.Daily());
+    RecurringJobRegistration.Register(app.Services, app.Configuration, app.Logger);
 
     app.Run();
 }
@@ -92,6 +74,7 @@ static void BuildAndRun(string[] args)
 static void ConfigureServices(IServiceCollection services, IConfiguration config, IHostEnvironment hostEnvironment)
 {
     services.AddHttpContextAccessor();
+    services.AddSingleton(TimeProvider.System);
     services.AddControllers().AddJsonOptions(options =>
     {
         options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
@@ -109,6 +92,7 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
     services.Configure<AzureResourceManagerOptions>(config.GetSection(key: nameof(AzureResourceManagerOptions)));
     services.Configure<AltinnOptions>(config.GetSection(key: nameof(AltinnOptions)));
     services.Configure<MaskinportenSettings>(config.GetSection(key: nameof(MaskinportenSettings)));
+    services.Configure<MaskinportenJwkRotationSettings>(config.GetSection(key: nameof(MaskinportenJwkRotationSettings)));
     services.Configure<AzureStorageOptions>(config.GetSection(key: nameof(AzureStorageOptions)));
     services.Configure<ReportStorageOptions>(config.GetSection(key: nameof(ReportStorageOptions)));
     services.Configure<ReportFilterOptions>(config);

--- a/src/Altinn.Broker.Application/DependencyInjection.cs
+++ b/src/Altinn.Broker.Application/DependencyInjection.cs
@@ -9,6 +9,8 @@ using Altinn.Broker.Application.GenerateReport;
 using Altinn.Broker.Application.InitializeFileTransfer;
 using Altinn.Broker.Application.Middlewares;
 using Altinn.Broker.Application.MonthlyStatistics;
+using Altinn.Broker.Application.MaskinportenJwkRotation;
+using Altinn.Broker.Application.SendSlackNotification;
 using Altinn.Broker.Application.UploadFile;
 using Altinn.Broker.Application.CleanupUseCaseTests;
 
@@ -38,5 +40,7 @@ public static class DependencyInjection
         services.AddScoped<GetMonthlyStatisticsCsvHandler>();
         services.AddScoped<RefreshMonthlyStatisticsRollupHandler>();
         services.AddScoped<CleanupUseCaseTestsHandler>();
+        services.AddScoped<MaskinportenJwkRotationHandler>();
+        services.AddScoped<SendSlackNotificationHandler>();
     }
 }

--- a/src/Altinn.Broker.Application/MaskinportenJwkRotation/MaskinportenJwkRotationHandler.cs
+++ b/src/Altinn.Broker.Application/MaskinportenJwkRotation/MaskinportenJwkRotationHandler.cs
@@ -1,0 +1,75 @@
+using Altinn.Broker.Application.SendSlackNotification;
+using Altinn.Broker.Core.Services;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+
+namespace Altinn.Broker.Application.MaskinportenJwkRotation;
+
+public class MaskinportenJwkRotationHandler(
+    IMaskinportenJwkRotationService rotationService,
+    SendSlackNotificationHandler slackNotificationHandler,
+    TimeProvider timeProvider,
+    ILogger<MaskinportenJwkRotationHandler> logger)
+{
+    [AutomaticRetry(Attempts = 0)]
+    [DisableConcurrentExecution(timeoutInSeconds: 1800)]
+    public async Task ProcessScheduled(CancellationToken cancellationToken)
+    {
+        var todayUtc = DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime.Date);
+
+        if (!IsFirstWeekdayOfMonth(todayUtc))
+        {
+            logger.LogInformation(
+                "Skipping scheduled Maskinporten JWK rotation on {Date} because it is not the first weekday of the month.",
+                todayUtc);
+            return;
+        }
+
+        await Process(cancellationToken);
+    }
+
+    [AutomaticRetry(Attempts = 0)]
+    [DisableConcurrentExecution(timeoutInSeconds: 1800)]
+    public async Task Process(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await rotationService.RotateAsync(cancellationToken);
+            var summary = string.Join(
+                " ",
+                result.Clients.Select(client =>
+                    $"Client {client.ClientName} ({client.ClientId}) rotated to kid {client.NewKid}. Keys before: {client.PreviousKeyCount}, keys after: {client.CurrentKeyCount}. Secret updated: {client.KeyVaultSecretName}. Verification scope: {client.VerificationScope}."));
+            await slackNotificationHandler.Process(
+                "Maskinporten JWK rotation completed",
+                summary,
+                ":white_check_mark:");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Maskinporten JWK rotation failed.");
+            await slackNotificationHandler.Process(
+                "Maskinporten JWK rotation failed",
+                ex.Message);
+            throw;
+        }
+    }
+
+    public static bool IsFirstWeekdayOfMonth(DateOnly date)
+    {
+        if (date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
+        {
+            return false;
+        }
+
+        for (var day = 1; day < date.Day; day++)
+        {
+            var candidate = new DateOnly(date.Year, date.Month, day);
+            if (candidate.DayOfWeek is not (DayOfWeek.Saturday or DayOfWeek.Sunday))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Altinn.Broker.Application/SendSlackNotification/SendSlackNotificationHandler.cs
+++ b/src/Altinn.Broker.Application/SendSlackNotification/SendSlackNotificationHandler.cs
@@ -1,0 +1,41 @@
+using Altinn.Broker.Core.Options;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Slack.Webhooks;
+
+namespace Altinn.Broker.Application.SendSlackNotification;
+
+/// <summary>
+/// Handler for sending operational Slack notifications.
+/// </summary>
+public class SendSlackNotificationHandler(
+    ISlackClient slackClient,
+    SlackSettings slackSettings,
+    IHostEnvironment hostEnvironment,
+    ILogger<SendSlackNotificationHandler> logger)
+{
+    public async Task Process(string title, string message, string emoji = ":warning:")
+    {
+        var text =
+            $"{emoji} *{title}*\n" +
+            $"*Environment:* {hostEnvironment.EnvironmentName}\n" +
+            $"*System:* Broker\n" +
+            $"*Message:* {message}\n" +
+            $"*Time:* {DateTime.UtcNow:u}\n";
+
+        var slackMessage = new SlackMessage
+        {
+            Text = text,
+            Channel = slackSettings.NotificationChannel
+        };
+
+        try
+        {
+            await slackClient.PostAsync(slackMessage);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send Slack notification. Title={Title}", title);
+        }
+    }
+}

--- a/src/Altinn.Broker.Core/Options/MaskinportenJwkRotationSettings.cs
+++ b/src/Altinn.Broker.Core/Options/MaskinportenJwkRotationSettings.cs
@@ -1,0 +1,51 @@
+namespace Altinn.Broker.Core.Options;
+
+public class MaskinportenJwkRotationSettings
+{
+    public bool Enabled { get; set; }
+
+    public int VerificationMaxAttempts { get; set; } = 12;
+
+    public int VerificationDelaySeconds { get; set; } = 15;
+
+    public string AdminClientId { get; set; } = string.Empty;
+
+    public string AdminEncodedJwk { get; set; } = string.Empty;
+
+    public string AdminScope { get; set; } = "idporten:dcr.write";
+
+    public string AdminApiBaseUrl { get; set; } = string.Empty;
+
+    public string AdminKeyVaultSecretName { get; set; } = "maskinporten-admin-jwk";
+
+    public string AdminClientIdKeyVaultSecretName { get; set; } = "maskinporten-admin-client-id";
+
+    public string AdminNewKeyIdPrefix { get; set; } = "altinn-broker-maskinporten-admin";
+
+    public string KeyVaultUrl { get; set; } = string.Empty;
+
+    public string ContainerAppResourceId { get; set; } = string.Empty;
+
+    public bool RefreshContainerAppsAfterRotation { get; set; } = true;
+
+    public string KeyVaultSecretName { get; set; } = "maskinporten-jwk";
+
+    public string TargetClientIdKeyVaultSecretName { get; set; } = "maskinporten-client-id";
+
+    public string NewKeyIdPrefix { get; set; } = "altinn-broker-maskinporten";
+
+    public List<MaskinportenJwkRotationTarget> Targets { get; set; } = [];
+}
+
+public class MaskinportenJwkRotationTarget
+{
+    public string Name { get; set; } = string.Empty;
+
+    public string KeyVaultUrl { get; set; } = string.Empty;
+
+    public string ClientIdSecretName { get; set; } = string.Empty;
+
+    public string EncodedJwkSecretName { get; set; } = string.Empty;
+
+    public string ContainerAppResourceId { get; set; } = string.Empty;
+}

--- a/src/Altinn.Broker.Core/Services/MaskinportenJwkModels.cs
+++ b/src/Altinn.Broker.Core/Services/MaskinportenJwkModels.cs
@@ -1,0 +1,82 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Broker.Core.Services;
+
+public class MaskinportenJwkKey
+{
+    [JsonPropertyName("kty")]
+    public string Kty { get; set; } = string.Empty;
+
+    [JsonPropertyName("kid")]
+    public string Kid { get; set; } = string.Empty;
+
+    [JsonPropertyName("use")]
+    public string Use { get; set; } = string.Empty;
+
+    [JsonPropertyName("alg")]
+    public string Alg { get; set; } = string.Empty;
+
+    [JsonPropertyName("n")]
+    public string N { get; set; } = string.Empty;
+
+    [JsonPropertyName("e")]
+    public string E { get; set; } = string.Empty;
+}
+
+public class MaskinportenJwkSet
+{
+    [JsonPropertyName("keys")]
+    public List<MaskinportenJwkKey> Keys { get; set; } = [];
+}
+
+public class MaskinportenGeneratedJwk
+{
+    public string Kid { get; init; } = string.Empty;
+
+    public string PrivateJwkJson { get; init; } = string.Empty;
+
+    public string PrivateJwkBase64 { get; init; } = string.Empty;
+
+    public MaskinportenJwkKey PublicJwk { get; init; } = new();
+}
+
+public class MaskinportenAdminApiCredentials
+{
+    public string ClientId { get; init; } = string.Empty;
+
+    public string EncodedJwk { get; init; } = string.Empty;
+
+    public string Scope { get; init; } = string.Empty;
+
+    public string ApiBaseUrl { get; init; } = string.Empty;
+
+    public string Environment { get; init; } = string.Empty;
+}
+
+public class MaskinportenJwkRotationClientResult
+{
+    public string ClientId { get; init; } = string.Empty;
+
+    public string ClientName { get; init; } = string.Empty;
+
+    public string NewKid { get; init; } = string.Empty;
+
+    public int PreviousKeyCount { get; init; }
+
+    public int CurrentKeyCount { get; init; }
+
+    public string VerificationScope { get; init; } = string.Empty;
+
+    public string KeyVaultUrl { get; init; } = string.Empty;
+
+    public string KeyVaultSecretName { get; init; } = string.Empty;
+
+    public string ContainerAppResourceId { get; init; } = string.Empty;
+
+    public IReadOnlyList<string> ContainerAppResourceIds { get; init; } = [];
+}
+
+public class MaskinportenJwkRotationResult
+{
+    public IReadOnlyList<MaskinportenJwkRotationClientResult> Clients { get; init; } = [];
+}

--- a/src/Altinn.Broker.Core/Services/MaskinportenJwkServiceInterfaces.cs
+++ b/src/Altinn.Broker.Core/Services/MaskinportenJwkServiceInterfaces.cs
@@ -1,0 +1,37 @@
+namespace Altinn.Broker.Core.Services;
+
+public interface IDigdirMaskinportenAdminService
+{
+    Task<MaskinportenJwkSet> GetJwksAsync(string clientId, MaskinportenAdminApiCredentials adminCredentials, CancellationToken cancellationToken);
+
+    Task<MaskinportenJwkSet> UpdateJwksAsync(string clientId, MaskinportenJwkSet jwks, MaskinportenAdminApiCredentials adminCredentials, CancellationToken cancellationToken);
+}
+
+public interface IKeyVaultSecretStore
+{
+    Task<string?> GetSecretValueAsync(string vaultUrl, string secretName, CancellationToken cancellationToken);
+
+    Task SetSecretAsync(string vaultUrl, string secretName, string value, CancellationToken cancellationToken);
+}
+
+public interface IMaskinportenJwkGenerator
+{
+    MaskinportenGeneratedJwk Generate(string keyIdPrefix);
+
+    MaskinportenJwkKey GetPublicKey(string encodedPrivateJwk);
+}
+
+public interface IMaskinportenJwkRotationService
+{
+    Task<MaskinportenJwkRotationResult> RotateAsync(CancellationToken cancellationToken);
+}
+
+public interface IMaskinportenTokenService
+{
+    Task<string> RequestTokenAsync(string clientId, string encodedPrivateJwk, string scope, string environment, CancellationToken cancellationToken);
+}
+
+public interface IContainerAppRefreshService
+{
+    Task RefreshAsync(string containerAppResourceId, string reason, CancellationToken cancellationToken);
+}

--- a/src/Altinn.Broker.Integrations/Altinn.Broker.Integrations.csproj
+++ b/src/Altinn.Broker.Integrations/Altinn.Broker.Integrations.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Azure.ResourceManager.Network" Version="1.11.1" />
     <PackageReference Include="Azure.ResourceManager.Storage" Version="1.4.4" />
     <PackageReference Include="Azure.ResourceManager.AppContainers" Version="1.4.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.20" />
     <PackageReference Include="Hangfire.Core" Version="1.8.20" />

--- a/src/Altinn.Broker.Integrations/Azure/AzureContainerAppRefreshService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureContainerAppRefreshService.cs
@@ -1,0 +1,52 @@
+using Altinn.Broker.Core.Services;
+using Azure;
+using Azure.Core;
+using Azure.Identity;
+using Azure.ResourceManager;
+using Azure.ResourceManager.AppContainers;
+using Azure.ResourceManager.AppContainers.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Altinn.Broker.Integrations.Azure;
+
+public class AzureContainerAppRefreshService(ILogger<AzureContainerAppRefreshService> logger) : IContainerAppRefreshService
+{
+    private const string RefreshEnvironmentVariableName = "MASKINPORTEN_JWK_ROTATION_REFRESHED_AT";
+    private readonly ArmClient _armClient = new(new DefaultAzureCredential());
+
+    public async Task RefreshAsync(string containerAppResourceId, string reason, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(containerAppResourceId))
+        {
+            return;
+        }
+
+        var containerApp = await _armClient.GetContainerAppResource(new ResourceIdentifier(containerAppResourceId)).GetAsync(cancellationToken);
+        var data = containerApp.Value.Data;
+        var appContainer = data.Template.Containers.FirstOrDefault()
+            ?? throw new InvalidOperationException($"Container app {containerAppResourceId} has no app container to refresh.");
+
+        var refreshValue = DateTimeOffset.UtcNow.ToString("O");
+        var refreshEnvironmentVariable = appContainer.Env.FirstOrDefault(env => env.Name == RefreshEnvironmentVariableName);
+        if (refreshEnvironmentVariable is null)
+        {
+            appContainer.Env.Add(new ContainerAppEnvironmentVariable
+            {
+                Name = RefreshEnvironmentVariableName,
+                Value = refreshValue
+            });
+        }
+        else
+        {
+            refreshEnvironmentVariable.Value = refreshValue;
+            refreshEnvironmentVariable.SecretRef = null;
+        }
+
+        logger.LogInformation(
+            "Refreshing container app {ContainerAppResourceId} after Maskinporten JWK rotation. Reason: {Reason}",
+            containerAppResourceId,
+            reason);
+
+        await containerApp.Value.UpdateAsync(WaitUntil.Started, data, cancellationToken);
+    }
+}

--- a/src/Altinn.Broker.Integrations/Azure/KeyVaultSecretStore.cs
+++ b/src/Altinn.Broker.Integrations/Azure/KeyVaultSecretStore.cs
@@ -1,0 +1,36 @@
+using Altinn.Broker.Core.Services;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+
+namespace Altinn.Broker.Integrations.Azure;
+
+public class KeyVaultSecretStore : IKeyVaultSecretStore
+{
+    public async Task<string?> GetSecretValueAsync(string vaultUrl, string secretName, CancellationToken cancellationToken)
+    {
+        var client = CreateSecretClient(vaultUrl, secretName);
+        var response = await client.GetSecretAsync(secretName, cancellationToken: cancellationToken);
+        return response.Value.Value;
+    }
+
+    public async Task SetSecretAsync(string vaultUrl, string secretName, string value, CancellationToken cancellationToken)
+    {
+        var client = CreateSecretClient(vaultUrl, secretName);
+        await client.SetSecretAsync(secretName, value, cancellationToken);
+    }
+
+    private static SecretClient CreateSecretClient(string vaultUrl, string secretName)
+    {
+        if (string.IsNullOrWhiteSpace(vaultUrl))
+        {
+            throw new InvalidOperationException("Key Vault URL is missing for Maskinporten JWK rotation.");
+        }
+
+        if (string.IsNullOrWhiteSpace(secretName))
+        {
+            throw new InvalidOperationException("Key Vault secret name is missing for Maskinporten JWK rotation.");
+        }
+
+        return new SecretClient(new Uri(vaultUrl), new DefaultAzureCredential());
+    }
+}

--- a/src/Altinn.Broker.Integrations/DependencyInjection.cs
+++ b/src/Altinn.Broker.Integrations/DependencyInjection.cs
@@ -9,6 +9,7 @@ using Altinn.Broker.Integrations.Altinn.Events;
 using Altinn.Broker.Integrations.Altinn.Register;
 using Altinn.Broker.Integrations.Altinn.ResourceRegistry;
 using Altinn.Broker.Integrations.Azure;
+using Altinn.Broker.Integrations.Maskinporten;
 using Altinn.Broker.Persistence.Repositories;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -26,6 +27,12 @@ public static class DependencyInjection
         services.AddScoped<IAltinnResourceRepository, AltinnResourceRegistryRepository>();
         services.AddScoped<IResourceRepository, ResourceRepository>();
         services.AddSingleton<IIdempotencyEventRepository, IdempotencyEventRepository>();
+        services.AddSingleton<IKeyVaultSecretStore, KeyVaultSecretStore>();
+        services.AddSingleton<IContainerAppRefreshService, AzureContainerAppRefreshService>();
+        services.AddSingleton<IMaskinportenJwkGenerator, MaskinportenJwkGenerator>();
+        services.AddScoped<IMaskinportenTokenService, MaskinportenTokenService>();
+        services.AddScoped<IDigdirMaskinportenAdminService, DigdirMaskinportenAdminService>();
+        services.AddScoped<IMaskinportenJwkRotationService, MaskinportenJwkRotationService>();
 
         var maskinportenSettings = new MaskinportenSettings();
         configuration.GetSection(nameof(MaskinportenSettings)).Bind(maskinportenSettings);

--- a/src/Altinn.Broker.Integrations/Maskinporten/DigdirMaskinportenAdminService.cs
+++ b/src/Altinn.Broker.Integrations/Maskinporten/DigdirMaskinportenAdminService.cs
@@ -1,0 +1,78 @@
+using Altinn.Broker.Core.Services;
+using Microsoft.Extensions.Logging;
+using System.Net.Http.Json;
+
+namespace Altinn.Broker.Integrations.Maskinporten;
+
+public class DigdirMaskinportenAdminService(
+    IHttpClientFactory httpClientFactory,
+    IMaskinportenTokenService tokenService,
+    ILogger<DigdirMaskinportenAdminService> logger) : IDigdirMaskinportenAdminService
+{
+    public async Task<MaskinportenJwkSet> GetJwksAsync(string clientId, MaskinportenAdminApiCredentials adminCredentials, CancellationToken cancellationToken)
+    {
+        using var request = await CreateRequestAsync(HttpMethod.Get, $"clients/{clientId}/jwks", adminCredentials, cancellationToken);
+        using var response = await SendAsync(request, cancellationToken);
+        return (await response.Content.ReadFromJsonAsync<MaskinportenJwkSet>(cancellationToken: cancellationToken))
+            ?? throw new InvalidOperationException($"Unable to deserialize Digdir JWKS for client '{clientId}'.");
+    }
+
+    public async Task<MaskinportenJwkSet> UpdateJwksAsync(string clientId, MaskinportenJwkSet jwks, MaskinportenAdminApiCredentials adminCredentials, CancellationToken cancellationToken)
+    {
+        using var request = await CreateRequestAsync(HttpMethod.Post, $"clients/{clientId}/jwks", adminCredentials, cancellationToken);
+        request.Content = JsonContent.Create(jwks);
+        using var response = await SendAsync(request, cancellationToken);
+        return (await response.Content.ReadFromJsonAsync<MaskinportenJwkSet>(cancellationToken: cancellationToken))
+            ?? throw new InvalidOperationException($"Unable to deserialize updated Digdir JWKS for client '{clientId}'.");
+    }
+
+    private async Task<HttpRequestMessage> CreateRequestAsync(
+        HttpMethod method,
+        string relativePath,
+        MaskinportenAdminApiCredentials adminCredentials,
+        CancellationToken cancellationToken)
+    {
+        var accessToken = await tokenService.RequestTokenAsync(
+            adminCredentials.ClientId,
+            adminCredentials.EncodedJwk,
+            adminCredentials.Scope,
+            adminCredentials.Environment,
+            cancellationToken);
+
+        var request = new HttpRequestMessage(method, $"{GetDigdirApiBaseUrl(adminCredentials.ApiBaseUrl, adminCredentials.Environment)}/{relativePath}");
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+        return request;
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        using var httpClient = httpClientFactory.CreateClient();
+        var response = await httpClient.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            logger.LogError(
+                "Digdir admin request failed. Method={Method}, Url={Url}, Status={StatusCode}, Body={Body}",
+                request.Method,
+                request.RequestUri,
+                (int)response.StatusCode,
+                body);
+            throw new InvalidOperationException($"Digdir admin request failed with status {(int)response.StatusCode}: {body}");
+        }
+
+        return response;
+    }
+
+    private static string GetDigdirApiBaseUrl(string configuredBaseUrl, string environment)
+    {
+        if (!string.IsNullOrWhiteSpace(configuredBaseUrl))
+        {
+            return configuredBaseUrl.TrimEnd('/');
+        }
+
+        return environment.Equals("prod", StringComparison.OrdinalIgnoreCase)
+            || environment.Equals("production", StringComparison.OrdinalIgnoreCase)
+            ? "https://api.samarbeid.digdir.no/external/api/v1"
+            : "https://api.test.samarbeid.digdir.no/external/api/v1";
+    }
+}

--- a/src/Altinn.Broker.Integrations/Maskinporten/MaskinportenJwkGenerator.cs
+++ b/src/Altinn.Broker.Integrations/Maskinporten/MaskinportenJwkGenerator.cs
@@ -1,0 +1,78 @@
+using Altinn.Broker.Core.Services;
+using Microsoft.IdentityModel.Tokens;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Altinn.Broker.Integrations.Maskinporten;
+
+public class MaskinportenJwkGenerator : IMaskinportenJwkGenerator
+{
+    public MaskinportenGeneratedJwk Generate(string keyIdPrefix)
+    {
+        using var rsa = RSA.Create(2048);
+        var parameters = rsa.ExportParameters(true);
+        var kid = $"{keyIdPrefix}-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}";
+
+        var publicJwk = new MaskinportenJwkKey
+        {
+            Kty = "RSA",
+            Use = "sig",
+            Alg = "RS256",
+            Kid = kid,
+            N = Base64UrlEncoder.Encode(parameters.Modulus),
+            E = Base64UrlEncoder.Encode(parameters.Exponent)
+        };
+
+        var privateJwk = new Dictionary<string, string>
+        {
+            ["kty"] = publicJwk.Kty,
+            ["use"] = publicJwk.Use,
+            ["alg"] = publicJwk.Alg,
+            ["kid"] = publicJwk.Kid,
+            ["n"] = publicJwk.N,
+            ["e"] = publicJwk.E,
+            ["d"] = Base64UrlEncoder.Encode(parameters.D!),
+            ["p"] = Base64UrlEncoder.Encode(parameters.P!),
+            ["q"] = Base64UrlEncoder.Encode(parameters.Q!),
+            ["dp"] = Base64UrlEncoder.Encode(parameters.DP!),
+            ["dq"] = Base64UrlEncoder.Encode(parameters.DQ!),
+            ["qi"] = Base64UrlEncoder.Encode(parameters.InverseQ!)
+        };
+
+        var privateJwkJson = JsonSerializer.Serialize(privateJwk);
+        return new MaskinportenGeneratedJwk
+        {
+            Kid = kid,
+            PrivateJwkJson = privateJwkJson,
+            PrivateJwkBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(privateJwkJson)),
+            PublicJwk = publicJwk
+        };
+    }
+
+    public MaskinportenJwkKey GetPublicKey(string encodedPrivateJwk)
+    {
+        var privateJwk = DecodePrivateJwk(encodedPrivateJwk);
+        return new MaskinportenJwkKey
+        {
+            Kty = privateJwk["kty"],
+            Use = privateJwk["use"],
+            Alg = privateJwk["alg"],
+            Kid = privateJwk["kid"],
+            N = privateJwk["n"],
+            E = privateJwk["e"]
+        };
+    }
+
+    private static Dictionary<string, string> DecodePrivateJwk(string encodedPrivateJwk)
+    {
+        if (string.IsNullOrWhiteSpace(encodedPrivateJwk))
+        {
+            throw new InvalidOperationException("Encoded private JWK is missing.");
+        }
+
+        var json = Encoding.UTF8.GetString(Convert.FromBase64String(encodedPrivateJwk));
+        return JsonSerializer.Deserialize<Dictionary<string, string>>(json)
+            ?? throw new InvalidOperationException("Unable to deserialize private JWK.");
+    }
+}

--- a/src/Altinn.Broker.Integrations/Maskinporten/MaskinportenJwkRotationService.cs
+++ b/src/Altinn.Broker.Integrations/Maskinporten/MaskinportenJwkRotationService.cs
@@ -1,0 +1,584 @@
+using Altinn.ApiClients.Maskinporten.Config;
+using Altinn.Broker.Core.Options;
+using Altinn.Broker.Core.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Runtime.ExceptionServices;
+
+namespace Altinn.Broker.Integrations.Maskinporten;
+
+public class MaskinportenJwkRotationService(
+    IOptions<MaskinportenJwkRotationSettings> rotationOptions,
+    IOptions<MaskinportenSettings> targetOptions,
+    IDigdirMaskinportenAdminService digdirMaskinportenAdminService,
+    IMaskinportenJwkGenerator jwkGenerator,
+    IMaskinportenTokenService tokenService,
+    IKeyVaultSecretStore keyVaultSecretStore,
+    IContainerAppRefreshService containerAppRefreshService,
+    ILogger<MaskinportenJwkRotationService> logger) : IMaskinportenJwkRotationService
+{
+    public async Task<MaskinportenJwkRotationResult> RotateAsync(CancellationToken cancellationToken)
+    {
+        var settings = rotationOptions.Value;
+        var target = targetOptions.Value;
+        ValidateConfiguration(settings, target);
+        var leaderKeyVaultUrl = NormalizeKeyVaultUrl(settings.KeyVaultUrl);
+        await PreflightKeyVaultSecretsAsync(
+            leaderKeyVaultUrl,
+            new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                [settings.AdminKeyVaultSecretName] = null,
+                [settings.AdminClientIdKeyVaultSecretName] = settings.AdminClientId
+            },
+            cancellationToken);
+        var targetRotation = await GetRotationTargetAsync(settings, target, cancellationToken);
+
+        var adminCredentials = CreateAdminCredentials(settings, target.Environment, settings.AdminEncodedJwk);
+        var adminRotation = await RotateClientAsync(
+            new RotationTarget(
+                settings.AdminClientId,
+                "Maskinporten admin",
+                settings.AdminEncodedJwk,
+                settings.AdminScope,
+                [
+                    new KeyVaultWriteTarget(
+                        "Maskinporten admin",
+                        leaderKeyVaultUrl,
+                        settings.AdminKeyVaultSecretName,
+                        settings.ContainerAppResourceId)
+                ],
+                settings.AdminNewKeyIdPrefix,
+                target.Environment),
+            adminCredentials,
+            generated => VerifyAdminDcrAccessAsync(settings, target.Environment, generated, cancellationToken),
+            cancellationToken);
+
+        adminCredentials = CreateAdminCredentials(settings, target.Environment, adminRotation.Generated.PrivateJwkBase64);
+        var clientResults = new List<MaskinportenJwkRotationClientResult> { adminRotation.Result };
+        try
+        {
+            var rotation = await RotateClientAsync(
+                targetRotation,
+                adminCredentials,
+                generated => tokenService.RequestTokenAsync(
+                    targetRotation.ClientId,
+                    generated.PrivateJwkBase64,
+                    targetRotation.VerificationScope,
+                    targetRotation.Environment,
+                    cancellationToken),
+                cancellationToken);
+            clientResults.Add(rotation.Result);
+
+            await RefreshCompletedRotationsAsync(settings, clientResults, cancellationToken);
+        }
+        catch
+        {
+            await RefreshCompletedRotationsAsync(settings, clientResults, cancellationToken);
+            throw;
+        }
+
+        return new MaskinportenJwkRotationResult
+        {
+            Clients = clientResults
+        };
+    }
+
+    private async Task RefreshCompletedRotationsAsync(
+        MaskinportenJwkRotationSettings settings,
+        IReadOnlyList<MaskinportenJwkRotationClientResult> clientResults,
+        CancellationToken cancellationToken)
+    {
+        if (!settings.RefreshContainerAppsAfterRotation)
+        {
+            return;
+        }
+
+        foreach (var refreshTarget in clientResults
+            .SelectMany(result =>
+                (result.ContainerAppResourceIds.Count > 0 ? result.ContainerAppResourceIds : [result.ContainerAppResourceId])
+                    .Select(containerAppResourceId => new
+                    {
+                        ContainerAppResourceId = containerAppResourceId,
+                        Reason = $"Maskinporten JWK rotation for {result.ClientName}"
+                    }))
+            .Where(target => !string.IsNullOrWhiteSpace(target.ContainerAppResourceId))
+            .DistinctBy(target => target.ContainerAppResourceId, StringComparer.OrdinalIgnoreCase))
+        {
+            await containerAppRefreshService.RefreshAsync(
+                refreshTarget.ContainerAppResourceId,
+                refreshTarget.Reason,
+                cancellationToken);
+        }
+    }
+
+    private static IEnumerable<MaskinportenJwkKey> MergeDistinctKeys(
+        IEnumerable<MaskinportenJwkKey> existingKeys,
+        params MaskinportenJwkKey[] keys)
+        => existingKeys
+            .Concat(keys)
+            .GroupBy(key => key.Kid, StringComparer.Ordinal)
+            .Select(group => group.Last());
+
+    private async Task<SingleRotationExecution> RotateClientAsync(
+        RotationTarget rotationTarget,
+        MaskinportenAdminApiCredentials adminCredentials,
+        Func<MaskinportenGeneratedJwk, Task> verifyNewKey,
+        CancellationToken cancellationToken)
+    {
+        var settings = rotationOptions.Value;
+        var currentPublicKey = jwkGenerator.GetPublicKey(rotationTarget.CurrentEncodedJwk);
+        var originalSecretValues = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        var updatedSecretTargets = new List<KeyVaultWriteTarget>();
+
+        logger.LogInformation("Starting Maskinporten JWK rotation for client {ClientId}.", rotationTarget.ClientId);
+        var originalJwks = await digdirMaskinportenAdminService.GetJwksAsync(rotationTarget.ClientId, adminCredentials, cancellationToken);
+        var generated = jwkGenerator.Generate(rotationTarget.NewKeyIdPrefix);
+
+        var rotatedJwks = new MaskinportenJwkSet
+        {
+            Keys = [.. MergeDistinctKeys(originalJwks.Keys, currentPublicKey, generated.PublicJwk)]
+        };
+
+        var jwksUpdated = false;
+        try
+        {
+            var updatedJwks = await digdirMaskinportenAdminService.UpdateJwksAsync(rotationTarget.ClientId, rotatedJwks, adminCredentials, cancellationToken);
+            jwksUpdated = true;
+
+            logger.LogInformation(
+                "Maskinporten JWKS updated for client {ClientId}. Returned kids: {Kids}.",
+                rotationTarget.ClientId,
+                FormatKids(updatedJwks.Keys));
+
+            var verifiedJwks = await VerifyNewKeyAsync(
+                settings,
+                rotationTarget.ClientId,
+                generated,
+                adminCredentials,
+                verifyNewKey,
+                cancellationToken);
+
+            foreach (var keyVaultTarget in rotationTarget.KeyVaultTargets)
+            {
+                originalSecretValues[GetSecretTargetKey(keyVaultTarget)] = await keyVaultSecretStore.GetSecretValueAsync(
+                    keyVaultTarget.KeyVaultUrl,
+                    keyVaultTarget.KeyVaultSecretName,
+                    cancellationToken);
+
+                await keyVaultSecretStore.SetSecretAsync(
+                    keyVaultTarget.KeyVaultUrl,
+                    keyVaultTarget.KeyVaultSecretName,
+                    generated.PrivateJwkBase64,
+                    cancellationToken);
+                updatedSecretTargets.Add(keyVaultTarget);
+            }
+
+            logger.LogInformation(
+                "Completed Maskinporten JWK rotation for client {ClientId}. New kid={Kid}. Keys before={Before}, keys after={After}. Key Vaults updated: {KeyVaultUrls}.",
+                rotationTarget.ClientId,
+                generated.Kid,
+                originalJwks.Keys.Count,
+                verifiedJwks.Keys.Count,
+                string.Join(", ", rotationTarget.KeyVaultTargets.Select(target => target.KeyVaultUrl)));
+
+            var primaryKeyVaultTarget = rotationTarget.KeyVaultTargets[0];
+            var containerAppResourceIds = rotationTarget.KeyVaultTargets
+                .Select(target => target.ContainerAppResourceId)
+                .Where(resourceId => !string.IsNullOrWhiteSpace(resourceId))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            return new SingleRotationExecution(
+                new MaskinportenJwkRotationClientResult
+                {
+                    ClientId = rotationTarget.ClientId,
+                    ClientName = rotationTarget.ClientName,
+                    NewKid = generated.Kid,
+                    PreviousKeyCount = originalJwks.Keys.Count,
+                    CurrentKeyCount = verifiedJwks.Keys.Count,
+                    VerificationScope = rotationTarget.VerificationScope,
+                    KeyVaultUrl = primaryKeyVaultTarget.KeyVaultUrl,
+                    KeyVaultSecretName = primaryKeyVaultTarget.KeyVaultSecretName,
+                    ContainerAppResourceId = primaryKeyVaultTarget.ContainerAppResourceId,
+                    ContainerAppResourceIds = containerAppResourceIds
+                },
+                generated);
+        }
+        catch (Exception ex)
+        {
+            List<Exception>? rollbackFailures = null;
+            var keyVaultRollbackFailed = false;
+
+            foreach (var keyVaultTarget in updatedSecretTargets.AsEnumerable().Reverse())
+            {
+                logger.LogWarning(
+                    "Maskinporten JWK rotation failed after updating Key Vault secret. Restoring previous secret value for vault: {KeyVaultUrl}.",
+                    keyVaultTarget.KeyVaultUrl);
+
+                var originalSecretValue = originalSecretValues[GetSecretTargetKey(keyVaultTarget)];
+                if (string.IsNullOrWhiteSpace(originalSecretValue))
+                {
+                    var rollbackException = new InvalidOperationException(
+                        $"Cannot restore Maskinporten JWK secret for vault {keyVaultTarget.KeyVaultUrl} because the original secret value was missing.");
+                    keyVaultRollbackFailed = true;
+                    rollbackFailures ??= [];
+                    rollbackFailures.Add(rollbackException);
+                    logger.LogError(rollbackException, "Failed to restore Maskinporten JWK secret for vault {KeyVaultUrl}.", keyVaultTarget.KeyVaultUrl);
+                }
+                else
+                {
+                    try
+                    {
+                        await keyVaultSecretStore.SetSecretAsync(
+                            keyVaultTarget.KeyVaultUrl,
+                            keyVaultTarget.KeyVaultSecretName,
+                            originalSecretValue,
+                            cancellationToken);
+                    }
+                    catch (Exception rollbackEx)
+                    {
+                        keyVaultRollbackFailed = true;
+                        rollbackFailures ??= [];
+                        rollbackFailures.Add(rollbackEx);
+                        logger.LogError(rollbackEx, "Failed to restore Maskinporten JWK secret for vault {KeyVaultUrl}.", keyVaultTarget.KeyVaultUrl);
+                    }
+                }
+            }
+
+            if (jwksUpdated && keyVaultRollbackFailed)
+            {
+                logger.LogWarning(
+                    "Keeping updated JWKS for client {ClientId} because one or more Key Vault secret rollback operations failed.",
+                    rotationTarget.ClientId);
+            }
+            else if (jwksUpdated)
+            {
+                logger.LogWarning("Maskinporten JWK rotation failed after JWKS update. Restoring original JWKS for client {ClientId}.", rotationTarget.ClientId);
+                try
+                {
+                    await digdirMaskinportenAdminService.UpdateJwksAsync(rotationTarget.ClientId, originalJwks, adminCredentials, cancellationToken);
+                }
+                catch (Exception rollbackEx)
+                {
+                    rollbackFailures ??= [];
+                    rollbackFailures.Add(rollbackEx);
+                    logger.LogError(rollbackEx, "Failed to restore original JWKS for client {ClientId}.", rotationTarget.ClientId);
+                }
+            }
+
+            if (rollbackFailures is not null)
+            {
+                rollbackFailures.Insert(0, ex);
+                throw new AggregateException("Maskinporten JWK rotation failed and one or more rollback operations also failed.", rollbackFailures);
+            }
+
+            throw;
+        }
+    }
+
+    private async Task<MaskinportenJwkSet> VerifyNewKeyAsync(
+        MaskinportenJwkRotationSettings settings,
+        string targetClientId,
+        MaskinportenGeneratedJwk generated,
+        MaskinportenAdminApiCredentials adminCredentials,
+        Func<MaskinportenGeneratedJwk, Task> verifyNewKey,
+        CancellationToken cancellationToken)
+    {
+        Exception? lastRetryableException = null;
+
+        for (var attempt = 1; attempt <= settings.VerificationMaxAttempts; attempt++)
+        {
+            try
+            {
+                var currentJwks = await digdirMaskinportenAdminService.GetJwksAsync(targetClientId, adminCredentials, cancellationToken);
+                var kidPresent = currentJwks.Keys.Any(key => string.Equals(key.Kid, generated.Kid, StringComparison.Ordinal));
+
+                logger.LogInformation(
+                    "Verifying Maskinporten JWK rotation for client {ClientId}. Attempt {Attempt}/{MaxAttempts}. New kid present in JWKS: {KidPresent}. Current kids: {Kids}.",
+                    targetClientId,
+                    attempt,
+                    settings.VerificationMaxAttempts,
+                    kidPresent,
+                    FormatKids(currentJwks.Keys));
+
+                await verifyNewKey(generated);
+
+                logger.LogInformation(
+                    "Verified Maskinporten JWK rotation for client {ClientId} with kid {Kid} on attempt {Attempt}/{MaxAttempts}.",
+                    targetClientId,
+                    generated.Kid,
+                    attempt,
+                    settings.VerificationMaxAttempts);
+
+                return currentJwks;
+            }
+            catch (Exception ex) when (IsRetryableVerificationFailure(ex) && attempt < settings.VerificationMaxAttempts)
+            {
+                lastRetryableException = ex;
+
+                logger.LogWarning(
+                    ex,
+                    "Verification attempt {Attempt}/{MaxAttempts} failed for client {ClientId} and will be retried in {DelaySeconds}s.",
+                    attempt,
+                    settings.VerificationMaxAttempts,
+                    targetClientId,
+                    settings.VerificationDelaySeconds);
+
+                if (settings.VerificationDelaySeconds > 0)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(settings.VerificationDelaySeconds), cancellationToken);
+                }
+            }
+        }
+
+        if (lastRetryableException is not null)
+        {
+            ExceptionDispatchInfo.Capture(lastRetryableException).Throw();
+        }
+
+        throw new InvalidOperationException("Maskinporten JWK rotation verification failed without a retryable exception.");
+    }
+
+    private async Task VerifyAdminDcrAccessAsync(
+        MaskinportenJwkRotationSettings settings,
+        string environment,
+        MaskinportenGeneratedJwk generated,
+        CancellationToken cancellationToken)
+    {
+        var updatedAdminCredentials = CreateAdminCredentials(settings, environment, generated.PrivateJwkBase64);
+        await digdirMaskinportenAdminService.GetJwksAsync(settings.AdminClientId, updatedAdminCredentials, cancellationToken);
+    }
+
+    private async Task<RotationTarget> GetRotationTargetAsync(
+        MaskinportenJwkRotationSettings settings,
+        MaskinportenSettings primaryTarget,
+        CancellationToken cancellationToken)
+    {
+        var verificationScope = GetVerificationScope(primaryTarget);
+        var keyVaultTargets = new List<KeyVaultWriteTarget>
+        {
+            new(
+                "Broker",
+                NormalizeKeyVaultUrl(settings.KeyVaultUrl),
+                settings.KeyVaultSecretName,
+                settings.ContainerAppResourceId)
+        };
+
+        await PreflightKeyVaultSecretsAsync(
+            keyVaultTargets[0].KeyVaultUrl,
+            new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                [settings.KeyVaultSecretName] = null,
+                [settings.TargetClientIdKeyVaultSecretName] = primaryTarget.ClientId
+            },
+            cancellationToken);
+
+        foreach (var configuredTarget in settings.Targets)
+        {
+            var keyVaultUrl = NormalizeKeyVaultUrl(configuredTarget.KeyVaultUrl);
+            var clientIdSecretName = string.IsNullOrWhiteSpace(configuredTarget.ClientIdSecretName)
+                ? settings.TargetClientIdKeyVaultSecretName
+                : configuredTarget.ClientIdSecretName;
+            var encodedJwkSecretName = string.IsNullOrWhiteSpace(configuredTarget.EncodedJwkSecretName)
+                ? settings.KeyVaultSecretName
+                : configuredTarget.EncodedJwkSecretName;
+
+            await PreflightKeyVaultSecretsAsync(
+                keyVaultUrl,
+                new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [clientIdSecretName] = primaryTarget.ClientId,
+                    [encodedJwkSecretName] = null
+                },
+                cancellationToken);
+
+            keyVaultTargets.Add(new KeyVaultWriteTarget(
+                string.IsNullOrWhiteSpace(configuredTarget.Name) ? keyVaultUrl : configuredTarget.Name,
+                keyVaultUrl,
+                encodedJwkSecretName,
+                configuredTarget.ContainerAppResourceId));
+        }
+
+        return new RotationTarget(
+            primaryTarget.ClientId,
+            "Broker",
+            primaryTarget.EncodedJwk,
+            verificationScope,
+            keyVaultTargets,
+            settings.NewKeyIdPrefix,
+            primaryTarget.Environment);
+    }
+
+    private async Task PreflightKeyVaultSecretsAsync(
+        string keyVaultUrl,
+        IReadOnlyDictionary<string, string?> secretRequirements,
+        CancellationToken cancellationToken)
+    {
+        foreach (var secretRequirement in secretRequirements)
+        {
+            var secretName = secretRequirement.Key;
+            var secretValue = await keyVaultSecretStore.GetSecretValueAsync(keyVaultUrl, secretName, cancellationToken);
+
+            if (secretRequirement.Value is not null
+                && !string.Equals(secretValue, secretRequirement.Value, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Key Vault {keyVaultUrl} contains unexpected value for secret {secretName} during Maskinporten rotation preflight.");
+            }
+        }
+    }
+
+    private static MaskinportenAdminApiCredentials CreateAdminCredentials(
+        MaskinportenJwkRotationSettings settings,
+        string environment,
+        string encodedJwk)
+        => new()
+        {
+            ClientId = settings.AdminClientId,
+            EncodedJwk = encodedJwk,
+            Scope = settings.AdminScope,
+            ApiBaseUrl = settings.AdminApiBaseUrl,
+            Environment = environment
+        };
+
+    private static string GetVerificationScope(MaskinportenSettings target)
+    {
+        var firstScope = target.Scope
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault();
+
+        return firstScope
+            ?? throw new InvalidOperationException("No verification scope configured for Maskinporten JWK rotation.");
+    }
+
+    private static string NormalizeKeyVaultUrl(string url)
+        => string.IsNullOrWhiteSpace(url)
+            ? string.Empty
+            : url.Trim().TrimEnd('/');
+
+    private static bool IsRetryableVerificationFailure(Exception exception)
+        => exception is InvalidOperationException invalidOperationException
+            && invalidOperationException.Message.Contains("Unknown key identifier (kid)", StringComparison.OrdinalIgnoreCase);
+
+    private static string FormatKids(IEnumerable<MaskinportenJwkKey> keys)
+    {
+        var kids = keys
+            .Select(key => string.IsNullOrWhiteSpace(key.Kid) ? "<missing>" : key.Kid)
+            .ToArray();
+
+        return kids.Length == 0 ? "<none>" : string.Join(", ", kids);
+    }
+
+    private static string GetSecretTargetKey(KeyVaultWriteTarget target)
+        => $"{target.KeyVaultUrl}|{target.KeyVaultSecretName}";
+
+    private static void ValidateConfiguration(MaskinportenJwkRotationSettings settings, MaskinportenSettings target)
+    {
+        if (string.IsNullOrWhiteSpace(settings.AdminClientId))
+        {
+            throw new InvalidOperationException("Maskinporten JWK rotation admin client id is missing.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.AdminEncodedJwk))
+        {
+            throw new InvalidOperationException("Maskinporten JWK rotation admin JWK is missing.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.AdminScope))
+        {
+            throw new InvalidOperationException("Maskinporten JWK rotation admin scope is missing.");
+        }
+
+        if (string.IsNullOrWhiteSpace(NormalizeKeyVaultUrl(settings.KeyVaultUrl)))
+        {
+            throw new InvalidOperationException("Maskinporten JWK rotation Key Vault URL is missing.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.AdminKeyVaultSecretName))
+        {
+            throw new InvalidOperationException("Maskinporten JWK rotation admin Key Vault secret name is missing.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.AdminClientIdKeyVaultSecretName))
+        {
+            throw new InvalidOperationException("Maskinporten JWK rotation admin client id Key Vault secret name is missing.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.KeyVaultSecretName))
+        {
+            throw new InvalidOperationException("Maskinporten JWK rotation Key Vault secret name is missing.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.TargetClientIdKeyVaultSecretName))
+        {
+            throw new InvalidOperationException("Maskinporten JWK rotation target client id Key Vault secret name is missing.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.AdminNewKeyIdPrefix))
+        {
+            throw new InvalidOperationException("Maskinporten JWK rotation admin key id prefix is missing.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.NewKeyIdPrefix))
+        {
+            throw new InvalidOperationException("Maskinporten JWK rotation key id prefix is missing.");
+        }
+
+        foreach (var configuredTarget in settings.Targets)
+        {
+            if (string.IsNullOrWhiteSpace(configuredTarget.KeyVaultUrl))
+            {
+                throw new InvalidOperationException("Maskinporten JWK rotation target Key Vault URL is missing.");
+            }
+        }
+
+        if (settings.VerificationMaxAttempts <= 0)
+        {
+            throw new InvalidOperationException("Maskinporten JWK rotation verification max attempts must be greater than zero.");
+        }
+
+        if (settings.VerificationDelaySeconds < 0)
+        {
+            throw new InvalidOperationException("Maskinporten JWK rotation verification delay seconds cannot be negative.");
+        }
+
+        if (string.IsNullOrWhiteSpace(target.ClientId))
+        {
+            throw new InvalidOperationException("Target Maskinporten client id is missing.");
+        }
+
+        if (string.IsNullOrWhiteSpace(target.EncodedJwk))
+        {
+            throw new InvalidOperationException("Target Maskinporten private JWK is missing.");
+        }
+
+        if (string.IsNullOrWhiteSpace(target.Scope))
+        {
+            throw new InvalidOperationException("Target Maskinporten scope is missing.");
+        }
+
+        if (string.IsNullOrWhiteSpace(target.Environment))
+        {
+            throw new InvalidOperationException("Target Maskinporten environment is missing.");
+        }
+    }
+
+    private sealed record RotationTarget(
+        string ClientId,
+        string ClientName,
+        string CurrentEncodedJwk,
+        string VerificationScope,
+        IReadOnlyList<KeyVaultWriteTarget> KeyVaultTargets,
+        string NewKeyIdPrefix,
+        string Environment);
+
+    private sealed record KeyVaultWriteTarget(
+        string Name,
+        string KeyVaultUrl,
+        string KeyVaultSecretName,
+        string ContainerAppResourceId);
+
+    private sealed record SingleRotationExecution(
+        MaskinportenJwkRotationClientResult Result,
+        MaskinportenGeneratedJwk Generated);
+}

--- a/src/Altinn.Broker.Integrations/Maskinporten/MaskinportenTokenService.cs
+++ b/src/Altinn.Broker.Integrations/Maskinporten/MaskinportenTokenService.cs
@@ -1,0 +1,105 @@
+using Altinn.Broker.Core.Services;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Altinn.Broker.Integrations.Maskinporten;
+
+public class MaskinportenTokenService(IHttpClientFactory httpClientFactory) : IMaskinportenTokenService
+{
+    public async Task<string> RequestTokenAsync(string clientId, string encodedPrivateJwk, string scope, string environment, CancellationToken cancellationToken)
+    {
+        using var httpClient = httpClientFactory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Post, GetTokenEndpoint(environment))
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["grant_type"] = "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                ["assertion"] = CreateClientAssertion(clientId, encodedPrivateJwk, scope, environment)
+            })
+        };
+
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+        var payload = await response.Content.ReadFromJsonAsync<MaskinportenTokenResponse>(cancellationToken: cancellationToken);
+        if (!response.IsSuccessStatusCode || string.IsNullOrWhiteSpace(payload?.AccessToken))
+        {
+            throw new InvalidOperationException(
+                $"Maskinporten token request failed for client '{clientId}'. Status={(int)response.StatusCode}. Error={payload?.Error}. Description={payload?.ErrorDescription}");
+        }
+
+        return payload.AccessToken;
+    }
+
+    private static string CreateClientAssertion(string clientId, string encodedPrivateJwk, string scope, string environment)
+    {
+        var jwk = DecodePrivateJwk(encodedPrivateJwk);
+        var rsaParameters = new RSAParameters
+        {
+            Modulus = Base64UrlEncoder.DecodeBytes(jwk["n"]),
+            Exponent = Base64UrlEncoder.DecodeBytes(jwk["e"]),
+            D = Base64UrlEncoder.DecodeBytes(jwk["d"]),
+            P = Base64UrlEncoder.DecodeBytes(jwk["p"]),
+            Q = Base64UrlEncoder.DecodeBytes(jwk["q"]),
+            DP = Base64UrlEncoder.DecodeBytes(jwk["dp"]),
+            DQ = Base64UrlEncoder.DecodeBytes(jwk["dq"]),
+            InverseQ = Base64UrlEncoder.DecodeBytes(jwk["qi"])
+        };
+
+        var handler = new JsonWebTokenHandler();
+        return handler.CreateToken(new SecurityTokenDescriptor
+        {
+            Claims = new Dictionary<string, object>
+            {
+                ["aud"] = GetTokenAudience(environment),
+                ["scope"] = scope,
+                ["iss"] = clientId,
+                ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                ["exp"] = DateTimeOffset.UtcNow.AddMinutes(2).ToUnixTimeSeconds(),
+                ["jti"] = Guid.NewGuid().ToString()
+            },
+            SigningCredentials = new SigningCredentials(
+                new RsaSecurityKey(rsaParameters) { KeyId = jwk["kid"] },
+                SecurityAlgorithms.RsaSha256)
+        });
+    }
+
+    private static Dictionary<string, string> DecodePrivateJwk(string encodedPrivateJwk)
+    {
+        if (string.IsNullOrWhiteSpace(encodedPrivateJwk))
+        {
+            throw new InvalidOperationException("Encoded private JWK is missing.");
+        }
+
+        var json = Encoding.UTF8.GetString(Convert.FromBase64String(encodedPrivateJwk));
+        return JsonSerializer.Deserialize<Dictionary<string, string>>(json)
+            ?? throw new InvalidOperationException("Unable to deserialize private JWK.");
+    }
+
+    private static string GetTokenEndpoint(string environment)
+        => environment.Equals("prod", StringComparison.OrdinalIgnoreCase)
+            || environment.Equals("production", StringComparison.OrdinalIgnoreCase)
+            ? "https://maskinporten.no/token"
+            : "https://test.maskinporten.no/token";
+
+    private static string GetTokenAudience(string environment)
+        => environment.Equals("prod", StringComparison.OrdinalIgnoreCase)
+            || environment.Equals("production", StringComparison.OrdinalIgnoreCase)
+            ? "https://maskinporten.no/"
+            : "https://test.maskinporten.no/";
+
+    private sealed class MaskinportenTokenResponse
+    {
+        [JsonPropertyName("access_token")]
+        public string AccessToken { get; set; } = string.Empty;
+
+        [JsonPropertyName("error")]
+        public string Error { get; set; } = string.Empty;
+
+        [JsonPropertyName("error_description")]
+        public string ErrorDescription { get; set; } = string.Empty;
+    }
+}

--- a/tests/Altinn.Broker.Tests/MaintenanceControllerMaskinportenJwkRotationTests.cs
+++ b/tests/Altinn.Broker.Tests/MaintenanceControllerMaskinportenJwkRotationTests.cs
@@ -1,0 +1,57 @@
+using Altinn.Broker.API.Controllers;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Altinn.Broker.Tests;
+
+public class MaintenanceControllerMaskinportenJwkRotationTests
+{
+    [Fact]
+    public void TriggerMaskinportenJwkRotation_ReturnsBadRequest_WhenConfirmationIsWrong()
+    {
+        var backgroundJobClient = new Mock<IBackgroundJobClient>();
+        var controller = CreateController();
+
+        var result = controller.TriggerMaskinportenJwkRotation(
+            backgroundJobClient.Object,
+            new TriggerMaskinportenJwkRotationRequest { Confirmation = "dry-run" });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        backgroundJobClient.Verify(client => client.Create(It.IsAny<Job>(), It.IsAny<IState>()), Times.Never);
+    }
+
+    [Fact]
+    public void TriggerMaskinportenJwkRotation_EnqueuesJob_WhenConfirmationIsCorrect()
+    {
+        var backgroundJobClient = new Mock<IBackgroundJobClient>();
+        backgroundJobClient
+            .Setup(client => client.Create(It.IsAny<Job>(), It.IsAny<IState>()))
+            .Returns("job-1");
+        var controller = CreateController();
+
+        var result = controller.TriggerMaskinportenJwkRotation(
+            backgroundJobClient.Object,
+            new TriggerMaskinportenJwkRotationRequest { Confirmation = "rotate-maskinporten-jwk" });
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(ok.Value);
+        backgroundJobClient.Verify(client => client.Create(
+            It.Is<Job>(job => job.Method.Name == "Process"),
+            It.IsAny<IState>()), Times.Once);
+    }
+
+    private static MaintenanceController CreateController()
+        => new(NullLogger<MaintenanceController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+}

--- a/tests/Altinn.Broker.Tests/MaskinportenJwkRotationHandlerTests.cs
+++ b/tests/Altinn.Broker.Tests/MaskinportenJwkRotationHandlerTests.cs
@@ -1,0 +1,113 @@
+using Altinn.Broker.Application.MaskinportenJwkRotation;
+using Altinn.Broker.Application.SendSlackNotification;
+using Altinn.Broker.Core.Options;
+using Altinn.Broker.Core.Services;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Slack.Webhooks;
+using Xunit;
+
+namespace Altinn.Broker.Tests;
+
+public class MaskinportenJwkRotationHandlerTests
+{
+    [Theory]
+    [InlineData(2026, 2, 2, true)]
+    [InlineData(2026, 2, 3, false)]
+    [InlineData(2026, 3, 2, true)]
+    [InlineData(2026, 3, 3, false)]
+    [InlineData(2026, 11, 1, false)]
+    public void IsFirstWeekdayOfMonth_ReturnsExpectedValue(int year, int month, int day, bool expected)
+    {
+        var result = MaskinportenJwkRotationHandler.IsFirstWeekdayOfMonth(new DateOnly(year, month, day));
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task ProcessScheduled_SkipsRotation_WhenDateIsNotFirstWeekday()
+    {
+        var rotationService = new Mock<IMaskinportenJwkRotationService>();
+        var slackClient = new Mock<ISlackClient>();
+
+        var handler = CreateHandler(
+            rotationService.Object,
+            slackClient.Object,
+            new DateTimeOffset(2026, 2, 3, 8, 0, 0, TimeSpan.Zero));
+
+        await handler.ProcessScheduled(CancellationToken.None);
+
+        rotationService.Verify(service => service.RotateAsync(It.IsAny<CancellationToken>()), Times.Never);
+        slackClient.Verify(client => client.PostAsync(It.IsAny<SlackMessage>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessScheduled_RunsRotation_WhenDateIsFirstWeekday()
+    {
+        var rotationService = new Mock<IMaskinportenJwkRotationService>();
+        rotationService.Setup(service => service.RotateAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MaskinportenJwkRotationResult
+            {
+                Clients =
+                [
+                    new MaskinportenJwkRotationClientResult
+                    {
+                        ClientId = "target-client",
+                        ClientName = "Broker",
+                        NewKid = "kid-1",
+                        PreviousKeyCount = 1,
+                        CurrentKeyCount = 2,
+                        VerificationScope = "scope:a",
+                        KeyVaultSecretName = "maskinporten-jwk"
+                    }
+                ]
+            });
+
+        var slackClient = new Mock<ISlackClient>();
+
+        var handler = CreateHandler(
+            rotationService.Object,
+            slackClient.Object,
+            new DateTimeOffset(2026, 2, 2, 8, 0, 0, TimeSpan.Zero));
+
+        await handler.ProcessScheduled(CancellationToken.None);
+
+        rotationService.Verify(service => service.RotateAsync(It.IsAny<CancellationToken>()), Times.Once);
+        slackClient.Verify(client => client.PostAsync(It.Is<SlackMessage>(message =>
+            message.Text.StartsWith(":white_check_mark: *Maskinporten JWK rotation completed*")
+            && message.Text.Contains("*System:* Broker"))), Times.Once);
+    }
+
+    private static MaskinportenJwkRotationHandler CreateHandler(
+        IMaskinportenJwkRotationService rotationService,
+        ISlackClient slackClient,
+        DateTimeOffset utcNow)
+    {
+        var slackHandler = new SendSlackNotificationHandler(
+            slackClient,
+            new SlackSettings(new FakeHostEnvironment()),
+            new FakeHostEnvironment(),
+            NullLogger<SendSlackNotificationHandler>.Instance);
+
+        return new MaskinportenJwkRotationHandler(
+            rotationService,
+            slackHandler,
+            new FixedTimeProvider(utcNow),
+            NullLogger<MaskinportenJwkRotationHandler>.Instance);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    private sealed class FakeHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Test";
+        public string ApplicationName { get; set; } = "Altinn.Broker.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds Maskinporten JWK rotation for Broker, based on the verified Correspondence implementation.
Includes monthly scheduled rotation, manual maintenance trigger, admin-client self-rotation before Broker client rotation, Key Vault secret updates, rollback handling, Maskinporten/Digdir verification with retry, Container App refresh, and Slack success/failure notifications.

## Related Issue(s)
- #929 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added maintenance API endpoint for triggering credential rotation on demand
  * Implemented automatic scheduled credential rotation with Slack notifications for success and failure events
  * Container applications automatically refresh after rotation to apply updated credentials

* **Infrastructure**
  * Enhanced Azure Key Vault integration for credential management
  * Added configuration support for rotation targets across multiple environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-broker/pull/931?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->