### PR TITLE
Added hangfire queue metrics

### DIFF
--- a/src/Altinn.Broker.Integrations/Azure/OpenTelemetryConfiguration.cs
+++ b/src/Altinn.Broker.Integrations/Azure/OpenTelemetryConfiguration.cs
@@ -29,7 +29,8 @@ public static class OpenTelemetryConfiguration
                     .AddMeter(
                         "Microsoft.AspNetCore.Hosting",
                         "Microsoft.AspNetCore.Server.Kestrel",
-                        "System.Net.Http")
+                        "System.Net.Http",
+                        "Altinn.Broker.Integrations.Hangfire")
                     .AddNpgsqlInstrumentation();
             })
             .WithTracing(tracing =>

--- a/src/Altinn.Broker.Integrations/Hangfire/DependencyInjection.cs
+++ b/src/Altinn.Broker.Integrations/Hangfire/DependencyInjection.cs
@@ -30,5 +30,7 @@ public static class DependencyInjection
         }
         );
         services.AddHangfireServer();
+
+        services.AddHostedService<HangfireQueueMetricsService>();
     }
 }

--- a/src/Altinn.Broker.Integrations/Hangfire/HangfireQueueMetricsService.cs
+++ b/src/Altinn.Broker.Integrations/Hangfire/HangfireQueueMetricsService.cs
@@ -1,0 +1,139 @@
+using System.Diagnostics.Metrics;
+using Hangfire;
+using Hangfire.Storage;
+using Microsoft.Extensions.Hosting;
+
+namespace Altinn.Broker.Integrations.Hangfire;
+
+public sealed class HangfireQueueMetricsService : IHostedService
+{
+    private const string MeterName = "Altinn.Broker.Integrations.Hangfire";
+    private static readonly TimeSpan SnapshotTtl = TimeSpan.FromSeconds(30);
+
+    private readonly Meter _meter = new(MeterName);
+    private readonly Lock _snapshotLock = new();
+
+    private DateTime _lastSnapshotAtUtc = DateTime.MinValue;
+    private HangfireMetricsSnapshot _lastSnapshot = HangfireMetricsSnapshot.Empty;
+
+    public HangfireQueueMetricsService()
+    {
+        _meter.CreateObservableGauge(
+            name: "hangfire.jobs.enqueued",
+            observeValues: ObserveEnqueuedByQueue,
+            unit: "jobs",
+            description: "Current number of enqueued jobs per Hangfire queue.");
+
+        _meter.CreateObservableGauge(
+            name: "hangfire.jobs.processing",
+            observeValue: () => GetSnapshot().Processing,
+            unit: "jobs",
+            description: "Current number of Hangfire jobs in Processing state.");
+
+        _meter.CreateObservableGauge(
+            name: "hangfire.jobs.scheduled",
+            observeValue: () => GetSnapshot().Scheduled,
+            unit: "jobs",
+            description: "Current number of Hangfire jobs in Scheduled state.");
+
+        _meter.CreateObservableGauge(
+            name: "hangfire.jobs.failed",
+            observeValue: () => GetSnapshot().Failed,
+            unit: "jobs",
+            description: "Current number of Hangfire jobs in Failed state.");
+
+        _meter.CreateObservableGauge(
+            name: "hangfire.servers.active",
+            observeValue: () => GetSnapshot().ActiveServers,
+            unit: "servers",
+            description: "Current number of active Hangfire servers.");
+
+        _meter.CreateObservableGauge(
+            name: "hangfire.component.healthy",
+            observeValue: () => GetSnapshot().ComponentHealthy,
+            unit: "state",
+            description: "1 when at least one Hangfire server is active, otherwise 0.");
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _ = GetSnapshot();
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _meter.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private IEnumerable<Measurement<long>> ObserveEnqueuedByQueue()
+    {
+        var snapshot = GetSnapshot();
+        foreach (var (queue, value) in snapshot.EnqueuedByQueue)
+        {
+            yield return new Measurement<long>(value, new KeyValuePair<string, object?>("queue", queue));
+        }
+    }
+
+    private HangfireMetricsSnapshot GetSnapshot()
+    {
+        lock (_snapshotLock)
+        {
+            var now = DateTime.UtcNow;
+            if (now - _lastSnapshotAtUtc < SnapshotTtl)
+            {
+                return _lastSnapshot;
+            }
+
+            var monitoringApi = JobStorage.Current.GetMonitoringApi();
+            var activeServers = GetActiveServerCount(monitoringApi);
+            var snapshot = new HangfireMetricsSnapshot(
+                EnqueuedByQueue: GetEnqueuedByQueue(monitoringApi),
+                Processing: monitoringApi.ProcessingCount(),
+                Scheduled: monitoringApi.ScheduledCount(),
+                Failed: monitoringApi.FailedCount(),
+                ActiveServers: activeServers,
+                ComponentHealthy: activeServers > 0 ? 1 : 0);
+
+            _lastSnapshot = snapshot;
+            _lastSnapshotAtUtc = now;
+
+            return _lastSnapshot;
+        }
+    }
+
+    private static IReadOnlyDictionary<string, long> GetEnqueuedByQueue(IMonitoringApi monitoringApi)
+    {
+        var result = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+        foreach (var queue in monitoringApi.Queues())
+        {
+            result[queue.Name] = queue.Length;
+        }
+
+        return result;
+    }
+
+    private static long GetActiveServerCount(IMonitoringApi monitoringApi)
+    {
+        var servers = monitoringApi.Servers();
+        return servers?.Count ?? 0;
+    }
+
+    private sealed record HangfireMetricsSnapshot(
+        IReadOnlyDictionary<string, long> EnqueuedByQueue,
+        long Processing,
+        long Scheduled,
+        long Failed,
+        long ActiveServers,
+        long ComponentHealthy)
+    {
+        public static readonly HangfireMetricsSnapshot Empty = new(
+            EnqueuedByQueue: new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase),
+            Processing: 0,
+            Scheduled: 0,
+            Failed: 0,
+            ActiveServers: 0,
+            ComponentHealthy: 0);
+    }
+}

--- a/src/Altinn.Broker.Integrations/Hangfire/HangfireQueueMetricsService.cs
+++ b/src/Altinn.Broker.Integrations/Hangfire/HangfireQueueMetricsService.cs
@@ -86,17 +86,22 @@ public sealed class HangfireQueueMetricsService : IHostedService
                 return _lastSnapshot;
             }
 
-            var monitoringApi = JobStorage.Current.GetMonitoringApi();
-            var activeServers = GetActiveServerCount(monitoringApi);
-            var snapshot = new HangfireMetricsSnapshot(
-                EnqueuedByQueue: GetEnqueuedByQueue(monitoringApi),
-                Processing: monitoringApi.ProcessingCount(),
-                Scheduled: monitoringApi.ScheduledCount(),
-                Failed: monitoringApi.FailedCount(),
-                ActiveServers: activeServers,
-                ComponentHealthy: activeServers > 0 ? 1 : 0);
-
-            _lastSnapshot = snapshot;
+            try
+            {
+                var monitoringApi = JobStorage.Current.GetMonitoringApi();
+                var activeServers = GetActiveServerCount(monitoringApi);
+                _lastSnapshot = new HangfireMetricsSnapshot(
+                    EnqueuedByQueue: GetEnqueuedByQueue(monitoringApi),
+                    Processing: monitoringApi.ProcessingCount(),
+                    Scheduled: monitoringApi.ScheduledCount(),
+                    Failed: monitoringApi.FailedCount(),
+                    ActiveServers: activeServers,
+                    ComponentHealthy: activeServers > 0 ? 1 : 0);
+            }
+            catch (Exception)
+            {
+                _lastSnapshot = _lastSnapshot with { ComponentHealthy = 0 };
+            }
             _lastSnapshotAtUtc = now;
 
             return _lastSnapshot;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds hangfire queue and server status metrics to azure openTelemetry. This data is used for grafana and can also be viewed from azure metrics.

## Related Issue(s)
- #940 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced observability by adding metrics tracking for background job queue monitoring, including enqueued jobs, processing counts, scheduled jobs, failed jobs, and server health status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->