### PR TITLE
Changed RequiredParty to be orgnumber to make it easier to test in tt02

### DIFF
--- a/.bruno/Resource/Configure resource for Broker.bru
+++ b/.bruno/Resource/Configure resource for Broker.bru
@@ -22,7 +22,8 @@ body:json {
     "PurgeFileTransferGracePeriod": "PT2H",
     "UseManifestFileShim": false,
     "ExternalServiceCodeLegacy": null,
-    "ExternalServiceEditionCodeLegacy": null
+    "ExternalServiceEditionCodeLegacy": null,
+    "RequiredParty": null
   }
 }
 

--- a/src/Altinn.Broker.API/Models/ResourceExt.cs
+++ b/src/Altinn.Broker.API/Models/ResourceExt.cs
@@ -55,8 +55,8 @@ public class ResourceExt
     public int? ExternalServiceEditionCodeLegacy { get; set; }
 
     /// <summary>
-    /// If the resource requires the service owner party to be subject of the file transfer.
+    /// The party that is required to be subject of the file transfer.
     /// </summary>
     [JsonPropertyName("requiredParty")]
-    public bool? RequiredParty { get; set; }
+    public string? RequiredParty { get; set; }
 }

--- a/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
+++ b/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceHandler.cs
@@ -108,7 +108,7 @@ public class ConfigureResourceHandler(IResourceRepository resourceRepository, IA
         }
         if (request.RequiredParty is not null)
         {
-            await resourceRepository.UpdateRequiredParty(existingResource!.Id, request.RequiredParty.Value, cancellationToken);
+            await resourceRepository.UpdateRequiredParty(existingResource!.Id, request.RequiredParty, cancellationToken);
         }
         return Task.CompletedTask;
     }

--- a/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceRequest.cs
+++ b/src/Altinn.Broker.Application/ConfigureResource/ConfigureResourceRequest.cs
@@ -9,5 +9,5 @@ public class ConfigureResourceRequest
     public bool? UseManifestFileShim { get; set; }
     public string? ExternalServiceCodeLegacy { get; set; }
     public int? ExternalServiceEditionCodeLegacy { get; set; }
-    public bool? RequiredParty { get; set; }
+    public string? RequiredParty { get; set; }
 }

--- a/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
+++ b/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
@@ -107,9 +107,10 @@ public class InitializeFileTransferHandler(
             }
         }
 
-        if (resource.RequiredParty == true)
+        if (!string.IsNullOrWhiteSpace(resource.RequiredParty))
         {
-            if (request.SenderExternalId.WithoutPrefix() == altinnResource.ServiceOwnerId.WithoutPrefix())
+            var requiredParty = resource.RequiredParty.WithoutPrefix();
+            if (request.SenderExternalId.WithoutPrefix() == requiredParty)
             {
             }
             else
@@ -120,7 +121,7 @@ public class InitializeFileTransferHandler(
                 }
                 
                 if (request.RecipientExternalIds.Count == 0 || 
-                    request.RecipientExternalIds[0].WithoutPrefix() != altinnResource.ServiceOwnerId.WithoutPrefix())
+                    request.RecipientExternalIds[0].WithoutPrefix() != requiredParty)
                 {
                     return Errors.RequiredPartyNotSpecified;
                 }

--- a/src/Altinn.Broker.Core/Domain/ResourceEntity.cs
+++ b/src/Altinn.Broker.Core/Domain/ResourceEntity.cs
@@ -14,6 +14,6 @@ public class ResourceEntity
     public string? ExternalServiceCodeLegacy { get; set; }
     public int? ExternalServiceEditionCodeLegacy { get; set; }
     public bool ApprovedForDisabledVirusScan { get; set; } = false;
-    public bool? RequiredParty { get; set; }
+    public string? RequiredParty { get; set; }
     public bool AccessListEnabled { get; set; } = false;
 }

--- a/src/Altinn.Broker.Core/Repositories/IResourceRepository.cs
+++ b/src/Altinn.Broker.Core/Repositories/IResourceRepository.cs
@@ -12,5 +12,5 @@ public interface IResourceRepository
     Task UpdateUseManifestFileShim(string resourceId, bool useManifestFileShim, CancellationToken cancellationToken = default);
     Task UpdateExternalServiceCodeLegacy(string resourceId, string externalServiceCodeLegacy, CancellationToken cancellationToken = default);
     Task UpdateExternalServiceEditionCodeLegacy(string resourceId, int? externalServiceEditionCodeLegacy, CancellationToken cancellationToken = default);
-    Task UpdateRequiredParty(string resourceId, bool requiredParty, CancellationToken cancellationToken = default);
+    Task UpdateRequiredParty(string resourceId, string? requiredParty, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Broker.Persistence/Migrations/V0024__required_party_to_text.sql
+++ b/src/Altinn.Broker.Persistence/Migrations/V0024__required_party_to_text.sql
@@ -1,0 +1,6 @@
+ALTER TABLE broker.altinn_resource
+ALTER COLUMN required_party TYPE TEXT
+USING CASE
+    WHEN required_party IS TRUE THEN organization_number
+    ELSE NULL
+END;

--- a/src/Altinn.Broker.Persistence/Repositories/ResourceRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/ResourceRepository.cs
@@ -22,6 +22,18 @@ public class ResourceRepository(NpgsqlDataSource dataSource, IAltinnResourceRepo
         {
             while (await reader.ReadAsync(cancellationToken))
             {
+                string? requiredParty = null;
+                var requiredPartyValue = reader.GetValue(reader.GetOrdinal("required_party"));
+                if (requiredPartyValue is string requiredPartyFromDb)
+                {
+                    requiredParty = requiredPartyFromDb;
+                }
+                else if (requiredPartyValue is bool requiredPartyEnabled && requiredPartyEnabled)
+                {
+                    // Backward compatibility for environments where required_party is still BOOLEAN.
+                    requiredParty = reader.GetString(reader.GetOrdinal("service_owner_id_fk"));
+                }
+
                 resource = new ResourceEntity
                 {
                     Id = reader.GetString(reader.GetOrdinal("resource_id_pk")),
@@ -35,7 +47,7 @@ public class ResourceRepository(NpgsqlDataSource dataSource, IAltinnResourceRepo
                     UseManifestFileShim = reader.IsDBNull(reader.GetOrdinal("use_manifest_file_shim")) ? null : reader.GetBoolean(reader.GetOrdinal("use_manifest_file_shim")),
                     ExternalServiceCodeLegacy = reader.IsDBNull(reader.GetOrdinal("external_service_code_legacy")) ? null : reader.GetString(reader.GetOrdinal("external_service_code_legacy")),
                     ExternalServiceEditionCodeLegacy = reader.IsDBNull(reader.GetOrdinal("external_service_edition_code_legacy")) ? null : reader.GetInt32(reader.GetOrdinal("external_service_edition_code_legacy")),
-                    RequiredParty = reader.IsDBNull(reader.GetOrdinal("required_party")) ? null : reader.GetString(reader.GetOrdinal("required_party")),
+                    RequiredParty = requiredParty,
                     ApprovedForDisabledVirusScan = reader.GetBoolean(reader.GetOrdinal("approved_for_disabled_virus_scan"))
                 };
             }

--- a/src/Altinn.Broker.Persistence/Repositories/ResourceRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/ResourceRepository.cs
@@ -35,7 +35,7 @@ public class ResourceRepository(NpgsqlDataSource dataSource, IAltinnResourceRepo
                     UseManifestFileShim = reader.IsDBNull(reader.GetOrdinal("use_manifest_file_shim")) ? null : reader.GetBoolean(reader.GetOrdinal("use_manifest_file_shim")),
                     ExternalServiceCodeLegacy = reader.IsDBNull(reader.GetOrdinal("external_service_code_legacy")) ? null : reader.GetString(reader.GetOrdinal("external_service_code_legacy")),
                     ExternalServiceEditionCodeLegacy = reader.IsDBNull(reader.GetOrdinal("external_service_edition_code_legacy")) ? null : reader.GetInt32(reader.GetOrdinal("external_service_edition_code_legacy")),
-                    RequiredParty = reader.IsDBNull(reader.GetOrdinal("required_party")) ? null : reader.GetBoolean(reader.GetOrdinal("required_party")),
+                    RequiredParty = reader.IsDBNull(reader.GetOrdinal("required_party")) ? null : reader.GetString(reader.GetOrdinal("required_party")),
                     ApprovedForDisabledVirusScan = reader.GetBoolean(reader.GetOrdinal("approved_for_disabled_virus_scan"))
                 };
             }
@@ -142,14 +142,14 @@ public class ResourceRepository(NpgsqlDataSource dataSource, IAltinnResourceRepo
         await commandExecutor.ExecuteWithRetry(command.ExecuteNonQueryAsync, cancellationToken);
     }
 
-    public async Task UpdateRequiredParty(string resourceId, bool requiredParty, CancellationToken cancellationToken = default)
+    public async Task UpdateRequiredParty(string resourceId, string? requiredParty, CancellationToken cancellationToken = default)
     {
         await using var command = dataSource.CreateCommand(
             "UPDATE broker.altinn_resource " +
             "SET required_party = @requiredParty " +
             "WHERE resource_id_pk = @resourceId");
         command.Parameters.AddWithValue("@resourceId", resourceId);
-        command.Parameters.AddWithValue("@requiredParty", requiredParty);
+        command.Parameters.AddWithValue("@requiredParty", (object?)requiredParty ?? DBNull.Value);
         
         await commandExecutor.ExecuteWithRetry(command.ExecuteNonQueryAsync, cancellationToken);
     }

--- a/tests/Altinn.Broker.Tests/Data/R__Prepare_Test_Data.sql
+++ b/tests/Altinn.Broker.Tests/Data/R__Prepare_Test_Data.sql
@@ -38,7 +38,7 @@ INSERT INTO broker.altinn_resource (
     null,
     '991825827',
     '0192:991825827',
-    true
+    '991825827'
 )
 ON CONFLICT (resource_id_pk) DO NOTHING;
 

--- a/tests/Altinn.Broker.Tests/Data/R__Prepare_Test_Data.sql
+++ b/tests/Altinn.Broker.Tests/Data/R__Prepare_Test_Data.sql
@@ -38,7 +38,7 @@ INSERT INTO broker.altinn_resource (
     null,
     '991825827',
     '0192:991825827',
-    '991825827'
+    true
 )
 ON CONFLICT (resource_id_pk) DO NOTHING;
 
@@ -48,18 +48,36 @@ INSERT INTO broker.altinn_resource (
     max_file_transfer_size,
     file_transfer_time_to_live,
     organization_number,
-    service_owner_id_fk,
-    required_party
+    service_owner_id_fk
 ) VALUES (
     'ttd-brokertestressurs',
     NOW(),
     null,
     null,
     '991825827',
-    '0192:991825827',
-    true
+    '0192:991825827'
 )
 ON CONFLICT (resource_id_pk) DO NOTHING;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'broker'
+          AND table_name = 'altinn_resource'
+          AND column_name = 'required_party'
+          AND data_type = 'boolean'
+    ) THEN
+        UPDATE broker.altinn_resource
+        SET required_party = true
+        WHERE resource_id_pk = 'ttd-brokertestressurs';
+    ELSE
+        UPDATE broker.altinn_resource
+        SET required_party = '991825827'
+        WHERE resource_id_pk = 'ttd-brokertestressurs';
+    END IF;
+END $$;
 
 INSERT INTO broker.altinn_resource (
     resource_id_pk,

--- a/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -162,7 +162,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                     Created = DateTime.UtcNow,
                     ServiceOwnerId = "0192:991825827",
                     OrganizationNumber = "991825827",
-                    RequiredParty = true
+                    RequiredParty = "991825827"
                 });
             altinnResourceRepository.Setup(x => x.GetResource(It.Is(TestConstants.RESOURCE_WITH_ACCESS_LIST, StringComparer.Ordinal), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => new ResourceEntity


### PR DESCRIPTION
## Description
When testing in tt02 there are some issues with using your own service owner org number for systemuser. Hence we support setting it specifically to work in tt02.

NOTE! If any of the resources have a non-null RequiredParty when this is deployed we'll get errors during deployment. So ensure that is not the case before running migration in that environment.

## Related Issue(s)
- #887 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Required-party setting now accepts party identifiers (strings) instead of a boolean flag.

* **Changes**
  * Sender and recipient validation now compares against the configured party identifier when present.
  * Storage and migrations updated to persist party identifiers; existing boolean-based settings migrated to organization numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->