### PR TITLE
Support the TUS protocol including concatenation extension

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -170,6 +170,19 @@ module containerAppEnv '../modules/containerAppEnvironment/main.bicep' = {
   }
 }
 
+module redis '../modules/redis/create.bicep' = {
+  scope: resourceGroup
+  name: 'redis'
+  dependsOn: [environmentKeyVault]
+  params: {
+    location: location
+    namePrefix: namePrefix
+    keyVaultName: sourceKeyVaultName
+    environment: environment
+    prodLikeEnvironment: environment != 'test'
+  }
+}
+
 module virusscan '../modules/virusscan/create.bicep' = {
   name: 'virusscan'
 }

--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -179,7 +179,6 @@ module redis '../modules/redis/create.bicep' = {
     namePrefix: namePrefix
     keyVaultName: sourceKeyVaultName
     environment: environment
-    prodLikeEnvironment: environment != 'test'
   }
 }
 

--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -137,9 +137,6 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
         targetPort: 2525
         external: true
         transport: 'Auto'
-        stickySessions: {
-          affinity: 'sticky'
-        }
         ipSecurityRestrictions: ipSecurityRestrictions
       }
       secrets: concat([

--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -238,8 +238,8 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
           env: containerAppEnvVars
           probes: probes
           resources: {
-            cpu: environment == 'production' ? json('2.0') : json('0.5')
-            memory: environment == 'production' ? '4.0Gi' : '1.0Gi'
+            cpu: json('2.0')
+            memory: '4.0Gi'
           }
         }
       ]

--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -84,6 +84,8 @@ var containerAppEnvVars = concat([
   { name: 'AzureStorageOptions__BlockSize', value: '33554432' }
   { name: 'AzureStorageOptions__ConcurrentUploadThreads', value: '3' }
   { name: 'AzureStorageOptions__BlocksBeforeCommit', value: '1000' }
+  { name: 'TusOptions__UploadExpiration', value: '24:00:00' }
+  { name: 'DistributedCacheOptions__RedisConnectionString', secretRef: 'redis-connection-string' }
   { name: 'ReportStorageOptions__ConnectionString', secretRef: 'storage-connection-string' }
   { name: 'ReportResourceIdFilter', secretRef: 'report-resource-id-filter' }
   { name: 'OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION', value: 'true' }
@@ -182,6 +184,11 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
           identity: principal_id
           keyVaultUrl: '${keyVaultUrl}/secrets/report-resource-id-filter'
           name: 'report-resource-id-filter'
+        }
+        {
+          identity: principal_id
+          keyVaultUrl: '${keyVaultUrl}/secrets/redis-connection-string'
+          name: 'redis-connection-string'
         }
       ], rotationKeyvaultSecrets)
     }

--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -137,6 +137,9 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
         targetPort: 2525
         external: true
         transport: 'Auto'
+        stickySessions: {
+          affinity: 'sticky'
+        }
         ipSecurityRestrictions: ipSecurityRestrictions
       }
       secrets: concat([

--- a/.azure/modules/redis/create.bicep
+++ b/.azure/modules/redis/create.bicep
@@ -1,0 +1,47 @@
+param location string
+param namePrefix string
+param keyVaultName string
+param environment string
+param prodLikeEnvironment bool
+
+resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: '${namePrefix}-redis-identity'
+  location: location
+  tags: resourceGroup().tags
+}
+
+resource redis 'Microsoft.Cache/redis@2024-11-01' = {
+  name: '${namePrefix}-redis'
+  location: location
+  tags: resourceGroup().tags
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${userAssignedIdentity.id}': {}
+    }
+  }
+  properties: {
+    enableNonSslPort: false
+    minimumTlsVersion: '1.2'
+    sku: {
+      name: 'Standard'
+      family: 'C'
+      capacity: prodLikeEnvironment ? 2 : environment == 'staging' ? 1 : 0
+    }
+  }
+}
+
+var redisConnectionStringName = 'redis-connection-string'
+
+module redisConnectionStringSecret '../keyvault/upsertSecret.bicep' = {
+  name: redisConnectionStringName
+  params: {
+    destKeyVaultName: keyVaultName
+    secretName: redisConnectionStringName
+    secretValue: '${redis.properties.hostName}:6380,password=${redis.listKeys().primaryKey},ssl=True,abortConnect=False'
+  }
+}
+
+output name string = redis.name
+output hostName string = redis.properties.hostName
+output secretName string = redisConnectionStringName

--- a/.azure/modules/redis/create.bicep
+++ b/.azure/modules/redis/create.bicep
@@ -2,7 +2,6 @@ param location string
 param namePrefix string
 param keyVaultName string
 param environment string
-param prodLikeEnvironment bool
 
 resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: '${namePrefix}-redis-identity'
@@ -26,7 +25,7 @@ resource redis 'Microsoft.Cache/redis@2024-11-01' = {
     sku: {
       name: 'Standard'
       family: 'C'
-      capacity: prodLikeEnvironment ? 2 : environment == 'staging' ? 1 : 0
+      capacity: environment == 'test' ? 0 : environment == 'staging' ? 1 : 2
     }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,3 +49,11 @@ services:
       [
         "flyway",
       ]
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+      retries: 30

--- a/src/Altinn.Broker.API/Altinn.Broker.API.csproj
+++ b/src/Altinn.Broker.API/Altinn.Broker.API.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9" />
     <PackageReference Include="Microsoft.Identity.Web" Version="3.11.0" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
@@ -29,6 +30,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Azure.Messaging.EventGrid" Version="5.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.13.0" />
+    <PackageReference Include="tusdotnet" Version="2.11.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.Broker.API/Configuration/DistributedCacheOptions.cs
+++ b/src/Altinn.Broker.API/Configuration/DistributedCacheOptions.cs
@@ -1,0 +1,8 @@
+namespace Altinn.Broker.API.Configuration;
+
+public class DistributedCacheOptions
+{
+    public const string SectionName = "DistributedCacheOptions";
+
+    public string? RedisConnectionString { get; set; }
+}

--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -70,7 +70,7 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
     /// </summary>
     /// <remarks>
     /// For large files that may exceed reverse-proxy connection timeouts, use the resumable TUS endpoint instead:
-    /// POST/PATCH <c>/broker/api/v1/filetransfer/{fileTransferId}/upload/tus</c> (TUS protocol).
+    /// POST/PATCH <c>/broker/api/v1/filetransfer/upload/tus/{fileTransferId}</c> (TUS protocol).
     /// One of the scopes: <br />
     /// - altinn:broker.write
     /// </remarks>

--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -69,6 +69,8 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
     /// Upload to an initialized file using a binary stream.
     /// </summary>
     /// <remarks>
+    /// For large files that may exceed reverse-proxy connection timeouts, use the resumable TUS endpoint instead:
+    /// POST/PATCH <c>/broker/api/v1/filetransfer/{fileTransferId}/upload/tus</c> (TUS protocol).
     /// One of the scopes: <br />
     /// - altinn:broker.write
     /// </remarks>

--- a/src/Altinn.Broker.API/Program.cs
+++ b/src/Altinn.Broker.API/Program.cs
@@ -94,6 +94,7 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
         var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
         options.IncludeXmlComments(xmlPath);
         options.OperationFilter<BinaryRequestBodyOperationFilter>();
+        options.DocumentFilter<TusUploadDocumentFilter>();
     });
 
     services.Configure<DatabaseOptions>(config.GetSection(key: nameof(DatabaseOptions)));

--- a/src/Altinn.Broker.API/Program.cs
+++ b/src/Altinn.Broker.API/Program.cs
@@ -5,10 +5,12 @@ using Altinn.ApiClients.Maskinporten.Config;
 using Altinn.Broker.API.Configuration;
 using Altinn.Broker.API.Filters;
 using Altinn.Broker.API.Helpers;
+using Altinn.Broker.API.Tus;
 using Altinn.Broker.Application;
 using Altinn.Broker.Core.Options;
 using Altinn.Broker.Helpers;
 using Altinn.Broker.Integrations;
+using Altinn.Broker.Integrations.Tus;
 using Altinn.Broker.Integrations.Azure;
 using Altinn.Broker.Integrations.Hangfire;
 using Altinn.Broker.Persistence;
@@ -21,7 +23,10 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.IdentityModel.Tokens;
+
+using StackExchange.Redis;
 
 BuildAndRun(args);
 
@@ -60,9 +65,12 @@ static void BuildAndRun(string[] args)
         app.UseSwagger();
         app.UseSwaggerUI();
     }
+
+    app.UseAuthentication();
     app.UseAuthorization();
 
     app.MapControllers();
+    app.MapBrokerTusUploads();
 
     app.UseHangfireDashboard();
 
@@ -97,6 +105,8 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
     services.Configure<ReportStorageOptions>(config.GetSection(key: nameof(ReportStorageOptions)));
     services.Configure<ReportFilterOptions>(config);
     services.Configure<GeneralSettings>(config.GetSection(key: nameof(GeneralSettings)));
+    services.Configure<DistributedCacheOptions>(config.GetSection(DistributedCacheOptions.SectionName));
+    services.Configure<TusOptions>(config.GetSection(TusOptions.SectionName));
 
     services.AddApplicationHandlers();
     services.AddIntegrations(config, hostEnvironment.IsDevelopment());
@@ -105,15 +115,19 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
     services.AddHttpClient();
     services.AddProblemDetails();
 
-    // Add distributed cache for rate limiting (use memory cache for development, Redis for production)
-    if (hostEnvironment.IsDevelopment())
+    // Add distributed cache for rate limiting and TUS upload expiration tracking.
+    var distributedCacheOptions = config.GetSection(DistributedCacheOptions.SectionName).Get<DistributedCacheOptions>();
+    if (!string.IsNullOrWhiteSpace(distributedCacheOptions?.RedisConnectionString))
     {
-        services.AddDistributedMemoryCache();
+        services.AddStackExchangeRedisCache(options =>
+        {
+            options.Configuration = distributedCacheOptions.RedisConnectionString;
+        });
+        services.AddSingleton<IConnectionMultiplexer>(_ =>
+            ConnectionMultiplexer.Connect(distributedCacheOptions.RedisConnectionString));
     }
     else
     {
-        // In production, use Redis if available
-        // For now, fall back to memory cache
         services.AddDistributedMemoryCache();
     }
 

--- a/src/Altinn.Broker.API/Program.cs
+++ b/src/Altinn.Broker.API/Program.cs
@@ -68,6 +68,7 @@ static void BuildAndRun(string[] args)
 
     app.UseAuthentication();
     app.UseAuthorization();
+    app.UseMiddleware<TusFileTransferIdRouteMiddleware>();
 
     app.MapControllers();
     app.MapBrokerTusUploads();

--- a/src/Altinn.Broker.API/Program.cs
+++ b/src/Altinn.Broker.API/Program.cs
@@ -68,6 +68,7 @@ static void BuildAndRun(string[] args)
 
     app.UseAuthentication();
     app.UseAuthorization();
+    app.UseMiddleware<TusPartialPathRewriteMiddleware>();
     app.UseMiddleware<TusFileTransferIdRouteMiddleware>();
 
     app.MapControllers();

--- a/src/Altinn.Broker.API/Program.cs
+++ b/src/Altinn.Broker.API/Program.cs
@@ -56,6 +56,7 @@ static void BuildAndRun(string[] args)
     builder.Services.ConfigureOpenTelemetry(generalSettings?.ApplicationInsightsConnectionString ?? string.Empty);
 
     var app = builder.Build();
+    app.UseMiddleware<TusPartialPathRewriteMiddleware>();
     app.UseMiddleware<SecurityHeadersMiddleware>();
     app.UseMiddleware<AcceptHeaderValidationMiddleware>();
     app.UseExceptionHandler();
@@ -68,7 +69,6 @@ static void BuildAndRun(string[] args)
 
     app.UseAuthentication();
     app.UseAuthorization();
-    app.UseMiddleware<TusPartialPathRewriteMiddleware>();
     app.UseMiddleware<TusFileTransferIdRouteMiddleware>();
 
     app.MapControllers();

--- a/src/Altinn.Broker.API/Swagger/TusUploadDocumentFilter.cs
+++ b/src/Altinn.Broker.API/Swagger/TusUploadDocumentFilter.cs
@@ -17,9 +17,11 @@ public sealed class TusUploadDocumentFilter : IDocumentFilter
     private const string TusResumableHeader = "Tus-Resumable";
     private const string UploadLengthHeader = "Upload-Length";
     private const string UploadOffsetHeader = "Upload-Offset";
+    private const string UploadConcatHeader = "Upload-Concat";
     private const string OffsetOctetStream = "application/offset+octet-stream";
 
     private static readonly string TusPath = TusEndpointExtensions.RouteTemplate;
+    private static readonly string TusPartialPath = TusEndpointExtensions.PartialRouteTemplate;
 
     public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
     {
@@ -34,6 +36,16 @@ public sealed class TusUploadDocumentFilter : IDocumentFilter
                 [OperationType.Delete] = CreateDeleteOperation()
             }
         };
+
+        swaggerDoc.Paths[TusPartialPath] = new OpenApiPathItem
+        {
+            Operations = new Dictionary<OperationType, OpenApiOperation>
+            {
+                [OperationType.Head] = CreatePartialHeadOperation(),
+                [OperationType.Patch] = CreatePartialPatchOperation(),
+                [OperationType.Delete] = CreatePartialDeleteOperation()
+            }
+        };
     }
 
     private static OpenApiOperation CreateOptionsOperation() => new()
@@ -43,6 +55,7 @@ public sealed class TusUploadDocumentFilter : IDocumentFilter
         Description = BuildDescription(
             "Returns supported TUS protocol version and extensions. " +
             "Call this before starting a resumable upload. " +
+            "The <c>Tus-Extension</c> response header includes <c>concatenation</c> for parallel partial uploads. " +
             "See https://tus.io/protocols/resumable-upload.html"),
         OperationId = "TusUploadOptions",
         Parameters = [FileTransferIdParameter()],
@@ -59,18 +72,25 @@ public sealed class TusUploadDocumentFilter : IDocumentFilter
         Summary = "Create a resumable upload",
         Description = BuildDescription(
             "Creates a TUS upload resource for an initialized file transfer. " +
-            "Requires the <c>Upload-Length</c> header with the total file size in bytes. " +
+            "<br/><br/><b>Single-file upload</b>: send <c>Upload-Length</c> only. " +
             "Continue uploading with <c>PATCH</c> and <c>HEAD</c> on this same URL. " +
+            "<br/><br/><b>Concatenation partial</b>: send <c>Upload-Concat: partial</c> and <c>Upload-Length</c> " +
+            "for each file segment. The response <c>Location</c> is " +
+            $"<c>{TusPartialPath}</c>. " +
+            "<br/><br/><b>Concatenation final</b>: after all partials are complete, send " +
+            "<c>Upload-Concat: final;&lt;partial-location-1&gt; &lt;partial-location-2&gt; ...</c> " +
+            "using the <c>Location</c> URLs from partial creates. Do not send <c>Upload-Length</c> on the final request. " +
             "Upload-Defer-Length is not supported."),
         OperationId = "TusUploadCreate",
         Parameters =
         [
             FileTransferIdParameter(),
             TusResumableParameter(required: true),
-            UploadLengthParameter(required: true)
+            UploadLengthParameter(required: false),
+            UploadConcatParameter(required: false)
         ],
         Responses = CreateResponses(
-            ("201", "Upload created. Continue with PATCH on this URL."),
+            ("201", "Upload created. For partial uploads, continue with PATCH on the returned Location URL."),
             ("400", BadRequest),
             ("401", Unauthorized),
             ("403", Forbidden),
@@ -86,7 +106,8 @@ public sealed class TusUploadDocumentFilter : IDocumentFilter
         Summary = "Get current upload offset",
         Description = BuildDescription(
             "Returns how many bytes have been uploaded so far via the <c>Upload-Offset</c> response header. " +
-            "Use this to resume an interrupted upload."),
+            "Use this to resume an interrupted single-file upload on this URL. " +
+            "For concatenation partial uploads, use the two-segment partial URL instead."),
         OperationId = "TusUploadHead",
         Parameters =
         [
@@ -107,7 +128,8 @@ public sealed class TusUploadDocumentFilter : IDocumentFilter
         Description = BuildDescription(
             "Appends a chunk of file data at the offset given in the <c>Upload-Offset</c> request header. " +
             "Repeat until the server offset equals <c>Upload-Length</c>. " +
-            "On completion the file is finalized and the file transfer status is updated."),
+            "On completion the file is finalized and the file transfer status is updated. " +
+            "For concatenation partial uploads, use the two-segment partial URL instead."),
         OperationId = "TusUploadPatch",
         Parameters =
         [
@@ -115,21 +137,7 @@ public sealed class TusUploadDocumentFilter : IDocumentFilter
             TusResumableParameter(required: true),
             UploadOffsetParameter(required: true)
         ],
-        RequestBody = new OpenApiRequestBody
-        {
-            Required = true,
-            Content = new Dictionary<string, OpenApiMediaType>
-            {
-                [OffsetOctetStream] = new OpenApiMediaType
-                {
-                    Schema = new OpenApiSchema
-                    {
-                        Type = "string",
-                        Format = "binary"
-                    }
-                }
-            }
-        },
+        RequestBody = CreateChunkRequestBody(),
         Responses = CreateResponses(
             ("204", "Chunk accepted. New offset returned in Upload-Offset header."),
             ("400", BadRequest),
@@ -159,6 +167,89 @@ public sealed class TusUploadDocumentFilter : IDocumentFilter
             ("404", NotFound))
     };
 
+    private static OpenApiOperation CreatePartialHeadOperation() => new()
+    {
+        Tags = [new OpenApiTag { Name = Tag }],
+        Summary = "Get current partial upload offset",
+        Description = BuildDescription(
+            "Returns the current byte offset for a concatenation partial upload via the <c>Upload-Offset</c> response header. " +
+            "Use the <c>Location</c> URL returned when creating the partial upload."),
+        OperationId = "TusPartialUploadHead",
+        Parameters =
+        [
+            FileTransferIdParameter(),
+            PartialUploadIdParameter(),
+            TusResumableParameter(required: true)
+        ],
+        Responses = CreateResponses(
+            ("200", "Current offset and Upload-Length returned in response headers"),
+            ("401", Unauthorized),
+            ("403", Forbidden),
+            ("404", NotFound))
+    };
+
+    private static OpenApiOperation CreatePartialPatchOperation() => new()
+    {
+        Tags = [new OpenApiTag { Name = Tag }],
+        Summary = "Upload the next chunk to a partial upload",
+        Description = BuildDescription(
+            "Appends a chunk to a concatenation partial upload at the offset given in the <c>Upload-Offset</c> request header. " +
+            "Repeat until the server offset equals the partial <c>Upload-Length</c>."),
+        OperationId = "TusPartialUploadPatch",
+        Parameters =
+        [
+            FileTransferIdParameter(),
+            PartialUploadIdParameter(),
+            TusResumableParameter(required: true),
+            UploadOffsetParameter(required: true)
+        ],
+        RequestBody = CreateChunkRequestBody(),
+        Responses = CreateResponses(
+            ("204", "Chunk accepted. New offset returned in Upload-Offset header."),
+            ("400", BadRequest),
+            ("401", Unauthorized),
+            ("403", Forbidden),
+            ("404", NotFound),
+            ("409", "Upload-Offset does not match server offset"),
+            ("503", ServiceUnavailable))
+    };
+
+    private static OpenApiOperation CreatePartialDeleteOperation() => new()
+    {
+        Tags = [new OpenApiTag { Name = Tag }],
+        Summary = "Terminate an incomplete partial upload",
+        Description = BuildDescription(
+            "Deletes an in-progress concatenation partial upload."),
+        OperationId = "TusPartialUploadDelete",
+        Parameters =
+        [
+            FileTransferIdParameter(),
+            PartialUploadIdParameter(),
+            TusResumableParameter(required: true)
+        ],
+        Responses = CreateResponses(
+            ("204", "Partial upload terminated"),
+            ("401", Unauthorized),
+            ("403", Forbidden),
+            ("404", NotFound))
+    };
+
+    private static OpenApiRequestBody CreateChunkRequestBody() => new()
+    {
+        Required = true,
+        Content = new Dictionary<string, OpenApiMediaType>
+        {
+            [OffsetOctetStream] = new OpenApiMediaType
+            {
+                Schema = new OpenApiSchema
+                {
+                    Type = "string",
+                    Format = "binary"
+                }
+            }
+        }
+    };
+
     private static string BuildDescription(string body) =>
         $"{body}<br/><br/>One of the scopes:<br/>- altinn:broker.write<br/><br/>" +
         $"Requires the <c>{TusResumableHeader}: {TusVersion}</c> header on every request except OPTIONS.";
@@ -170,6 +261,15 @@ public sealed class TusUploadDocumentFilter : IDocumentFilter
         Required = true,
         Schema = new OpenApiSchema { Type = "string", Format = "uuid" },
         Description = "The file transfer id returned from initialize."
+    };
+
+    private static OpenApiParameter PartialUploadIdParameter() => new()
+    {
+        Name = "partialUploadId",
+        In = ParameterLocation.Path,
+        Required = true,
+        Schema = new OpenApiSchema { Type = "string" },
+        Description = "The partial upload id returned in the Location header when creating a partial upload."
     };
 
     private static OpenApiParameter TusResumableParameter(bool required) => new()
@@ -187,7 +287,18 @@ public sealed class TusUploadDocumentFilter : IDocumentFilter
         In = ParameterLocation.Header,
         Required = required,
         Schema = new OpenApiSchema { Type = "integer", Format = "int64" },
-        Description = "Total upload size in bytes."
+        Description = "Total upload size in bytes. Required for single-file and partial uploads. Omit on final concatenation requests."
+    };
+
+    private static OpenApiParameter UploadConcatParameter(bool required) => new()
+    {
+        Name = UploadConcatHeader,
+        In = ParameterLocation.Header,
+        Required = required,
+        Schema = new OpenApiSchema { Type = "string" },
+        Description =
+            "Concatenation mode. Use <c>partial</c> when creating a segment upload, or " +
+            "<c>final;&lt;partial-location-1&gt; &lt;partial-location-2&gt; ...</c> to finalize."
     };
 
     private static OpenApiParameter UploadOffsetParameter(bool required) => new()

--- a/src/Altinn.Broker.API/Swagger/TusUploadDocumentFilter.cs
+++ b/src/Altinn.Broker.API/Swagger/TusUploadDocumentFilter.cs
@@ -1,0 +1,236 @@
+using Altinn.Broker.API.Tus;
+
+using Microsoft.OpenApi.Models;
+
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Altinn.Broker.API.Swagger;
+
+/// <summary>
+/// Adds TUS resumable upload endpoints to the OpenAPI document.
+/// These routes are registered via tusdotnet (<see cref="TusEndpointExtensions"/>) and are not MVC controllers.
+/// </summary>
+public sealed class TusUploadDocumentFilter : IDocumentFilter
+{
+    private const string Tag = "FileTransfer";
+    private const string TusVersion = "1.0.0";
+    private const string TusResumableHeader = "Tus-Resumable";
+    private const string UploadLengthHeader = "Upload-Length";
+    private const string UploadOffsetHeader = "Upload-Offset";
+    private const string OffsetOctetStream = "application/offset+octet-stream";
+
+    private static readonly string TusBasePath = TusEndpointExtensions.RouteTemplate;
+    private static readonly string TusUploadPath = $"{TusEndpointExtensions.RouteTemplate}/{{fileTransferId}}";
+
+    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    {
+        swaggerDoc.Paths[TusBasePath] = new OpenApiPathItem
+        {
+            Operations = new Dictionary<OperationType, OpenApiOperation>
+            {
+                [OperationType.Options] = CreateOptionsOperation(),
+                [OperationType.Post] = CreatePostOperation()
+            }
+        };
+
+        swaggerDoc.Paths[TusUploadPath] = new OpenApiPathItem
+        {
+            Operations = new Dictionary<OperationType, OpenApiOperation>
+            {
+                [OperationType.Head] = CreateHeadOperation(),
+                [OperationType.Patch] = CreatePatchOperation(),
+                [OperationType.Delete] = CreateDeleteOperation()
+            }
+        };
+    }
+
+    private static OpenApiOperation CreateOptionsOperation() => new()
+    {
+        Tags = [new OpenApiTag { Name = Tag }],
+        Summary = "Discover TUS server capabilities",
+        Description = BuildDescription(
+            "Returns supported TUS protocol version and extensions. " +
+            "Call this before starting a resumable upload. " +
+            "See https://tus.io/protocols/resumable-upload.html"),
+        OperationId = "TusUploadOptions",
+        Parameters = [FileTransferIdParameter()],
+        Responses = CreateResponses(
+            ("204", "Server capabilities returned in Tus-* response headers"),
+            ("401", Unauthorized),
+            ("403", Forbidden),
+            ("404", NotFound))
+    };
+
+    private static OpenApiOperation CreatePostOperation() => new()
+    {
+        Tags = [new OpenApiTag { Name = Tag }],
+        Summary = "Create a resumable upload",
+        Description = BuildDescription(
+            "Creates a TUS upload resource for an initialized file transfer. " +
+            "Requires the <c>Upload-Length</c> header with the total file size in bytes. " +
+            "The response <c>Location</c> header points to the URL used for <c>PATCH</c> and <c>HEAD</c> requests. " +
+            "Upload-Defer-Length is not supported."),
+        OperationId = "TusUploadCreate",
+        Parameters =
+        [
+            FileTransferIdParameter(),
+            TusResumableParameter(required: true),
+            UploadLengthParameter(required: true)
+        ],
+        Responses = CreateResponses(
+            ("201", "Upload created. Continue with PATCH to the Location URL."),
+            ("400", BadRequest),
+            ("401", Unauthorized),
+            ("403", Forbidden),
+            ("404", NotFound),
+            ("409", Conflict),
+            ("413", "File size exceeds maximum"),
+            ("503", ServiceUnavailable))
+    };
+
+    private static OpenApiOperation CreateHeadOperation() => new()
+    {
+        Tags = [new OpenApiTag { Name = Tag }],
+        Summary = "Get current upload offset",
+        Description = BuildDescription(
+            "Returns how many bytes have been uploaded so far via the <c>Upload-Offset</c> response header. " +
+            "Use this to resume an interrupted upload."),
+        OperationId = "TusUploadHead",
+        Parameters =
+        [
+            FileTransferIdParameter(),
+            TusResumableParameter(required: true)
+        ],
+        Responses = CreateResponses(
+            ("200", "Current offset returned in Upload-Offset header"),
+            ("401", Unauthorized),
+            ("403", Forbidden),
+            ("404", NotFound))
+    };
+
+    private static OpenApiOperation CreatePatchOperation() => new()
+    {
+        Tags = [new OpenApiTag { Name = Tag }],
+        Summary = "Upload the next chunk",
+        Description = BuildDescription(
+            "Appends a chunk of file data at the offset given in the <c>Upload-Offset</c> request header. " +
+            "Repeat until the server offset equals <c>Upload-Length</c>. " +
+            "On completion the file is finalized and the file transfer status is updated."),
+        OperationId = "TusUploadPatch",
+        Parameters =
+        [
+            FileTransferIdParameter(),
+            TusResumableParameter(required: true),
+            UploadOffsetParameter(required: true)
+        ],
+        RequestBody = new OpenApiRequestBody
+        {
+            Required = true,
+            Content = new Dictionary<string, OpenApiMediaType>
+            {
+                [OffsetOctetStream] = new OpenApiMediaType
+                {
+                    Schema = new OpenApiSchema
+                    {
+                        Type = "string",
+                        Format = "binary"
+                    }
+                }
+            }
+        },
+        Responses = CreateResponses(
+            ("204", "Chunk accepted. New offset returned in Upload-Offset header."),
+            ("400", BadRequest),
+            ("401", Unauthorized),
+            ("403", Forbidden),
+            ("404", NotFound),
+            ("409", "Upload-Offset does not match server offset"),
+            ("503", ServiceUnavailable))
+    };
+
+    private static OpenApiOperation CreateDeleteOperation() => new()
+    {
+        Tags = [new OpenApiTag { Name = Tag }],
+        Summary = "Terminate an incomplete upload",
+        Description = BuildDescription(
+            "Deletes an in-progress TUS upload. Supported when the termination extension is enabled."),
+        OperationId = "TusUploadDelete",
+        Parameters =
+        [
+            FileTransferIdParameter(),
+            TusResumableParameter(required: true)
+        ],
+        Responses = CreateResponses(
+            ("204", "Upload terminated"),
+            ("401", Unauthorized),
+            ("403", Forbidden),
+            ("404", NotFound))
+    };
+
+    private static string BuildDescription(string body) =>
+        $"{body}<br/><br/>One of the scopes:<br/>- altinn:broker.write<br/><br/>" +
+        $"Requires the <c>{TusResumableHeader}: {TusVersion}</c> header on every request except OPTIONS.";
+
+    private static OpenApiParameter FileTransferIdParameter() => new()
+    {
+        Name = "fileTransferId",
+        In = ParameterLocation.Path,
+        Required = true,
+        Schema = new OpenApiSchema { Type = "string", Format = "uuid" },
+        Description = "The file transfer id returned from initialize."
+    };
+
+    private static OpenApiParameter TusResumableParameter(bool required) => new()
+    {
+        Name = TusResumableHeader,
+        In = ParameterLocation.Header,
+        Required = required,
+        Schema = new OpenApiSchema { Type = "string", Default = new Microsoft.OpenApi.Any.OpenApiString(TusVersion) },
+        Description = "TUS protocol version. Must be 1.0.0."
+    };
+
+    private static OpenApiParameter UploadLengthParameter(bool required) => new()
+    {
+        Name = UploadLengthHeader,
+        In = ParameterLocation.Header,
+        Required = required,
+        Schema = new OpenApiSchema { Type = "integer", Format = "int64" },
+        Description = "Total upload size in bytes."
+    };
+
+    private static OpenApiParameter UploadOffsetParameter(bool required) => new()
+    {
+        Name = UploadOffsetHeader,
+        In = ParameterLocation.Header,
+        Required = required,
+        Schema = new OpenApiSchema { Type = "integer", Format = "int64" },
+        Description = "Byte offset at which this chunk should be appended."
+    };
+
+    private static OpenApiResponses CreateResponses(params (string statusCode, string description)[] responses)
+    {
+        var result = new OpenApiResponses();
+        foreach (var (statusCode, description) in responses)
+        {
+            result[statusCode] = new OpenApiResponse { Description = description };
+        }
+
+        return result;
+    }
+
+    private const string Unauthorized =
+        "You must use a bearer token that represents a system user with access to the resource in the Resource Rights Registry";
+
+    private const string Forbidden =
+        "The resource needs to be registered as an Altinn 3 resource and it has to be associated with a service owner";
+
+    private const string NotFound = "The requested file transfer was not found";
+
+    private const string Conflict =
+        "A file transfer has already been, or attempted to be, created. Create a new file transfer resource to try again.";
+
+    private const string BadRequest =
+        "Service owner needs to be configured, file size exceeds maximum, checksum mismatch, or invalid TUS request";
+
+    private const string ServiceUnavailable = "Storage provider is not ready yet. Please try again later";
+}

--- a/src/Altinn.Broker.API/Swagger/TusUploadDocumentFilter.cs
+++ b/src/Altinn.Broker.API/Swagger/TusUploadDocumentFilter.cs
@@ -19,24 +19,16 @@ public sealed class TusUploadDocumentFilter : IDocumentFilter
     private const string UploadOffsetHeader = "Upload-Offset";
     private const string OffsetOctetStream = "application/offset+octet-stream";
 
-    private static readonly string TusBasePath = TusEndpointExtensions.RouteTemplate;
-    private static readonly string TusUploadPath = $"{TusEndpointExtensions.RouteTemplate}/{{fileTransferId}}";
+    private static readonly string TusPath = TusEndpointExtensions.RouteTemplate;
 
     public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
     {
-        swaggerDoc.Paths[TusBasePath] = new OpenApiPathItem
+        swaggerDoc.Paths[TusPath] = new OpenApiPathItem
         {
             Operations = new Dictionary<OperationType, OpenApiOperation>
             {
                 [OperationType.Options] = CreateOptionsOperation(),
-                [OperationType.Post] = CreatePostOperation()
-            }
-        };
-
-        swaggerDoc.Paths[TusUploadPath] = new OpenApiPathItem
-        {
-            Operations = new Dictionary<OperationType, OpenApiOperation>
-            {
+                [OperationType.Post] = CreatePostOperation(),
                 [OperationType.Head] = CreateHeadOperation(),
                 [OperationType.Patch] = CreatePatchOperation(),
                 [OperationType.Delete] = CreateDeleteOperation()
@@ -68,7 +60,7 @@ public sealed class TusUploadDocumentFilter : IDocumentFilter
         Description = BuildDescription(
             "Creates a TUS upload resource for an initialized file transfer. " +
             "Requires the <c>Upload-Length</c> header with the total file size in bytes. " +
-            "The response <c>Location</c> header points to the URL used for <c>PATCH</c> and <c>HEAD</c> requests. " +
+            "Continue uploading with <c>PATCH</c> and <c>HEAD</c> on this same URL. " +
             "Upload-Defer-Length is not supported."),
         OperationId = "TusUploadCreate",
         Parameters =
@@ -78,7 +70,7 @@ public sealed class TusUploadDocumentFilter : IDocumentFilter
             UploadLengthParameter(required: true)
         ],
         Responses = CreateResponses(
-            ("201", "Upload created. Continue with PATCH to the Location URL."),
+            ("201", "Upload created. Continue with PATCH on this URL."),
             ("400", BadRequest),
             ("401", Unauthorized),
             ("403", Forbidden),

--- a/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
+++ b/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
@@ -57,16 +57,22 @@ public static class TusEndpointExtensions
 
     private static bool TryResolveFileTransferId(HttpContext httpContext, string? tusFileId, out Guid fileTransferId)
     {
-        if (Guid.TryParse(tusFileId, out fileTransferId))
+        if (TusRouteHelper.TryGetFileTransferIdFromRoute(httpContext, out fileTransferId))
         {
             return true;
         }
 
-        return TusRouteHelper.TryGetFileTransferIdFromRoute(httpContext, out fileTransferId);
+        return Guid.TryParse(tusFileId, out fileTransferId);
     }
 
     private static async Task OnAuthorizeAsync(AuthorizeContext context)
     {
+        // TUS OPTIONS is server capability discovery and does not target a file resource.
+        if (context.Intent == IntentType.GetOptions)
+        {
+            return;
+        }
+
         if (!TryResolveFileTransferId(context.HttpContext, context.FileId, out var fileTransferId))
         {
             context.FailRequest(HttpStatusCode.NotFound, "Missing file transfer id");

--- a/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
+++ b/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
@@ -23,6 +23,9 @@ public static class TusEndpointExtensions
     // OpenAPI/APIM path (fileTransferId is the tus file id in the last segment).
     public const string RouteTemplate = "/broker/api/v1/filetransfer/upload/tus/{fileTransferId}";
 
+    // Concatenation partial uploads are addressed at /tus/{fileTransferId}/{partialUploadId}.
+    public const string PartialRouteTemplate = "/broker/api/v1/filetransfer/upload/tus/{fileTransferId}/{partialUploadId}";
+
     // MapTus appends /{TusFileId?} automatically — do not add a path parameter here.
     public const string TusMapPath = "/broker/api/v1/filetransfer/upload/tus";
 

--- a/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
+++ b/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
@@ -145,15 +145,17 @@ public static class TusEndpointExtensions
 
     private static async Task OnCreateCompleteAsync(CreateCompleteContext context)
     {
-        var uploadPath = $"{TusMapPath}/{context.FileId}";
-        context.SetUploadUrl(new Uri(uploadPath, UriKind.Relative));
-
         if (!TryResolveFileTransferId(context.HttpContext, context.FileId, out var fileTransferId))
         {
             throw new TusStoreException("Invalid file transfer id");
         }
 
         var partialUploadRegistry = context.HttpContext.RequestServices.GetRequiredService<ITusPartialUploadRegistry>();
+        var uploadPath = partialUploadRegistry.IsPartial(context.FileId)
+            ? $"{TusMapPath}/{fileTransferId}/{context.FileId}"
+            : $"{TusMapPath}/{context.FileId}";
+        context.SetUploadUrl(new Uri(uploadPath, UriKind.Relative));
+
         if (partialUploadRegistry.IsPartial(context.FileId))
         {
             return;

--- a/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
+++ b/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
@@ -84,7 +84,7 @@ public static class TusEndpointExtensions
             context.HttpContext.User,
             fileTransferId,
             uploadLength: null,
-            context.CancellationToken);
+            cancellationToken: context.CancellationToken);
 
         if (error is not null)
         {
@@ -111,7 +111,7 @@ public static class TusEndpointExtensions
             context.HttpContext.User,
             fileTransferId,
             context.UploadLength,
-            context.CancellationToken);
+            cancellationToken: context.CancellationToken);
 
         if (error is not null)
         {

--- a/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
+++ b/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
@@ -19,12 +19,18 @@ namespace Altinn.Broker.API.Tus;
 
 public static class TusEndpointExtensions
 {
-    // fileTransferId must be the last path segment (tusdotnet requirement) and must only appear once (APIM/OpenAPI).
+    // OpenAPI/APIM path (fileTransferId is the tus file id in the last segment).
     public const string RouteTemplate = "/broker/api/v1/filetransfer/upload/tus/{fileTransferId}";
+
+    // MapTus appends /{TusFileId?} automatically — do not add a path parameter here.
+    public const string TusMapPath = "/broker/api/v1/filetransfer/upload/tus";
+
+    // Route key added by tusdotnet; maps to fileTransferId in our API.
+    public const string TusFileIdRouteKey = TusRouteHelper.TusFileIdRouteKey;
 
     public static WebApplication MapBrokerTusUploads(this WebApplication app)
     {
-        app.MapTus(RouteTemplate, httpContext => CreateTusConfiguration(httpContext))
+        app.MapTus(TusMapPath, httpContext => CreateTusConfiguration(httpContext))
             .RequireAuthorization(AuthorizationConstants.Sender);
 
         return app;
@@ -32,11 +38,6 @@ public static class TusEndpointExtensions
 
     private static Task<DefaultTusConfiguration?> CreateTusConfiguration(HttpContext httpContext)
     {
-        if (!TryGetFileTransferId(httpContext, out var fileTransferId))
-        {
-            return Task.FromResult<DefaultTusConfiguration?>(null);
-        }
-
         var tusOptions = httpContext.RequestServices.GetRequiredService<IOptions<TusOptions>>().Value;
         var store = httpContext.RequestServices.GetRequiredService<BrokerTusStore>();
 
@@ -46,23 +47,32 @@ public static class TusEndpointExtensions
             Expiration = new SlidingExpiration(tusOptions.UploadExpiration),
             Events = new Events
             {
-                OnAuthorizeAsync = ctx => OnAuthorizeAsync(ctx, fileTransferId),
-                OnBeforeCreateAsync = ctx => OnBeforeCreateAsync(ctx, fileTransferId),
-                OnCreateCompleteAsync = ctx => OnCreateCompleteAsync(ctx, fileTransferId),
-                OnFileCompleteAsync = ctx => OnFileCompleteAsync(ctx, fileTransferId)
+                OnAuthorizeAsync = OnAuthorizeAsync,
+                OnBeforeCreateAsync = OnBeforeCreateAsync,
+                OnCreateCompleteAsync = OnCreateCompleteAsync,
+                OnFileCompleteAsync = OnFileCompleteAsync
             }
         });
     }
 
-    private static bool TryGetFileTransferId(HttpContext httpContext, out Guid fileTransferId)
+    private static bool TryResolveFileTransferId(HttpContext httpContext, string? tusFileId, out Guid fileTransferId)
     {
-        fileTransferId = default;
-        var routeValue = httpContext.Request.RouteValues["fileTransferId"]?.ToString();
-        return Guid.TryParse(routeValue, out fileTransferId);
+        if (Guid.TryParse(tusFileId, out fileTransferId))
+        {
+            return true;
+        }
+
+        return TusRouteHelper.TryGetFileTransferIdFromRoute(httpContext, out fileTransferId);
     }
 
-    private static async Task OnAuthorizeAsync(AuthorizeContext context, Guid fileTransferId)
+    private static async Task OnAuthorizeAsync(AuthorizeContext context)
     {
+        if (!TryResolveFileTransferId(context.HttpContext, context.FileId, out var fileTransferId))
+        {
+            context.FailRequest(HttpStatusCode.NotFound, "Missing file transfer id");
+            return;
+        }
+
         var validationService = context.HttpContext.RequestServices.GetRequiredService<TusUploadValidationService>();
         var (_, _, error) = await validationService.ValidateForUploadAsync(
             context.HttpContext.User,
@@ -76,11 +86,17 @@ public static class TusEndpointExtensions
         }
     }
 
-    private static async Task OnBeforeCreateAsync(BeforeCreateContext context, Guid fileTransferId)
+    private static async Task OnBeforeCreateAsync(BeforeCreateContext context)
     {
         if (context.UploadLengthIsDeferred)
         {
             context.FailRequest(HttpStatusCode.BadRequest, "Upload-Defer-Length is not supported");
+            return;
+        }
+
+        if (!TryResolveFileTransferId(context.HttpContext, context.FileId, out var fileTransferId))
+        {
+            context.FailRequest(HttpStatusCode.NotFound, "Missing file transfer id");
             return;
         }
 
@@ -103,10 +119,15 @@ public static class TusEndpointExtensions
         }
     }
 
-    private static async Task OnCreateCompleteAsync(CreateCompleteContext context, Guid fileTransferId)
+    private static async Task OnCreateCompleteAsync(CreateCompleteContext context)
     {
-        // tusdotnet would otherwise append the file id again, producing .../tus/{id}/{id}.
-        context.SetUploadUrl(new Uri(context.HttpContext.Request.Path.Value!, UriKind.Relative));
+        var uploadPath = $"{TusMapPath}/{context.FileId}";
+        context.SetUploadUrl(new Uri(uploadPath, UriKind.Relative));
+
+        if (!Guid.TryParse(context.FileId, out var fileTransferId))
+        {
+            throw new TusStoreException("Invalid file transfer id");
+        }
 
         var fileTransferStatusRepository = context.HttpContext.RequestServices
             .GetRequiredService<IFileTransferStatusRepository>();
@@ -120,8 +141,13 @@ public static class TusEndpointExtensions
             cancellationToken: context.CancellationToken);
     }
 
-    private static async Task OnFileCompleteAsync(FileCompleteContext context, Guid fileTransferId)
+    private static async Task OnFileCompleteAsync(FileCompleteContext context)
     {
+        if (!Guid.TryParse(context.FileId, out var fileTransferId))
+        {
+            throw new TusStoreException("Invalid file transfer id");
+        }
+
         var tusUploadCompleteHandler = context.HttpContext.RequestServices.GetRequiredService<TusUploadCompleteHandler>();
         var result = await tusUploadCompleteHandler.Process(
             fileTransferId,

--- a/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
+++ b/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
@@ -79,12 +79,13 @@ public static class TusEndpointExtensions
             return;
         }
 
-        var validationService = context.HttpContext.RequestServices.GetRequiredService<TusUploadValidationService>();
-        var (_, _, error) = await validationService.ValidateForUploadAsync(
+        var authorizationService = context.HttpContext.RequestServices.GetRequiredService<TusUploadAuthorizationService>();
+        var error = await authorizationService.AuthorizeAsync(
             context.HttpContext.User,
             fileTransferId,
+            MapAuthIntent(context.Intent),
             uploadLength: null,
-            cancellationToken: context.CancellationToken);
+            context.CancellationToken);
 
         if (error is not null)
         {
@@ -107,11 +108,10 @@ public static class TusEndpointExtensions
         }
 
         var validationService = context.HttpContext.RequestServices.GetRequiredService<TusUploadValidationService>();
-        var (_, maxUploadSize, error) = await validationService.ValidateForUploadAsync(
-            context.HttpContext.User,
+        var (maxUploadSize, error) = await validationService.ValidateUploadSizeAsync(
             fileTransferId,
             context.UploadLength,
-            cancellationToken: context.CancellationToken);
+            context.CancellationToken);
 
         if (error is not null)
         {
@@ -164,5 +164,17 @@ public static class TusEndpointExtensions
         {
             throw new TusStoreException(result.AsT1.Message);
         }
+
+        var authorizationService = context.HttpContext.RequestServices.GetRequiredService<TusUploadAuthorizationService>();
+        await authorizationService.InvalidateAsync(fileTransferId, context.HttpContext.User, context.CancellationToken);
     }
+
+    private static TusUploadAuthIntent MapAuthIntent(IntentType intent) => intent switch
+    {
+        IntentType.CreateFile => TusUploadAuthIntent.Create,
+        IntentType.WriteFile => TusUploadAuthIntent.WriteChunk,
+        IntentType.GetFileInfo => TusUploadAuthIntent.GetInfo,
+        IntentType.DeleteFile => TusUploadAuthIntent.Delete,
+        _ => TusUploadAuthIntent.WriteChunk
+    };
 }

--- a/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
+++ b/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
@@ -23,8 +23,10 @@ public static class TusEndpointExtensions
     // OpenAPI/APIM path (fileTransferId is the tus file id in the last segment).
     public const string RouteTemplate = "/broker/api/v1/filetransfer/upload/tus/{fileTransferId}";
 
-    // Concatenation partial uploads are addressed at /tus/{fileTransferId}/{partialUploadId}.
-    public const string PartialRouteTemplate = "/broker/api/v1/filetransfer/upload/tus/{fileTransferId}/{partialUploadId}";
+    // Concatenation partial uploads use a literal "partial" segment to avoid APIM route ambiguity.
+    public const string PartialPathSegment = "partial";
+    public const string PartialRouteTemplate =
+        $"/broker/api/v1/filetransfer/upload/tus/{{fileTransferId}}/{PartialPathSegment}/{{partialUploadId}}";
 
     // MapTus appends /{TusFileId?} automatically — do not add a path parameter here.
     public const string TusMapPath = "/broker/api/v1/filetransfer/upload/tus";
@@ -37,8 +39,8 @@ public static class TusEndpointExtensions
         app.MapTus(TusMapPath, CreateTusConfiguration)
             .RequireAuthorization(AuthorizationConstants.Sender);
 
-        // Concatenation partial uploads use /tus/{fileTransferId}/{partialId}.
-        app.MapTus($"{TusMapPath}/{{fileTransferId}}", CreateTusConfiguration)
+        // Concatenation partial uploads use /tus/{fileTransferId}/partial/{partialId}.
+        app.MapTus($"{TusMapPath}/{{fileTransferId}}/{PartialPathSegment}", CreateTusConfiguration)
             .RequireAuthorization(AuthorizationConstants.Sender);
 
         return app;
@@ -159,7 +161,7 @@ public static class TusEndpointExtensions
 
         var partialUploadRegistry = context.HttpContext.RequestServices.GetRequiredService<ITusPartialUploadRegistry>();
         var uploadPath = partialUploadRegistry.IsPartial(context.FileId)
-            ? $"{TusMapPath}/{fileTransferId}/{context.FileId}"
+            ? $"{TusMapPath}/{fileTransferId}/{PartialPathSegment}/{context.FileId}"
             : $"{TusMapPath}/{context.FileId}";
         context.SetUploadUrl(new Uri(uploadPath, UriKind.Relative));
 

--- a/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
+++ b/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
@@ -19,7 +19,8 @@ namespace Altinn.Broker.API.Tus;
 
 public static class TusEndpointExtensions
 {
-    public const string RouteTemplate = "/broker/api/v1/filetransfer/{fileTransferId}/upload/tus";
+    // fileTransferId must be the last path segment (tusdotnet requirement) and must only appear once (APIM/OpenAPI).
+    public const string RouteTemplate = "/broker/api/v1/filetransfer/upload/tus/{fileTransferId}";
 
     public static WebApplication MapBrokerTusUploads(this WebApplication app)
     {
@@ -104,6 +105,9 @@ public static class TusEndpointExtensions
 
     private static async Task OnCreateCompleteAsync(CreateCompleteContext context, Guid fileTransferId)
     {
+        // tusdotnet would otherwise append the file id again, producing .../tus/{id}/{id}.
+        context.SetUploadUrl(new Uri(context.HttpContext.Request.Path.Value!, UriKind.Relative));
+
         var fileTransferStatusRepository = context.HttpContext.RequestServices
             .GetRequiredService<IFileTransferStatusRepository>();
         var uploaderVendor = context.HttpContext.User.GetCallerVendorId()?.WithPrefix();

--- a/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
+++ b/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
@@ -1,0 +1,132 @@
+using System.Net;
+
+using Altinn.Broker.API.Configuration;
+using Altinn.Broker.Application;
+using Altinn.Broker.Application.UploadFile;
+using Altinn.Broker.Common;
+using Altinn.Broker.Core.Domain.Enums;
+using Altinn.Broker.Core.Repositories;
+using Altinn.Broker.Integrations.Tus;
+
+using Microsoft.Extensions.Options;
+
+using tusdotnet;
+using tusdotnet.Models;
+using tusdotnet.Models.Configuration;
+using tusdotnet.Models.Expiration;
+
+namespace Altinn.Broker.API.Tus;
+
+public static class TusEndpointExtensions
+{
+    public const string RouteTemplate = "/broker/api/v1/filetransfer/{fileTransferId}/upload/tus";
+
+    public static WebApplication MapBrokerTusUploads(this WebApplication app)
+    {
+        app.MapTus(RouteTemplate, httpContext => CreateTusConfiguration(httpContext))
+            .RequireAuthorization(AuthorizationConstants.Sender);
+
+        return app;
+    }
+
+    private static Task<DefaultTusConfiguration?> CreateTusConfiguration(HttpContext httpContext)
+    {
+        if (!TryGetFileTransferId(httpContext, out var fileTransferId))
+        {
+            return Task.FromResult<DefaultTusConfiguration?>(null);
+        }
+
+        var tusOptions = httpContext.RequestServices.GetRequiredService<IOptions<TusOptions>>().Value;
+        var store = httpContext.RequestServices.GetRequiredService<BrokerTusStore>();
+
+        return Task.FromResult<DefaultTusConfiguration?>(new DefaultTusConfiguration
+        {
+            Store = store,
+            Expiration = new SlidingExpiration(tusOptions.UploadExpiration),
+            Events = new Events
+            {
+                OnAuthorizeAsync = ctx => OnAuthorizeAsync(ctx, fileTransferId),
+                OnBeforeCreateAsync = ctx => OnBeforeCreateAsync(ctx, fileTransferId),
+                OnCreateCompleteAsync = ctx => OnCreateCompleteAsync(ctx, fileTransferId),
+                OnFileCompleteAsync = ctx => OnFileCompleteAsync(ctx, fileTransferId)
+            }
+        });
+    }
+
+    private static bool TryGetFileTransferId(HttpContext httpContext, out Guid fileTransferId)
+    {
+        fileTransferId = default;
+        var routeValue = httpContext.Request.RouteValues["fileTransferId"]?.ToString();
+        return Guid.TryParse(routeValue, out fileTransferId);
+    }
+
+    private static async Task OnAuthorizeAsync(AuthorizeContext context, Guid fileTransferId)
+    {
+        var validationService = context.HttpContext.RequestServices.GetRequiredService<TusUploadValidationService>();
+        var (_, _, error) = await validationService.ValidateForUploadAsync(
+            context.HttpContext.User,
+            fileTransferId,
+            uploadLength: null,
+            context.CancellationToken);
+
+        if (error is not null)
+        {
+            context.FailRequest(error.StatusCode, error.Message);
+        }
+    }
+
+    private static async Task OnBeforeCreateAsync(BeforeCreateContext context, Guid fileTransferId)
+    {
+        if (context.UploadLengthIsDeferred)
+        {
+            context.FailRequest(HttpStatusCode.BadRequest, "Upload-Defer-Length is not supported");
+            return;
+        }
+
+        var validationService = context.HttpContext.RequestServices.GetRequiredService<TusUploadValidationService>();
+        var (_, maxUploadSize, error) = await validationService.ValidateForUploadAsync(
+            context.HttpContext.User,
+            fileTransferId,
+            context.UploadLength,
+            context.CancellationToken);
+
+        if (error is not null)
+        {
+            context.FailRequest(error.StatusCode, error.Message);
+            return;
+        }
+
+        if (maxUploadSize is not null && context.UploadLength > maxUploadSize)
+        {
+            context.FailRequest(HttpStatusCode.BadRequest, Errors.FileSizeTooBig.Message);
+        }
+    }
+
+    private static async Task OnCreateCompleteAsync(CreateCompleteContext context, Guid fileTransferId)
+    {
+        var fileTransferStatusRepository = context.HttpContext.RequestServices
+            .GetRequiredService<IFileTransferStatusRepository>();
+        var uploaderVendor = context.HttpContext.User.GetCallerVendorId()?.WithPrefix();
+
+        await fileTransferStatusRepository.InsertFileTransferStatus(
+            fileTransferId,
+            FileTransferStatus.UploadStarted,
+            timestamp: DateTime.UtcNow,
+            vendor: uploaderVendor,
+            cancellationToken: context.CancellationToken);
+    }
+
+    private static async Task OnFileCompleteAsync(FileCompleteContext context, Guid fileTransferId)
+    {
+        var tusUploadCompleteHandler = context.HttpContext.RequestServices.GetRequiredService<TusUploadCompleteHandler>();
+        var result = await tusUploadCompleteHandler.Process(
+            fileTransferId,
+            context.HttpContext.User,
+            context.CancellationToken);
+
+        if (result.IsT1)
+        {
+            throw new TusStoreException(result.AsT1.Message);
+        }
+    }
+}

--- a/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
+++ b/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
@@ -207,9 +207,10 @@ public static class TusEndpointExtensions
     private static TusUploadAuthIntent MapAuthIntent(IntentType intent) => intent switch
     {
         IntentType.CreateFile => TusUploadAuthIntent.Create,
+        IntentType.ConcatenateFiles => TusUploadAuthIntent.Create,
         IntentType.WriteFile => TusUploadAuthIntent.WriteChunk,
         IntentType.GetFileInfo => TusUploadAuthIntent.GetInfo,
         IntentType.DeleteFile => TusUploadAuthIntent.Delete,
-        _ => TusUploadAuthIntent.WriteChunk
+        _ => throw new ArgumentOutOfRangeException(nameof(intent), intent, "Unsupported tus authorization intent.")
     };
 }

--- a/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
+++ b/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
@@ -57,6 +57,12 @@ public static class TusEndpointExtensions
 
     private static bool TryResolveFileTransferId(HttpContext httpContext, string? tusFileId, out Guid fileTransferId)
     {
+        var partialUploadRegistry = httpContext.RequestServices.GetRequiredService<ITusPartialUploadRegistry>();
+        if (!string.IsNullOrEmpty(tusFileId) && partialUploadRegistry.TryGetFileTransferId(tusFileId, out fileTransferId))
+        {
+            return true;
+        }
+
         if (TusRouteHelper.TryGetFileTransferIdFromRoute(httpContext, out fileTransferId))
         {
             return true;
@@ -130,9 +136,15 @@ public static class TusEndpointExtensions
         var uploadPath = $"{TusMapPath}/{context.FileId}";
         context.SetUploadUrl(new Uri(uploadPath, UriKind.Relative));
 
-        if (!Guid.TryParse(context.FileId, out var fileTransferId))
+        if (!TryResolveFileTransferId(context.HttpContext, context.FileId, out var fileTransferId))
         {
             throw new TusStoreException("Invalid file transfer id");
+        }
+
+        var partialUploadRegistry = context.HttpContext.RequestServices.GetRequiredService<ITusPartialUploadRegistry>();
+        if (partialUploadRegistry.IsPartial(context.FileId))
+        {
+            return;
         }
 
         var fileTransferStatusRepository = context.HttpContext.RequestServices

--- a/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
+++ b/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Options;
 
 using tusdotnet;
 using tusdotnet.Models;
+using tusdotnet.Models.Concatenation;
 using tusdotnet.Models.Configuration;
 using tusdotnet.Models.Expiration;
 
@@ -101,6 +102,17 @@ public static class TusEndpointExtensions
 
     private static async Task OnBeforeCreateAsync(BeforeCreateContext context)
     {
+        if (context.FileConcatenation is FileConcatFinal)
+        {
+            // TUS concatenation final requests must not include Upload-Length.
+            if (!TryResolveFileTransferId(context.HttpContext, context.FileId, out _))
+            {
+                context.FailRequest(HttpStatusCode.NotFound, "Missing file transfer id");
+            }
+
+            return;
+        }
+
         if (context.UploadLengthIsDeferred)
         {
             context.FailRequest(HttpStatusCode.BadRequest, "Upload-Defer-Length is not supported");

--- a/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
+++ b/src/Altinn.Broker.API/Tus/TusEndpointExtensions.cs
@@ -31,7 +31,11 @@ public static class TusEndpointExtensions
 
     public static WebApplication MapBrokerTusUploads(this WebApplication app)
     {
-        app.MapTus(TusMapPath, httpContext => CreateTusConfiguration(httpContext))
+        app.MapTus(TusMapPath, CreateTusConfiguration)
+            .RequireAuthorization(AuthorizationConstants.Sender);
+
+        // Concatenation partial uploads use /tus/{fileTransferId}/{partialId}.
+        app.MapTus($"{TusMapPath}/{{fileTransferId}}", CreateTusConfiguration)
             .RequireAuthorization(AuthorizationConstants.Sender);
 
         return app;

--- a/src/Altinn.Broker.API/Tus/TusFileTransferIdRouteMiddleware.cs
+++ b/src/Altinn.Broker.API/Tus/TusFileTransferIdRouteMiddleware.cs
@@ -24,7 +24,15 @@ public sealed class TusFileTransferIdRouteMiddleware(RequestDelegate next)
     }
 
     private static bool IsTusEndpoint(HttpContext context)
-        => context.GetEndpoint()?.DisplayName?.StartsWith("tus:", StringComparison.Ordinal) == true;
+    {
+        if (context.GetEndpoint()?.DisplayName?.StartsWith("tus:", StringComparison.Ordinal) == true)
+        {
+            return true;
+        }
+
+        var path = context.Request.Path.Value;
+        return path?.StartsWith(TusEndpointExtensions.TusMapPath, StringComparison.OrdinalIgnoreCase) == true;
+    }
 
     private static void NormalizeRouteValues(HttpContext context)
     {

--- a/src/Altinn.Broker.API/Tus/TusFileTransferIdRouteMiddleware.cs
+++ b/src/Altinn.Broker.API/Tus/TusFileTransferIdRouteMiddleware.cs
@@ -1,0 +1,49 @@
+using Altinn.Broker.Integrations.Tus;
+
+namespace Altinn.Broker.API.Tus;
+
+/// <summary>
+/// tusdotnet appends /{TusFileId?} to the mapped path. When clients call
+/// /upload/tus/{fileTransferId}, ASP.NET binds the id as TusFileId which makes tusdotnet
+/// treat OPTIONS/POST as file-resource requests and return 404. For those methods we copy
+/// the id to fileTransferId and remove TusFileId so tus sees a collection URL.
+/// For HEAD/PATCH/DELETE we ensure TusFileId is set from the path id.
+/// </summary>
+public sealed class TusFileTransferIdRouteMiddleware(RequestDelegate next)
+{
+    private const string FileTransferIdRouteKey = "fileTransferId";
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (IsTusEndpoint(context))
+        {
+            NormalizeRouteValues(context);
+        }
+
+        await next(context);
+    }
+
+    private static bool IsTusEndpoint(HttpContext context)
+        => context.GetEndpoint()?.DisplayName?.StartsWith("tus:", StringComparison.Ordinal) == true;
+
+    private static void NormalizeRouteValues(HttpContext context)
+    {
+        var tusFileId = context.Request.RouteValues[TusRouteHelper.TusFileIdRouteKey]?.ToString();
+        var method = context.Request.Method;
+
+        if (!string.IsNullOrEmpty(tusFileId)
+            && (HttpMethods.IsOptions(method) || HttpMethods.IsPost(method)))
+        {
+            context.Request.RouteValues[FileTransferIdRouteKey] = tusFileId;
+            context.Request.RouteValues.Remove(TusRouteHelper.TusFileIdRouteKey);
+            return;
+        }
+
+        if (string.IsNullOrEmpty(tusFileId)
+            && context.Request.RouteValues.TryGetValue(FileTransferIdRouteKey, out var fileTransferId)
+            && !string.IsNullOrWhiteSpace(fileTransferId?.ToString()))
+        {
+            context.Request.RouteValues[TusRouteHelper.TusFileIdRouteKey] = fileTransferId.ToString();
+        }
+    }
+}

--- a/src/Altinn.Broker.API/Tus/TusPartialPathRewriteMiddleware.cs
+++ b/src/Altinn.Broker.API/Tus/TusPartialPathRewriteMiddleware.cs
@@ -3,9 +3,8 @@ using Altinn.Broker.Integrations.Tus;
 namespace Altinn.Broker.API.Tus;
 
 /// <summary>
-/// Rewrites concatenation partial URLs from
-/// /upload/tus/{fileTransferId}/{partialId} to /upload/tus/{partialId}
-/// so tusdotnet's single-segment MapTus route can handle PATCH/HEAD/DELETE.
+/// Rewrites legacy concatenation partial URLs from
+/// /upload/tus/{fileTransferId}/{partialId} to /upload/tus/{fileTransferId}/partial/{partialId}.
 /// The file transfer id is preserved in <see cref="TusRouteHelper.FileTransferIdItemKey"/> for auth and storage resolution.
 /// </summary>
 public sealed class TusPartialPathRewriteMiddleware(RequestDelegate next)
@@ -39,13 +38,15 @@ public sealed class TusPartialPathRewriteMiddleware(RequestDelegate next)
 
         var fileTransferId = segments[0];
         var partialId = segments[1];
-        if (!Guid.TryParse(fileTransferId, out _))
+        if (!Guid.TryParse(fileTransferId, out _)
+            || string.Equals(partialId, TusEndpointExtensions.PartialPathSegment, StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }
 
         context.Items[TusRouteHelper.FileTransferIdItemKey] = fileTransferId;
-        context.Request.Path = new PathString($"{prefix}{partialId}");
+        context.Request.Path = new PathString(
+            $"{prefix}{fileTransferId}/{TusEndpointExtensions.PartialPathSegment}/{partialId}");
         return true;
     }
 }

--- a/src/Altinn.Broker.API/Tus/TusPartialPathRewriteMiddleware.cs
+++ b/src/Altinn.Broker.API/Tus/TusPartialPathRewriteMiddleware.cs
@@ -1,0 +1,51 @@
+using Altinn.Broker.Integrations.Tus;
+
+namespace Altinn.Broker.API.Tus;
+
+/// <summary>
+/// Rewrites concatenation partial URLs from
+/// /upload/tus/{fileTransferId}/{partialId} to /upload/tus/{partialId}
+/// so tusdotnet's single-segment MapTus route can handle PATCH/HEAD/DELETE.
+/// The file transfer id is preserved in <see cref="TusRouteHelper.FileTransferIdItemKey"/> for auth and storage resolution.
+/// </summary>
+public sealed class TusPartialPathRewriteMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        TryRewriteConcatPartialPath(context);
+        await next(context);
+    }
+
+    public static bool TryRewriteConcatPartialPath(HttpContext context)
+    {
+        var path = context.Request.Path.Value;
+        if (string.IsNullOrEmpty(path))
+        {
+            return false;
+        }
+
+        var prefix = $"{TusEndpointExtensions.TusMapPath}/";
+        if (!path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var remainder = path[prefix.Length..].TrimEnd('/');
+        var segments = remainder.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (segments.Length != 2)
+        {
+            return false;
+        }
+
+        var fileTransferId = segments[0];
+        var partialId = segments[1];
+        if (!Guid.TryParse(fileTransferId, out _))
+        {
+            return false;
+        }
+
+        context.Items[TusRouteHelper.FileTransferIdItemKey] = fileTransferId;
+        context.Request.Path = new PathString($"{prefix}{partialId}");
+        return true;
+    }
+}

--- a/src/Altinn.Broker.API/appsettings.Development.json
+++ b/src/Altinn.Broker.API/appsettings.Development.json
@@ -37,5 +37,8 @@
     "BlockSize": 33554432,
     "ConcurrentUploadThreads": 3,
     "BlocksBeforeCommit": 1000
+  },
+  "TusOptions": {
+    "UploadExpiration": "24:00:00"
   }
 }

--- a/src/Altinn.Broker.API/appsettings.Development.json
+++ b/src/Altinn.Broker.API/appsettings.Development.json
@@ -40,5 +40,8 @@
   },
   "TusOptions": {
     "UploadExpiration": "24:00:00"
+  },
+  "DistributedCacheOptions": {
+    "RedisConnectionString": "localhost:6379"
   }
 }

--- a/src/Altinn.Broker.API/appsettings.json
+++ b/src/Altinn.Broker.API/appsettings.json
@@ -9,5 +9,11 @@
     "Scope": "altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:serviceowner altinn:authorization/authorize.admin altinn:resourceregistry/resource.admin",
     "ExhangeToAltinnToken": true
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "DistributedCacheOptions": {
+    "RedisConnectionString": ""
+  },
+  "TusOptions": {
+    "UploadExpiration": "24:00:00"
+  }
 }

--- a/src/Altinn.Broker.Application/Altinn.Broker.Application.csproj
+++ b/src/Altinn.Broker.Application/Altinn.Broker.Application.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Altinn.Authorization.ProblemDetails" Version="4.0.1" />
     <PackageReference Include="Hangfire.Core" Version="1.8.20" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="Parquet.Net" Version="5.3.0" />

--- a/src/Altinn.Broker.Application/DependencyInjection.cs
+++ b/src/Altinn.Broker.Application/DependencyInjection.cs
@@ -23,6 +23,9 @@ public static class DependencyInjection
     {
         services.AddScoped<InitializeFileTransferHandler>();
         services.AddScoped<UploadFileHandler>();
+        services.AddScoped<CompleteFileUploadHandler>();
+        services.AddScoped<TusUploadValidationService>();
+        services.AddScoped<TusUploadCompleteHandler>();
         services.AddScoped<GetFileTransferOverviewHandler>();
         services.AddScoped<GetFileTransferDetailsHandler>();
         services.AddScoped<DownloadFileHandler>();

--- a/src/Altinn.Broker.Application/DependencyInjection.cs
+++ b/src/Altinn.Broker.Application/DependencyInjection.cs
@@ -25,6 +25,7 @@ public static class DependencyInjection
         services.AddScoped<UploadFileHandler>();
         services.AddScoped<CompleteFileUploadHandler>();
         services.AddScoped<TusUploadValidationService>();
+        services.AddScoped<TusUploadAuthorizationService>();
         services.AddScoped<TusUploadCompleteHandler>();
         services.AddScoped<GetFileTransferOverviewHandler>();
         services.AddScoped<GetFileTransferDetailsHandler>();

--- a/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
@@ -1,0 +1,228 @@
+using System.Security.Claims;
+
+using Altinn.Broker.Application.Middlewares;
+using Altinn.Broker.Application.Settings;
+using Altinn.Broker.Core;
+using Altinn.Broker.Core.Application;
+using Altinn.Broker.Core.Domain;
+using Altinn.Broker.Core.Domain.Enums;
+using Altinn.Broker.Core.Services;
+using Altinn.Broker.Core.Helpers;
+using Altinn.Broker.Core.Options;
+using Altinn.Broker.Core.Repositories;
+using Altinn.Broker.Core.Services.Enums;
+
+using Hangfire;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using OneOf;
+
+namespace Altinn.Broker.Application.UploadFile;
+
+public class CompleteFileUploadHandler(
+    IFileTransferRepository fileTransferRepository,
+    IFileTransferStatusRepository fileTransferStatusRepository,
+    IServiceOwnerRepository serviceOwnerRepository,
+    IResourceRepository resourceRepository,
+    IBackgroundJobClient backgroundJobClient,
+    EventBusMiddleware eventBus,
+    IHostEnvironment hostEnvironment,
+    IOptions<GeneralSettings> generalSettings,
+    MalwareScanningResultHandler malwareScanResultHandler,
+    ILogger<CompleteFileUploadHandler> logger) : IHandler<CompleteFileUploadRequest, Guid>
+{
+    public async Task<OneOf<Guid, Error>> Process(CompleteFileUploadRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
+    {
+        var fileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
+        if (fileTransfer is null)
+        {
+            return Errors.FileTransferNotFound;
+        }
+
+        if (fileTransfer.FileTransferStatusEntity.Status > FileTransferStatus.UploadStarted)
+        {
+            return request.FileTransferId;
+        }
+
+        var resource = await resourceRepository.GetResource(fileTransfer.ResourceId, cancellationToken);
+        if (resource is null)
+        {
+            return Errors.InvalidResourceDefinition;
+        }
+
+        var serviceOwner = await serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId);
+        if (serviceOwner is null)
+        {
+            return Errors.ServiceOwnerNotConfigured;
+        }
+
+        var storageProvider = serviceOwner.GetStorageProvider(fileTransfer.UseVirusScan);
+        if (storageProvider is null)
+        {
+            return Errors.StorageProviderNotReady;
+        }
+
+        var finishedUploadTimestamp = DateTime.UtcNow;
+        if (!string.IsNullOrWhiteSpace(fileTransfer.Checksum)
+            && !string.Equals(request.Checksum, fileTransfer.Checksum, StringComparison.InvariantCultureIgnoreCase))
+        {
+            await fileTransferStatusRepository.InsertFileTransferStatus(
+                request.FileTransferId,
+                FileTransferStatus.Failed,
+                timestamp: finishedUploadTimestamp,
+                detailedFileTransferStatus: "Checksum mismatch",
+                cancellationToken: cancellationToken);
+            backgroundJobClient.Enqueue<IBrokerStorageService>(service =>
+                service.DeleteFile(serviceOwner, fileTransfer, cancellationToken));
+            return Errors.ChecksumMismatch;
+        }
+
+        try
+        {
+            await TransactionWithRetriesPolicy.Execute<Task>(async ct =>
+            {
+                if (storageProvider.Type == StorageProviderType.Altinn3Azure)
+                {
+                    await fileTransferStatusRepository.InsertFileTransferStatus(
+                        request.FileTransferId,
+                        FileTransferStatus.UploadProcessing,
+                        timestamp: finishedUploadTimestamp,
+                        cancellationToken: ct);
+                    backgroundJobClient.Enqueue(() => eventBus.Publish(
+                        AltinnEventType.UploadProcessing,
+                        fileTransfer.ResourceId,
+                        request.FileTransferId.ToString(),
+                        fileTransfer.Sender.ActorExternalId,
+                        Guid.NewGuid(),
+                        AltinnEventSubjectRole.Sender));
+                }
+                else if (storageProvider.Type == StorageProviderType.Altinn3AzureWithoutVirusScan
+                         && !generalSettings.Value.SimulateMalwareScan)
+                {
+                    await fileTransferStatusRepository.InsertFileTransferStatus(
+                        request.FileTransferId,
+                        FileTransferStatus.Published,
+                        timestamp: finishedUploadTimestamp,
+                        cancellationToken: ct);
+                    backgroundJobClient.Enqueue(() => eventBus.Publish(
+                        AltinnEventType.Published,
+                        fileTransfer.ResourceId,
+                        request.FileTransferId.ToString(),
+                        fileTransfer.Sender.ActorExternalId,
+                        Guid.NewGuid(),
+                        AltinnEventSubjectRole.Sender));
+                    foreach (var recipient in fileTransfer.RecipientCurrentStatuses)
+                    {
+                        backgroundJobClient.Enqueue(() => eventBus.Publish(
+                            AltinnEventType.Published,
+                            fileTransfer.ResourceId,
+                            request.FileTransferId.ToString(),
+                            recipient.Actor.ActorExternalId,
+                            Guid.NewGuid(),
+                            AltinnEventSubjectRole.Recipient));
+                    }
+                }
+
+                await fileTransferRepository.SetStorageDetails(
+                    request.FileTransferId,
+                    storageProvider.Id,
+                    request.FileTransferId.ToString(),
+                    request.UploadLength,
+                    ct);
+
+                if (string.IsNullOrWhiteSpace(fileTransfer.Checksum))
+                {
+                    await fileTransferRepository.SetChecksum(request.FileTransferId, request.Checksum, ct);
+                }
+
+                return Task.CompletedTask;
+            }, logger, cancellationToken);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(
+                "Unexpected error occurred while completing file upload: {errorMessage} \nStack trace: {stackTrace}",
+                e.Message,
+                e.StackTrace);
+            return await TransactionWithRetriesPolicy.Execute(async ct =>
+            {
+                await fileTransferStatusRepository.InsertFileTransferStatus(
+                    request.FileTransferId,
+                    FileTransferStatus.Failed,
+                    timestamp: DateTime.UtcNow,
+                    detailedFileTransferStatus: "Error occurred while uploading fileTransfer",
+                    cancellationToken: ct);
+                backgroundJobClient.Enqueue(() => eventBus.Publish(
+                    AltinnEventType.UploadFailed,
+                    fileTransfer.ResourceId,
+                    request.FileTransferId.ToString(),
+                    fileTransfer.Sender.ActorExternalId,
+                    Guid.NewGuid(),
+                    AltinnEventSubjectRole.Sender));
+                return Errors.UploadFailed;
+            }, logger, cancellationToken);
+        }
+
+        if (hostEnvironment.IsDevelopment() && generalSettings.Value.SimulateMalwareScan)
+        {
+            await SimulateMalwareScanResult(request.FileTransferId);
+            backgroundJobClient.Enqueue(() => eventBus.Publish(
+                AltinnEventType.Published,
+                fileTransfer.ResourceId,
+                request.FileTransferId.ToString(),
+                fileTransfer.Sender.ActorExternalId,
+                Guid.NewGuid(),
+                AltinnEventSubjectRole.Sender));
+            foreach (var recipient in fileTransfer.RecipientCurrentStatuses)
+            {
+                backgroundJobClient.Enqueue(() => eventBus.Publish(
+                    AltinnEventType.Published,
+                    fileTransfer.ResourceId,
+                    request.FileTransferId.ToString(),
+                    recipient.Actor.ActorExternalId,
+                    Guid.NewGuid(),
+                    AltinnEventSubjectRole.Recipient));
+            }
+        }
+
+        return request.FileTransferId;
+    }
+
+    private async Task SimulateMalwareScanResult(Guid fileTransferId)
+    {
+        if (!hostEnvironment.IsDevelopment())
+        {
+            logger.LogWarning("SimulateMalwareScanResult called outside development environment");
+            return;
+        }
+
+        logger.LogInformation("Simulating malware scan result for filetransfer {fileTransferId}", fileTransferId);
+
+        var simulatedScanResult = new ScanResultData
+        {
+            BlobUri = $"http://127.0.0.1:10000/devstoreaccount1/brokerfiles/{fileTransferId}",
+            CorrelationId = Guid.NewGuid(),
+            ETag = "simulated-etag",
+            ScanFinishedTimeUtc = DateTime.UtcNow,
+            ScanResultDetails = new ScanResultDetails
+            {
+                MalwareNamesFound = new List<string>(),
+                Sha256 = "simulated-sha256"
+            },
+            ScanResultType = "No threats found"
+        };
+
+        var result = await malwareScanResultHandler.Process(simulatedScanResult, null, CancellationToken.None);
+        if (result.IsT1)
+        {
+            var error = result.AsT1;
+            logger.LogError(
+                "Error in simulated malware scan result for filetransfer {fileTransferId}: {Error}",
+                fileTransferId,
+                error.Message);
+        }
+    }
+}

--- a/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadRequest.cs
+++ b/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadRequest.cs
@@ -1,0 +1,8 @@
+namespace Altinn.Broker.Application.UploadFile;
+
+public class CompleteFileUploadRequest
+{
+    public Guid FileTransferId { get; set; }
+    public required string Checksum { get; set; }
+    public long UploadLength { get; set; }
+}

--- a/src/Altinn.Broker.Application/UploadFile/TusUploadAuthorizationService.cs
+++ b/src/Altinn.Broker.Application/UploadFile/TusUploadAuthorizationService.cs
@@ -1,0 +1,84 @@
+using System.Security.Claims;
+
+using Altinn.Broker.Common;
+
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Configuration;
+
+namespace Altinn.Broker.Application.UploadFile;
+
+public enum TusUploadAuthIntent
+{
+    Create,
+    WriteChunk,
+    GetInfo,
+    Delete
+}
+
+public class TusUploadAuthorizationService(
+    IDistributedCache cache,
+    TusUploadValidationService validationService,
+    IConfiguration configuration)
+{
+    private const string CacheValue = "1";
+
+    public async Task<Error?> AuthorizeAsync(
+        ClaimsPrincipal user,
+        Guid fileTransferId,
+        TusUploadAuthIntent intent,
+        long? uploadLength,
+        CancellationToken cancellationToken)
+    {
+        var cacheKey = BuildCacheKey(fileTransferId, user);
+
+        if (intent is TusUploadAuthIntent.WriteChunk or TusUploadAuthIntent.GetInfo
+            && await cache.GetStringAsync(cacheKey, cancellationToken) == CacheValue)
+        {
+            return await validationService.ValidateUploadInProgressAsync(fileTransferId, cancellationToken);
+        }
+
+        var (_, _, error) = await validationService.ValidateForUploadAsync(
+            user,
+            fileTransferId,
+            uploadLength,
+            isLegacyUser: false,
+            cancellationToken);
+
+        if (error is null && intent is not TusUploadAuthIntent.Delete)
+        {
+            await cache.SetStringAsync(
+                cacheKey,
+                CacheValue,
+                new DistributedCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = GetCacheExpiration()
+                },
+                cancellationToken);
+        }
+
+        if (error is null && intent is TusUploadAuthIntent.Delete)
+        {
+            await cache.RemoveAsync(cacheKey, cancellationToken);
+        }
+
+        return error;
+    }
+
+    public Task InvalidateAsync(Guid fileTransferId, ClaimsPrincipal user, CancellationToken cancellationToken)
+        => cache.RemoveAsync(BuildCacheKey(fileTransferId, user), cancellationToken);
+
+    private static string BuildCacheKey(Guid fileTransferId, ClaimsPrincipal user)
+    {
+        var subject = user.FindFirst("sid")?.Value
+            ?? user.FindFirst("client_id")?.Value
+            ?? "unknown";
+        var organization = user.GetCallerOrganizationId() ?? string.Empty;
+        return $"tus-upload-auth:{fileTransferId}:{subject}:{organization}";
+    }
+
+    private TimeSpan GetCacheExpiration()
+    {
+        var configured = configuration.GetSection("TusOptions:UploadExpiration").Value;
+        return TimeSpan.TryParse(configured, out var expiration) ? expiration : TimeSpan.FromHours(24);
+    }
+}

--- a/src/Altinn.Broker.Application/UploadFile/TusUploadAuthorizationService.cs
+++ b/src/Altinn.Broker.Application/UploadFile/TusUploadAuthorizationService.cs
@@ -37,9 +37,10 @@ public class TusUploadAuthorizationService(
                 cancellationToken);
         }
 
-        var cacheKey = BuildCacheKey(fileTransferId, user);
+        var hasCacheKey = TryBuildCacheKey(fileTransferId, user, out var cacheKey);
 
         if (intent is TusUploadAuthIntent.WriteChunk
+            && hasCacheKey
             && await cache.GetStringAsync(cacheKey, cancellationToken) == CacheValue)
         {
             return await validationService.ValidateUploadInProgressAsync(fileTransferId, cancellationToken);
@@ -52,7 +53,7 @@ public class TusUploadAuthorizationService(
             isLegacyUser: false,
             cancellationToken);
 
-        if (error is null && intent is not TusUploadAuthIntent.Delete)
+        if (error is null && intent is not TusUploadAuthIntent.Delete && hasCacheKey)
         {
             await cache.SetStringAsync(
                 cacheKey,
@@ -64,7 +65,7 @@ public class TusUploadAuthorizationService(
                 cancellationToken);
         }
 
-        if (error is null && intent is TusUploadAuthIntent.Delete)
+        if (error is null && intent is TusUploadAuthIntent.Delete && hasCacheKey)
         {
             await cache.RemoveAsync(cacheKey, cancellationToken);
         }
@@ -73,15 +74,29 @@ public class TusUploadAuthorizationService(
     }
 
     public Task InvalidateAsync(Guid fileTransferId, ClaimsPrincipal user, CancellationToken cancellationToken)
-        => cache.RemoveAsync(BuildCacheKey(fileTransferId, user), cancellationToken);
+    {
+        if (!TryBuildCacheKey(fileTransferId, user, out var cacheKey))
+        {
+            return Task.CompletedTask;
+        }
 
-    private static string BuildCacheKey(Guid fileTransferId, ClaimsPrincipal user)
+        return cache.RemoveAsync(cacheKey, cancellationToken);
+    }
+
+    private static bool TryBuildCacheKey(Guid fileTransferId, ClaimsPrincipal user, out string cacheKey)
     {
         var subject = user.FindFirst("sid")?.Value
-            ?? user.FindFirst("client_id")?.Value
-            ?? "unknown";
+            ?? user.FindFirst("client_id")?.Value;
+
+        if (string.IsNullOrEmpty(subject))
+        {
+            cacheKey = string.Empty;
+            return false;
+        }
+
         var organization = user.GetCallerOrganizationId() ?? string.Empty;
-        return $"tus-upload-auth:{fileTransferId}:{subject}:{organization}";
+        cacheKey = $"tus-upload-auth:{fileTransferId}:{subject}:{organization}";
+        return true;
     }
 
     private TimeSpan GetCacheExpiration()

--- a/src/Altinn.Broker.Application/UploadFile/TusUploadAuthorizationService.cs
+++ b/src/Altinn.Broker.Application/UploadFile/TusUploadAuthorizationService.cs
@@ -29,9 +29,17 @@ public class TusUploadAuthorizationService(
         long? uploadLength,
         CancellationToken cancellationToken)
     {
+        if (intent is TusUploadAuthIntent.GetInfo)
+        {
+            return await validationService.ValidateTusGetInfoAsync(
+                user,
+                fileTransferId,
+                cancellationToken);
+        }
+
         var cacheKey = BuildCacheKey(fileTransferId, user);
 
-        if (intent is TusUploadAuthIntent.WriteChunk or TusUploadAuthIntent.GetInfo
+        if (intent is TusUploadAuthIntent.WriteChunk
             && await cache.GetStringAsync(cacheKey, cancellationToken) == CacheValue)
         {
             return await validationService.ValidateUploadInProgressAsync(fileTransferId, cancellationToken);

--- a/src/Altinn.Broker.Application/UploadFile/TusUploadCompleteHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/TusUploadCompleteHandler.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 
 using Altinn.Broker.Common;
+using Altinn.Broker.Core.Domain.Enums;
 using Altinn.Broker.Core.Repositories;
 using Altinn.Broker.Core.Services;
 
@@ -38,6 +39,11 @@ public class TusUploadCompleteHandler(
         if (serviceOwner is null)
         {
             return Errors.ServiceOwnerNotConfigured;
+        }
+
+        if (fileTransfer.FileTransferStatusEntity.Status > FileTransferStatus.UploadStarted)
+        {
+            return fileTransferId;
         }
 
         var finalizeResult = await brokerStorageService.FinalizeTusUpload(serviceOwner, fileTransfer, cancellationToken);

--- a/src/Altinn.Broker.Application/UploadFile/TusUploadCompleteHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/TusUploadCompleteHandler.cs
@@ -1,0 +1,60 @@
+using System.Security.Claims;
+
+using Altinn.Broker.Common;
+using Altinn.Broker.Core.Repositories;
+using Altinn.Broker.Core.Services;
+
+using Microsoft.Extensions.Logging;
+
+using OneOf;
+
+namespace Altinn.Broker.Application.UploadFile;
+
+public class TusUploadCompleteHandler(
+    IFileTransferRepository fileTransferRepository,
+    IServiceOwnerRepository serviceOwnerRepository,
+    IResourceRepository resourceRepository,
+    IBrokerStorageService brokerStorageService,
+    CompleteFileUploadHandler completeFileUploadHandler,
+    ILogger<TusUploadCompleteHandler> logger)
+{
+    public async Task<OneOf<Guid, Error>> Process(Guid fileTransferId, ClaimsPrincipal? user, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Completing TUS upload for file transfer {fileTransferId}", fileTransferId);
+
+        var fileTransfer = await fileTransferRepository.GetFileTransfer(fileTransferId, cancellationToken);
+        if (fileTransfer is null)
+        {
+            return Errors.FileTransferNotFound;
+        }
+
+        var resource = await resourceRepository.GetResource(fileTransfer.ResourceId, cancellationToken);
+        if (resource is null)
+        {
+            return Errors.InvalidResourceDefinition;
+        }
+
+        var serviceOwner = await serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId);
+        if (serviceOwner is null)
+        {
+            return Errors.ServiceOwnerNotConfigured;
+        }
+
+        var finalizeResult = await brokerStorageService.FinalizeTusUpload(serviceOwner, fileTransfer, cancellationToken);
+        if (finalizeResult is null)
+        {
+            return Errors.UploadFailed;
+        }
+
+        var (checksum, uploadLength) = finalizeResult.Value;
+        return await completeFileUploadHandler.Process(
+            new CompleteFileUploadRequest
+            {
+                FileTransferId = fileTransferId,
+                Checksum = checksum,
+                UploadLength = uploadLength
+            },
+            user,
+            cancellationToken);
+    }
+}

--- a/src/Altinn.Broker.Application/UploadFile/TusUploadValidationService.cs
+++ b/src/Altinn.Broker.Application/UploadFile/TusUploadValidationService.cs
@@ -17,7 +17,8 @@ public class TusUploadValidationService(
         ClaimsPrincipal? user,
         Guid fileTransferId,
         long? uploadLength,
-        CancellationToken cancellationToken)
+        bool isLegacyUser = false,
+        CancellationToken cancellationToken = default)
     {
         var fileTransfer = await fileTransferRepository.GetFileTransfer(fileTransferId, cancellationToken);
         if (fileTransfer is null)
@@ -29,7 +30,7 @@ public class TusUploadValidationService(
             user,
             fileTransfer.ResourceId,
             fileTransfer.Sender.ActorExternalId,
-            isLegacyUser: false,
+            isLegacyUser,
             cancellationToken);
         if (!hasAccess)
         {

--- a/src/Altinn.Broker.Application/UploadFile/TusUploadValidationService.cs
+++ b/src/Altinn.Broker.Application/UploadFile/TusUploadValidationService.cs
@@ -76,6 +76,31 @@ public class TusUploadValidationService(
         return (fileTransfer, resource.MaxFileTransferSize, null);
     }
 
+    public async Task<Error?> ValidateTusGetInfoAsync(
+        ClaimsPrincipal? user,
+        Guid fileTransferId,
+        CancellationToken cancellationToken = default)
+    {
+        var fileTransfer = await fileTransferRepository.GetFileTransfer(fileTransferId, cancellationToken);
+        if (fileTransfer is null)
+        {
+            return Errors.FileTransferNotFound;
+        }
+
+        var hasAccess = await authorizationService.CheckAccessAsSender(
+            user,
+            fileTransfer.ResourceId,
+            fileTransfer.Sender.ActorExternalId,
+            isLegacyUser: false,
+            cancellationToken);
+        if (!hasAccess)
+        {
+            return Errors.NoAccessToResource;
+        }
+
+        return null;
+    }
+
     public async Task<Error?> ValidateUploadInProgressAsync(Guid fileTransferId, CancellationToken cancellationToken)
     {
         var fileTransfer = await fileTransferRepository.GetFileTransfer(fileTransferId, cancellationToken);

--- a/src/Altinn.Broker.Application/UploadFile/TusUploadValidationService.cs
+++ b/src/Altinn.Broker.Application/UploadFile/TusUploadValidationService.cs
@@ -75,4 +75,50 @@ public class TusUploadValidationService(
 
         return (fileTransfer, resource.MaxFileTransferSize, null);
     }
+
+    public async Task<Error?> ValidateUploadInProgressAsync(Guid fileTransferId, CancellationToken cancellationToken)
+    {
+        var fileTransfer = await fileTransferRepository.GetFileTransfer(fileTransferId, cancellationToken);
+        if (fileTransfer is null)
+        {
+            return Errors.FileTransferNotFound;
+        }
+
+        if (fileTransfer.FileTransferStatusEntity.Status > FileTransferStatus.UploadStarted)
+        {
+            return Errors.FileTransferAlreadyUploaded;
+        }
+
+        return null;
+    }
+
+    public async Task<(long? MaxUploadSize, Error? Error)> ValidateUploadSizeAsync(
+        Guid fileTransferId,
+        long uploadLength,
+        CancellationToken cancellationToken)
+    {
+        var fileTransfer = await fileTransferRepository.GetFileTransfer(fileTransferId, cancellationToken);
+        if (fileTransfer is null)
+        {
+            return (null, Errors.FileTransferNotFound);
+        }
+
+        var resource = await resourceRepository.GetResource(fileTransfer.ResourceId, cancellationToken);
+        if (resource is null)
+        {
+            return (null, Errors.InvalidResourceDefinition);
+        }
+
+        if (fileTransfer.UseVirusScan && uploadLength > ApplicationConstants.MaxVirusScanUploadSize)
+        {
+            return (resource.MaxFileTransferSize, Errors.FileSizeTooBig);
+        }
+
+        if (resource.MaxFileTransferSize is not null && uploadLength > resource.MaxFileTransferSize)
+        {
+            return (resource.MaxFileTransferSize, Errors.FileSizeTooBig);
+        }
+
+        return (resource.MaxFileTransferSize, null);
+    }
 }

--- a/src/Altinn.Broker.Application/UploadFile/TusUploadValidationService.cs
+++ b/src/Altinn.Broker.Application/UploadFile/TusUploadValidationService.cs
@@ -1,0 +1,77 @@
+using System.Security.Claims;
+
+using Altinn.Broker.Application.Settings;
+using Altinn.Broker.Core.Domain;
+using Altinn.Broker.Core.Domain.Enums;
+using Altinn.Broker.Core.Repositories;
+
+namespace Altinn.Broker.Application.UploadFile;
+
+public class TusUploadValidationService(
+    IAuthorizationService authorizationService,
+    IFileTransferRepository fileTransferRepository,
+    IResourceRepository resourceRepository,
+    IServiceOwnerRepository serviceOwnerRepository)
+{
+    public async Task<(FileTransferEntity FileTransfer, long? MaxUploadSize, Error? Error)> ValidateForUploadAsync(
+        ClaimsPrincipal? user,
+        Guid fileTransferId,
+        long? uploadLength,
+        CancellationToken cancellationToken)
+    {
+        var fileTransfer = await fileTransferRepository.GetFileTransfer(fileTransferId, cancellationToken);
+        if (fileTransfer is null)
+        {
+            return (null!, null, Errors.FileTransferNotFound);
+        }
+
+        var hasAccess = await authorizationService.CheckAccessAsSender(
+            user,
+            fileTransfer.ResourceId,
+            fileTransfer.Sender.ActorExternalId,
+            isLegacyUser: false,
+            cancellationToken);
+        if (!hasAccess)
+        {
+            return (fileTransfer, null, Errors.NoAccessToResource);
+        }
+
+        if (fileTransfer.FileTransferStatusEntity.Status > FileTransferStatus.UploadStarted)
+        {
+            return (fileTransfer, null, Errors.FileTransferAlreadyUploaded);
+        }
+
+        var resource = await resourceRepository.GetResource(fileTransfer.ResourceId, cancellationToken);
+        if (resource is null)
+        {
+            return (fileTransfer, null, Errors.InvalidResourceDefinition);
+        }
+
+        var serviceOwner = await serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId);
+        if (serviceOwner is null)
+        {
+            return (fileTransfer, null, Errors.ServiceOwnerNotConfigured);
+        }
+
+        var storageProvider = serviceOwner.GetStorageProvider(fileTransfer.UseVirusScan);
+        if (storageProvider is null)
+        {
+            return (fileTransfer, null, Errors.StorageProviderNotReady);
+        }
+
+        if (uploadLength is not null)
+        {
+            if (fileTransfer.UseVirusScan && uploadLength > ApplicationConstants.MaxVirusScanUploadSize)
+            {
+                return (fileTransfer, null, Errors.FileSizeTooBig);
+            }
+
+            if (resource.MaxFileTransferSize is not null && uploadLength > resource.MaxFileTransferSize)
+            {
+                return (fileTransfer, null, Errors.FileSizeTooBig);
+            }
+        }
+
+        return (fileTransfer, resource.MaxFileTransferSize, null);
+    }
+}

--- a/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
@@ -38,6 +38,7 @@ public class UploadFileHandler(
             user,
             request.FileTransferId,
             request.ContentLength,
+            request.IsLegacy,
             cancellationToken);
         if (validationError is not null)
         {
@@ -75,13 +76,23 @@ public class UploadFileHandler(
             var result = await brokerStorageService.UploadFile(serviceOwner, fileTransfer, request.UploadStream, cancellationToken);
             if (result is null)
             {
-                await fileTransferStatusRepository.InsertFileTransferStatus(
-                    request.FileTransferId,
-                    FileTransferStatus.Failed,
-                    timestamp: DateTime.UtcNow,
-                    detailedFileTransferStatus: "File upload failed and was aborted",
-                    cancellationToken: cancellationToken);
-                return Errors.UploadFailed;
+                return await TransactionWithRetriesPolicy.Execute(async ct =>
+                {
+                    await fileTransferStatusRepository.InsertFileTransferStatus(
+                        request.FileTransferId,
+                        FileTransferStatus.Failed,
+                        timestamp: DateTime.UtcNow,
+                        detailedFileTransferStatus: "File upload failed and was aborted",
+                        cancellationToken: ct);
+                    backgroundJobClient.Enqueue(() => eventBus.Publish(
+                        AltinnEventType.UploadFailed,
+                        fileTransfer.ResourceId,
+                        request.FileTransferId.ToString(),
+                        fileTransfer.Sender.ActorExternalId,
+                        Guid.NewGuid(),
+                        AltinnEventSubjectRole.Sender));
+                    return Errors.UploadFailed;
+                }, logger, cancellationToken);
             }
 
             var (checksum, uploadLength) = result.Value;

--- a/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
@@ -5,188 +5,119 @@ using Altinn.Broker.Application.Settings;
 using Altinn.Broker.Common;
 using Altinn.Broker.Core;
 using Altinn.Broker.Core.Application;
-using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Domain.Enums;
 using Altinn.Broker.Core.Helpers;
-using Altinn.Broker.Core.Options;
 using Altinn.Broker.Core.Repositories;
+using Altinn.Broker.Core.Services;
 using Altinn.Broker.Core.Services.Enums;
 
 using Hangfire;
 
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 using OneOf;
 
 namespace Altinn.Broker.Application.UploadFile;
 
 public class UploadFileHandler(
-    IAuthorizationService authorizationService,
-    IResourceRepository resourceRepository,
-    IServiceOwnerRepository serviceOwnerRepository,
-    IFileTransferRepository fileTransferRepository,
+    TusUploadValidationService tusUploadValidationService,
     IFileTransferStatusRepository fileTransferStatusRepository,
     IBrokerStorageService brokerStorageService,
+    CompleteFileUploadHandler completeFileUploadHandler,
+    IResourceRepository resourceRepository,
+    IServiceOwnerRepository serviceOwnerRepository,
     IBackgroundJobClient backgroundJobClient,
     EventBusMiddleware eventBus,
-    IHostEnvironment hostEnvironment,
-    IOptions<GeneralSettings> generalSettings,
-    MalwareScanningResultHandler malwareScanResultHandler,
     ILogger<UploadFileHandler> logger) : IHandler<UploadFileRequest, Guid>
 {
     public async Task<OneOf<Guid, Error>> Process(UploadFileRequest request, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
         logger.LogInformation("Uploading file for file transfer {fileTransferId}", request.FileTransferId);
-        var fileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, cancellationToken);
-        if (fileTransfer is null)
+
+        var (fileTransfer, _, validationError) = await tusUploadValidationService.ValidateForUploadAsync(
+            user,
+            request.FileTransferId,
+            request.ContentLength,
+            cancellationToken);
+        if (validationError is not null)
         {
-            return Errors.FileTransferNotFound;
+            return validationError;
         }
-        var hasAccess = await authorizationService.CheckAccessAsSender(user, fileTransfer.ResourceId, fileTransfer.Sender.ActorExternalId, request.IsLegacy, cancellationToken);
-        if (!hasAccess)
-        {
-            return Errors.NoAccessToResource;
-        }
+
         if (request.IsLegacy && request.OnBehalfOfConsumer is not null && !fileTransfer.IsSender(request.OnBehalfOfConsumer))
         {
             return Errors.NoAccessToResource;
         }
-        if (fileTransfer.FileTransferStatusEntity.Status > FileTransferStatus.UploadStarted)
-        {
-            return Errors.FileTransferAlreadyUploaded;
-        }
+
         var resource = await resourceRepository.GetResource(fileTransfer.ResourceId, cancellationToken);
         if (resource is null)
         {
             return Errors.InvalidResourceDefinition;
         }
+
         var serviceOwner = await serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId);
         if (serviceOwner is null)
         {
             return Errors.ServiceOwnerNotConfigured;
         }
-        var storageProvider = serviceOwner.GetStorageProvider(fileTransfer.UseVirusScan);
-        if (storageProvider is null)
-        {
-            return Errors.StorageProviderNotReady;
-        }
-        if (fileTransfer.UseVirusScan && request.ContentLength > ApplicationConstants.MaxVirusScanUploadSize)
-        {
-            return Errors.FileSizeTooBig;
-        }
-        if (resource?.MaxFileTransferSize is not null && request.ContentLength > resource.MaxFileTransferSize)
-        {
-            return Errors.FileSizeTooBig;
-        }
 
         var uploadStartedTimestamp = DateTime.UtcNow;
         var uploaderVendor = user?.GetCallerVendorId()?.WithPrefix();
-        await fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.UploadStarted, timestamp: uploadStartedTimestamp, vendor: uploaderVendor, cancellationToken: cancellationToken);
+        await fileTransferStatusRepository.InsertFileTransferStatus(
+            request.FileTransferId,
+            FileTransferStatus.UploadStarted,
+            timestamp: uploadStartedTimestamp,
+            vendor: uploaderVendor,
+            cancellationToken: cancellationToken);
 
         try
         {
             var result = await brokerStorageService.UploadFile(serviceOwner, fileTransfer, request.UploadStream, cancellationToken);
-            var finishedUploadTimestamp = DateTime.UtcNow;
             if (result is null)
             {
-                await fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.Failed, timestamp: finishedUploadTimestamp, detailedFileTransferStatus: "File upload failed and was aborted", cancellationToken: cancellationToken);
+                await fileTransferStatusRepository.InsertFileTransferStatus(
+                    request.FileTransferId,
+                    FileTransferStatus.Failed,
+                    timestamp: DateTime.UtcNow,
+                    detailedFileTransferStatus: "File upload failed and was aborted",
+                    cancellationToken: cancellationToken);
                 return Errors.UploadFailed;
             }
-            var (checksum, uploadLength) = result.Value;
-            if (!string.IsNullOrWhiteSpace(fileTransfer.Checksum) && !string.Equals(checksum, fileTransfer.Checksum, StringComparison.InvariantCultureIgnoreCase))
-            {
-                await fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.Failed, timestamp: finishedUploadTimestamp, detailedFileTransferStatus: "Checksum mismatch", cancellationToken: cancellationToken);
-                backgroundJobClient.Enqueue(() => brokerStorageService.DeleteFile(serviceOwner, fileTransfer, cancellationToken));
-                return Errors.ChecksumMismatch;
-            }
-            await TransactionWithRetriesPolicy.Execute<Task>(async (cancellationToken) =>
-            {
-                if (storageProvider.Type == StorageProviderType.Altinn3Azure)
-                {
-                    await fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.UploadProcessing, timestamp: finishedUploadTimestamp, cancellationToken: cancellationToken);
-                    backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.UploadProcessing, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Sender));
 
-                }
-                else if (storageProvider.Type == StorageProviderType.Altinn3AzureWithoutVirusScan && !generalSettings.Value.SimulateMalwareScan) {
-                    await fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.Published, timestamp: finishedUploadTimestamp, cancellationToken: cancellationToken);
-                    backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Sender));
-                    foreach (var recipient in fileTransfer.RecipientCurrentStatuses)
-                    {
-                        backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), recipient.Actor.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Recipient));
-                    }
-                }                 
-                await fileTransferRepository.SetStorageDetails(request.FileTransferId, storageProvider.Id, request.FileTransferId.ToString(), uploadLength, cancellationToken);
-                if (string.IsNullOrWhiteSpace(fileTransfer.Checksum))
+            var (checksum, uploadLength) = result.Value;
+            return await completeFileUploadHandler.Process(
+                new CompleteFileUploadRequest
                 {
-                    await fileTransferRepository.SetChecksum(request.FileTransferId, checksum, cancellationToken);
-                }
-                return Task.CompletedTask;
-            }, logger, cancellationToken);
+                    FileTransferId = request.FileTransferId,
+                    Checksum = checksum,
+                    UploadLength = uploadLength
+                },
+                user,
+                cancellationToken);
         }
         catch (Exception e)
         {
-            logger.LogError("Unexpected error occurred while uploading file: {errorMessage} \nStack trace: {stackTrace}", e.Message, e.StackTrace);
-            return await TransactionWithRetriesPolicy.Execute(async (cancellationToken) =>
+            logger.LogError(
+                "Unexpected error occurred while uploading file: {errorMessage} \nStack trace: {stackTrace}",
+                e.Message,
+                e.StackTrace);
+            return await TransactionWithRetriesPolicy.Execute(async ct =>
             {
-                await fileTransferStatusRepository.InsertFileTransferStatus(request.FileTransferId, FileTransferStatus.Failed, timestamp: DateTime.UtcNow, detailedFileTransferStatus: "Error occurred while uploading fileTransfer", cancellationToken: cancellationToken);
-                backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.UploadFailed, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Sender));
+                await fileTransferStatusRepository.InsertFileTransferStatus(
+                    request.FileTransferId,
+                    FileTransferStatus.Failed,
+                    timestamp: DateTime.UtcNow,
+                    detailedFileTransferStatus: "Error occurred while uploading fileTransfer",
+                    cancellationToken: ct);
+                backgroundJobClient.Enqueue(() => eventBus.Publish(
+                    AltinnEventType.UploadFailed,
+                    fileTransfer.ResourceId,
+                    request.FileTransferId.ToString(),
+                    fileTransfer.Sender.ActorExternalId,
+                    Guid.NewGuid(),
+                    AltinnEventSubjectRole.Sender));
                 return Errors.UploadFailed;
             }, logger, cancellationToken);
-        }
-
-        if (hostEnvironment.IsDevelopment() && generalSettings.Value.SimulateMalwareScan)
-        {
-            await SimulateMalwareScanResult(request.FileTransferId);
-            backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), fileTransfer.Sender.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Sender));
-            foreach (var recipient in fileTransfer.RecipientCurrentStatuses)
-            {
-                backgroundJobClient.Enqueue(() => eventBus.Publish(AltinnEventType.Published, fileTransfer.ResourceId, request.FileTransferId.ToString(), recipient.Actor.ActorExternalId, Guid.NewGuid(), AltinnEventSubjectRole.Recipient));
-            }
-        }
-        return fileTransfer.FileTransferId;
-    }
-
-
-
-    /// <summary>
-    /// Simulates a malware scan result for local development and tests by calling the MalwareScanResultHandler with fake ScanResultData.
-    /// </summary>
-    public async Task SimulateMalwareScanResult(Guid fileTransferId)
-    {
-        if (!hostEnvironment.IsDevelopment())
-        {
-            logger.LogWarning("SimulateMalwareScanResult called outside development environment");
-            return;
-        }
-
-        logger.LogInformation("Simulating malware scan result for filetransfer {fileTransferId}", fileTransferId);
-
-        var simulatedScanResult = new ScanResultData
-        {
-            BlobUri = $"http://127.0.0.1:10000/devstoreaccount1/filetransfer/{fileTransferId}",
-            CorrelationId = Guid.NewGuid(),
-            ETag = "simulated-etag",
-            ScanFinishedTimeUtc = DateTime.UtcNow,
-            ScanResultDetails = new ScanResultDetails
-            {
-                MalwareNamesFound = new List<string>(),
-                Sha256 = "simulated-sha256"
-            },
-            ScanResultType = "No threats found"
-        };
-
-        var result = await malwareScanResultHandler.Process(simulatedScanResult, null, CancellationToken.None);
-
-        if (result.IsT0)
-        {
-            logger.LogInformation("Successfully simulated malware scan result for filetransfer {fileTransferId} using MalwareScanResultHandler", fileTransferId);
-        }
-        else
-        {
-            var error = result.AsT1;
-            logger.LogError("Error in simulated malware scan result for filetransfer {fileTransferId}: {Error}", fileTransferId, error.Message);
         }
     }
 }

--- a/src/Altinn.Broker.Core/Services/IBrokerStorageService.cs
+++ b/src/Altinn.Broker.Core/Services/IBrokerStorageService.cs
@@ -17,4 +17,5 @@ public interface IBrokerStorageService
     Task DeleteFile(ServiceOwnerEntity serviceOwnerEntity, FileTransferEntity fileTransferEntity, CancellationToken cancellationToken);
     Task SetContentHashForExistingBlob(ServiceOwnerEntity serviceOwnerEntity, FileTransferEntity fileTransferEntity, CancellationToken cancellationToken);
     Task<string> UploadReportFileToStorage(string fileName, Stream stream, CancellationToken cancellationToken);
+    Task<(string Checksum, long Length)?> FinalizeTusUpload(ServiceOwnerEntity serviceOwnerEntity, FileTransferEntity fileTransferEntity, CancellationToken cancellationToken);
 }

--- a/src/Altinn.Broker.Integrations/Altinn.Broker.Integrations.csproj
+++ b/src/Altinn.Broker.Integrations/Altinn.Broker.Integrations.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Hangfire.Core" Version="1.8.20" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.12" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.11" />
     <PackageReference Include="Microsoft.Azure.Management.Storage" Version="25.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.13.0" />
 	<PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
@@ -38,6 +39,8 @@
 	<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
 	<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="Slack.Webhooks" Version="1.1.5" />
+    <PackageReference Include="StackExchange.Redis" Version="3.0.11" />
+    <PackageReference Include="Xtensible.TusDotNet.Azure" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.Broker.Integrations/Azure/AzureStorageConstants.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureStorageConstants.cs
@@ -1,0 +1,8 @@
+namespace Altinn.Broker.Integrations.Azure;
+
+public static class AzureStorageConstants
+{
+    public const string BrokerFilesContainerName = "brokerfiles";
+    public const string TusStagingBlobPath = "tus-staging";
+    public const string TusMd5ChecksumMetadataKey = "MD5Checksum";
+}

--- a/src/Altinn.Broker.Integrations/Azure/AzureStorageConstants.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureStorageConstants.cs
@@ -4,5 +4,6 @@ public static class AzureStorageConstants
 {
     public const string BrokerFilesContainerName = "brokerfiles";
     public const string TusStagingBlobPath = "tus-staging";
+    public const string TusBlockStagingBlobPath = "tus-block-staging";
     public const string TusMd5ChecksumMetadataKey = "MD5Checksum";
 }

--- a/src/Altinn.Broker.Integrations/Azure/AzureStorageService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureStorageService.cs
@@ -216,9 +216,12 @@ public class AzureStorageService(IOptions<AzureStorageOptions> azureStorageOptio
         try
         {
             await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
-            var tusStagingBlob = blobContainerClient.GetAppendBlobClient(
+            var tusStagingAppendBlob = blobContainerClient.GetBlobClient(
                 Path.Combine(AzureStorageConstants.TusStagingBlobPath, fileTransferEntity.FileTransferId.ToString()));
-            await tusStagingBlob.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+            await tusStagingAppendBlob.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+            var tusStagingBlockBlob = blobContainerClient.GetBlobClient(
+                Path.Combine(AzureStorageConstants.TusBlockStagingBlobPath, fileTransferEntity.FileTransferId.ToString()));
+            await tusStagingBlockBlob.DeleteIfExistsAsync(cancellationToken: cancellationToken);
         }
         catch (RequestFailedException requestFailedException)
         {
@@ -234,12 +237,17 @@ public class AzureStorageService(IOptions<AzureStorageOptions> azureStorageOptio
     {
         logger.LogInformation("Finalizing TUS upload for {fileTransferId}", fileTransferEntity.FileTransferId);
         var blobContainerClient = await GetBlobContainerClient(fileTransferEntity, serviceOwnerEntity);
-        var stagingBlobClient = blobContainerClient.GetAppendBlobClient(
+        var blockStagingBlobClient = blobContainerClient.GetBlobClient(
+            Path.Combine(AzureStorageConstants.TusBlockStagingBlobPath, fileTransferEntity.FileTransferId.ToString()));
+        var appendStagingBlobClient = blobContainerClient.GetBlobClient(
             Path.Combine(AzureStorageConstants.TusStagingBlobPath, fileTransferEntity.FileTransferId.ToString()));
         var destinationBlobClient = blobContainerClient.GetBlockBlobClient(fileTransferEntity.FileTransferId.ToString());
 
         try
         {
+            var stagingBlobClient = await blockStagingBlobClient.ExistsAsync(cancellationToken)
+                ? blockStagingBlobClient
+                : appendStagingBlobClient;
             if (!await stagingBlobClient.ExistsAsync(cancellationToken))
             {
                 logger.LogError("TUS staging blob not found for {fileTransferId}", fileTransferEntity.FileTransferId);
@@ -276,6 +284,8 @@ public class AzureStorageService(IOptions<AzureStorageOptions> azureStorageOptio
                 cancellationToken: cancellationToken);
 
             await stagingBlobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+            await appendStagingBlobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+            await blockStagingBlobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
 
             logger.LogInformation(
                 "Finalized TUS upload for {fileTransferId}, size {contentLength}",

--- a/src/Altinn.Broker.Integrations/Azure/AzureStorageService.cs
+++ b/src/Altinn.Broker.Integrations/Azure/AzureStorageService.cs
@@ -216,10 +216,80 @@ public class AzureStorageService(IOptions<AzureStorageOptions> azureStorageOptio
         try
         {
             await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+            var tusStagingBlob = blobContainerClient.GetAppendBlobClient(
+                Path.Combine(AzureStorageConstants.TusStagingBlobPath, fileTransferEntity.FileTransferId.ToString()));
+            await tusStagingBlob.DeleteIfExistsAsync(cancellationToken: cancellationToken);
         }
         catch (RequestFailedException requestFailedException)
         {
             logger.LogError("Error occurred while deleting file: {errorCode}: {errorMessage} ", requestFailedException.ErrorCode, requestFailedException.Message);
+            throw;
+        }
+    }
+
+    public async Task<(string Checksum, long Length)?> FinalizeTusUpload(
+        ServiceOwnerEntity serviceOwnerEntity,
+        FileTransferEntity fileTransferEntity,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Finalizing TUS upload for {fileTransferId}", fileTransferEntity.FileTransferId);
+        var blobContainerClient = await GetBlobContainerClient(fileTransferEntity, serviceOwnerEntity);
+        var stagingBlobClient = blobContainerClient.GetAppendBlobClient(
+            Path.Combine(AzureStorageConstants.TusStagingBlobPath, fileTransferEntity.FileTransferId.ToString()));
+        var destinationBlobClient = blobContainerClient.GetBlockBlobClient(fileTransferEntity.FileTransferId.ToString());
+
+        try
+        {
+            if (!await stagingBlobClient.ExistsAsync(cancellationToken))
+            {
+                logger.LogError("TUS staging blob not found for {fileTransferId}", fileTransferEntity.FileTransferId);
+                return null;
+            }
+
+            var stagingProperties = await stagingBlobClient.GetPropertiesAsync(cancellationToken: cancellationToken);
+            var contentLength = stagingProperties.Value.ContentLength;
+            if (!stagingProperties.Value.Metadata.TryGetValue(AzureStorageConstants.TusMd5ChecksumMetadataKey, out var md5Base64)
+                || string.IsNullOrWhiteSpace(md5Base64))
+            {
+                logger.LogError("TUS staging blob is missing MD5 checksum metadata for {fileTransferId}", fileTransferEntity.FileTransferId);
+                return null;
+            }
+
+            var checksum = BitConverter.ToString(Convert.FromBase64String(md5Base64)).Replace("-", "").ToLowerInvariant();
+
+            var copyOperation = await destinationBlobClient.StartCopyFromUriAsync(
+                stagingBlobClient.Uri,
+                new BlobCopyFromUriOptions
+                {
+                    Metadata = new Dictionary<string, string>()
+                },
+                cancellationToken);
+            await copyOperation.WaitForCompletionAsync(cancellationToken);
+
+            var contentHash = Convert.FromBase64String(md5Base64);
+            await destinationBlobClient.SetHttpHeadersAsync(
+                new BlobHttpHeaders
+                {
+                    ContentType = "application/octet-stream",
+                    ContentHash = contentHash
+                },
+                cancellationToken: cancellationToken);
+
+            await stagingBlobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+
+            logger.LogInformation(
+                "Finalized TUS upload for {fileTransferId}, size {contentLength}",
+                fileTransferEntity.FileTransferId,
+                contentLength);
+            return (checksum, contentLength);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                "Error finalizing TUS upload for {fileTransferId}: {errorMessage}",
+                fileTransferEntity.FileTransferId,
+                ex.Message);
+            await destinationBlobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
             throw;
         }
     }

--- a/src/Altinn.Broker.Integrations/DependencyInjection.cs
+++ b/src/Altinn.Broker.Integrations/DependencyInjection.cs
@@ -110,6 +110,8 @@ public static class DependencyInjection
                 : new NullExpirationDetailsStore();
         });
         services.AddSingleton<ITusPartialUploadRegistry, TusPartialUploadRegistry>();
+        services.AddSingleton<ITusUploadStateRegistry, TusUploadStateRegistry>();
+        services.AddSingleton<ITusUploadProgressCache, TusUploadProgressCache>();
         services.AddScoped<BrokerTusStore>();
         services.AddScoped<ITusStorageResolver, TusStorageResolver>();
     }

--- a/src/Altinn.Broker.Integrations/DependencyInjection.cs
+++ b/src/Altinn.Broker.Integrations/DependencyInjection.cs
@@ -11,8 +11,16 @@ using Altinn.Broker.Integrations.Altinn.ResourceRegistry;
 using Altinn.Broker.Integrations.Azure;
 using Altinn.Broker.Integrations.Maskinporten;
 using Altinn.Broker.Persistence.Repositories;
+using Altinn.Broker.Integrations.Tus;
+
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using StackExchange.Redis;
+
+using Xtensible.TusDotNet.Azure;
 using Altinn.Broker.Integrations.Slack;
 using Slack.Webhooks;
 using Altinn.Broker.Core.Helpers;
@@ -86,5 +94,22 @@ public static class DependencyInjection
         services.AddSingleton<SlackSettings>();
         services.AddSingleton<SlackExceptionNotificationHandler>();
         services.AddExceptionHandler<SlackExceptionNotificationHandler>();
+
+        AddTusUploads(services, configuration);
+    }
+
+    private static void AddTusUploads(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddHttpContextAccessor();
+        services.Configure<TusOptions>(configuration.GetSection(TusOptions.SectionName));
+        services.AddSingleton<ITusExpirationDetailsStore>(serviceProvider =>
+        {
+            var multiplexer = serviceProvider.GetService<IConnectionMultiplexer>();
+            return multiplexer is not null
+                ? new RedisTusExpirationDetailsStore(multiplexer)
+                : new NullExpirationDetailsStore();
+        });
+        services.AddScoped<BrokerTusStore>();
+        services.AddScoped<ITusStorageResolver, TusStorageResolver>();
     }
 }

--- a/src/Altinn.Broker.Integrations/DependencyInjection.cs
+++ b/src/Altinn.Broker.Integrations/DependencyInjection.cs
@@ -109,6 +109,7 @@ public static class DependencyInjection
                 ? new RedisTusExpirationDetailsStore(multiplexer)
                 : new NullExpirationDetailsStore();
         });
+        services.AddSingleton<ITusPartialUploadRegistry, TusPartialUploadRegistry>();
         services.AddScoped<BrokerTusStore>();
         services.AddScoped<ITusStorageResolver, TusStorageResolver>();
     }

--- a/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
+++ b/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
@@ -35,6 +35,7 @@ public class BrokerTusStore(
 
     public async Task<long> AppendDataAsync(string fileId, Stream stream, CancellationToken cancellationToken)
     {
+        fileId = ResolveStoreFileId(fileId);
         var state = await GetOrCreateUploadStateAsync(fileId, cancellationToken);
 
         using var chunkBuffer = new MemoryStream();
@@ -81,6 +82,7 @@ public class BrokerTusStore(
 
     public async Task<bool> FileExistAsync(string fileId, CancellationToken cancellationToken)
     {
+        fileId = ResolveStoreFileId(fileId);
         if (_uploadLengths.ContainsKey(fileId))
         {
             return true;
@@ -117,6 +119,7 @@ public class BrokerTusStore(
 
     public async Task<long?> GetUploadLengthAsync(string fileId, CancellationToken cancellationToken)
     {
+        fileId = ResolveStoreFileId(fileId);
         if (_uploadLengths.TryGetValue(fileId, out var cachedLength))
         {
             return cachedLength;
@@ -144,6 +147,7 @@ public class BrokerTusStore(
 
     public async Task<long> GetUploadOffsetAsync(string fileId, CancellationToken cancellationToken)
     {
+        fileId = ResolveStoreFileId(fileId);
         if (uploadStateRegistry.TryGet(fileId, out var state))
         {
             lock (state!.SyncRoot)
@@ -266,6 +270,7 @@ public class BrokerTusStore(
 
     public Task<FileConcat?> GetUploadConcatAsync(string fileId, CancellationToken cancellationToken)
     {
+        fileId = ResolveStoreFileId(fileId);
         if (partialUploadRegistry.IsPartial(fileId))
         {
             return Task.FromResult<FileConcat?>(new FileConcatPartial());
@@ -281,6 +286,7 @@ public class BrokerTusStore(
 
     public async Task<string> GetUploadMetadataAsync(string fileId, CancellationToken cancellationToken)
     {
+        fileId = ResolveStoreFileId(fileId);
         if (_uploadMetadata.TryGetValue(fileId, out var metadata))
         {
             return metadata;
@@ -302,6 +308,7 @@ public class BrokerTusStore(
 
     public async Task<ITusFile> GetFileAsync(string fileId, CancellationToken cancellationToken)
     {
+        fileId = ResolveStoreFileId(fileId);
         var legacyStore = await GetLegacyAppendBlobStoreIfExistsAsync(fileId, cancellationToken);
         if (legacyStore is not null)
         {
@@ -313,6 +320,7 @@ public class BrokerTusStore(
 
     public async Task DeleteFileAsync(string fileId, CancellationToken cancellationToken)
     {
+        fileId = ResolveStoreFileId(fileId);
         await storageResolver.DeleteStagingBlobAsync(fileId, cancellationToken);
 
         var legacyStore = await GetLegacyAppendBlobStoreIfExistsAsync(fileId, cancellationToken);
@@ -370,6 +378,7 @@ public class BrokerTusStore(
 
     public async Task<bool> VerifyChecksumAsync(string fileId, string algorithm, byte[] checksum, CancellationToken cancellationToken)
     {
+        fileId = ResolveStoreFileId(fileId);
         var legacyStore = await GetLegacyAppendBlobStoreIfExistsAsync(fileId, cancellationToken);
         if (legacyStore is not null)
         {
@@ -572,6 +581,12 @@ public class BrokerTusStore(
 
         return fileTransferId;
     }
+
+    /// <summary>
+    /// tusdotnet passes concatenation partial ids as "partial/{partialUploadId}" when the upload URL
+    /// includes the literal partial segment. Storage always uses the bare partial upload id.
+    /// </summary>
+    private static string ResolveStoreFileId(string fileId) => NormalizePartialFileId(fileId);
 
     private static string NormalizePartialFileId(string partialFileReference)
     {

--- a/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
+++ b/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
@@ -22,26 +22,19 @@ public class BrokerTusStore(
     ITusChecksumStore
 {
     private readonly ConcurrentDictionary<string, MD5> _uploadMd5Hashers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, long> _uploadLengths = new(StringComparer.OrdinalIgnoreCase);
 
     public async Task<long> AppendDataAsync(string fileId, Stream stream, CancellationToken cancellationToken)
     {
         var store = await GetRequiredStore(fileId, cancellationToken);
         var md5 = await GetOrCreateUploadMd5Async(store, fileId, cancellationToken);
+        var uploadLength = await GetCachedUploadLengthAsync(store, fileId, cancellationToken);
+        var offsetBefore = await store.GetUploadOffsetAsync(fileId, cancellationToken);
 
-        using var chunkData = new MemoryStream();
-        await stream.CopyToAsync(chunkData, cancellationToken);
-        var chunkBytes = chunkData.ToArray();
-        if (chunkBytes.Length > 0)
-        {
-            md5.TransformBlock(chunkBytes, 0, chunkBytes.Length, null, 0);
-        }
+        var bytesWritten = await store.AppendDataAsync(fileId, new Md5ComputingStream(stream, md5), cancellationToken);
+        var newOffset = offsetBefore + bytesWritten;
 
-        await using var chunkStream = new MemoryStream(chunkBytes, writable: false);
-        var bytesWritten = await store.AppendDataAsync(fileId, chunkStream, cancellationToken);
-
-        var uploadLength = await store.GetUploadLengthAsync(fileId, cancellationToken);
-        var offset = await store.GetUploadOffsetAsync(fileId, cancellationToken);
-        if (uploadLength is not null && offset >= uploadLength.Value)
+        if (newOffset >= uploadLength)
         {
             md5.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
             if (md5.Hash is not null)
@@ -53,6 +46,8 @@ public class BrokerTusStore(
             {
                 hasher.Dispose();
             }
+
+            _uploadLengths.TryRemove(fileId, out _);
         }
 
         return bytesWritten;
@@ -80,7 +75,9 @@ public class BrokerTusStore(
     {
         var fileTransferId = GetFileTransferIdFromRoute();
         var store = await GetRequiredStore(fileTransferId, cancellationToken);
-        return await store.CreateFileAsync(uploadLength, metadata, cancellationToken);
+        var fileId = await store.CreateFileAsync(uploadLength, metadata, cancellationToken);
+        _uploadLengths[fileId] = uploadLength;
+        return fileId;
     }
 
     public async Task<string> GetUploadMetadataAsync(string fileId, CancellationToken cancellationToken)
@@ -103,6 +100,8 @@ public class BrokerTusStore(
         {
             hasher.Dispose();
         }
+
+        _uploadLengths.TryRemove(fileId, out _);
 
         if (expirationDetailsStore is RedisTusExpirationDetailsStore redisExpirationStore)
         {
@@ -149,6 +148,22 @@ public class BrokerTusStore(
     {
         var store = await GetRequiredStore(fileId, cancellationToken);
         return await store.VerifyChecksumAsync(fileId, algorithm, checksum, cancellationToken);
+    }
+
+    private async Task<long> GetCachedUploadLengthAsync(
+        AzureBlobTusStore store,
+        string fileId,
+        CancellationToken cancellationToken)
+    {
+        if (_uploadLengths.TryGetValue(fileId, out var cachedLength))
+        {
+            return cachedLength;
+        }
+
+        var uploadLength = await store.GetUploadLengthAsync(fileId, cancellationToken)
+            ?? throw new TusStoreException($"Upload length is missing for file id {fileId}");
+        _uploadLengths[fileId] = uploadLength;
+        return uploadLength;
     }
 
     private async Task<MD5> GetOrCreateUploadMd5Async(AzureBlobTusStore store, string fileId, CancellationToken cancellationToken)

--- a/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
+++ b/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
@@ -96,6 +96,11 @@ public class BrokerTusStore(
             return true;
         }
 
+        if (await uploadProgressCache.GetAsync(fileId, cancellationToken) is not null)
+        {
+            return true;
+        }
+
         if (await storageResolver.StagingBlobExistsAsync(fileId, cancellationToken))
         {
             return true;
@@ -120,6 +125,12 @@ public class BrokerTusStore(
         if (partialUploadRegistry.TryGetUploadLength(fileId, out var registeredLength))
         {
             return registeredLength;
+        }
+
+        var cachedProgress = await uploadProgressCache.GetAsync(fileId, cancellationToken);
+        if (cachedProgress is not null)
+        {
+            return cachedProgress.UploadLength;
         }
 
         var legacyStore = await GetLegacyAppendBlobStoreIfExistsAsync(fileId, cancellationToken);

--- a/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
+++ b/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
@@ -2,10 +2,12 @@ using System.Collections.Concurrent;
 using System.Security.Cryptography;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 using tusdotnet.Interfaces;
 using tusdotnet.Models;
 
+using Altinn.Broker.Core.Options;
 using Xtensible.TusDotNet.Azure;
 
 namespace Altinn.Broker.Integrations.Tus;
@@ -13,7 +15,8 @@ namespace Altinn.Broker.Integrations.Tus;
 public class BrokerTusStore(
     ITusStorageResolver storageResolver,
     ITusExpirationDetailsStore expirationDetailsStore,
-    IHttpContextAccessor httpContextAccessor) :
+    IHttpContextAccessor httpContextAccessor,
+    IOptions<AzureStorageOptions> azureStorageOptions) :
     ITusStore,
     ITusCreationStore,
     ITusReadableStore,
@@ -21,7 +24,6 @@ public class BrokerTusStore(
     ITusExpirationStore,
     ITusChecksumStore
 {
-    private readonly ConcurrentDictionary<string, MD5> _uploadMd5Hashers = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, long> _uploadLengths = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, UploadState> _uploadStates = new(StringComparer.OrdinalIgnoreCase);
 
@@ -38,9 +40,10 @@ public class BrokerTusStore(
             return 0;
         }
 
-        var shouldStartProcessor = false;
+        string blockId;
         long acceptedOffset;
         bool isFinalChunk;
+        int chunkLength = chunk.Length;
 
         lock (state.SyncRoot)
         {
@@ -49,33 +52,27 @@ public class BrokerTusStore(
                 throw new TusStoreException($"Buffered TUS upload failed for file id {fileId}. {state.Fault.Message}");
             }
 
-            state.PendingChunks.Enqueue(chunk);
-            state.AcceptedOffset += chunk.Length;
+            blockId = BuildBlockId(state.NextBlockIndex++);
+            state.BlockIds.Add(blockId);
+            state.AcceptedOffset += chunkLength;
             acceptedOffset = state.AcceptedOffset;
             isFinalChunk = acceptedOffset >= state.UploadLength;
-
-            if (!state.IsProcessing)
-            {
-                state.IsProcessing = true;
-                shouldStartProcessor = true;
-            }
+            state.PendingUploads++;
+            state.UploadMd5.TransformBlock(chunk, 0, chunkLength, null, 0);
         }
 
-        if (shouldStartProcessor)
-        {
-            _ = Task.Run(() => ProcessPendingChunksAsync(fileId, store, state));
-        }
+        _ = Task.Run(() => UploadBlockAsync(fileId, state, blockId, chunk));
 
         // For intermediate chunks we ACK as soon as bytes are read into memory.
         // For the final chunk we still wait until all buffered data is committed to storage.
         if (isFinalChunk)
         {
             await WaitForCommittedOffsetAsync(fileId, state, acceptedOffset, cancellationToken);
-            await FinalizeUploadChecksumAsync(fileId, state, cancellationToken);
+            await FinalizeUploadAsync(fileId, state, cancellationToken);
             CleanupUploadState(fileId);
         }
 
-        return chunk.Length;
+        return chunkLength;
     }
 
     public async Task<bool> FileExistAsync(string fileId, CancellationToken cancellationToken)
@@ -115,7 +112,7 @@ public class BrokerTusStore(
         var store = await GetRequiredStore(fileTransferId, cancellationToken);
         var fileId = await store.CreateFileAsync(uploadLength, metadata, cancellationToken);
         _uploadLengths[fileId] = uploadLength;
-        _uploadStates[fileId] = new UploadState(uploadLength, initialOffset: 0);
+        _uploadStates[fileId] = new UploadState(uploadLength, initialOffset: 0, azureStorageOptions.Value.ConcurrentUploadThreads);
         return fileId;
     }
 
@@ -212,89 +209,39 @@ public class BrokerTusStore(
 
         var uploadLength = await GetCachedUploadLengthAsync(store, fileId, cancellationToken);
         var currentOffset = await store.GetUploadOffsetAsync(fileId, cancellationToken);
-        var newState = new UploadState(uploadLength, currentOffset);
+        var newState = new UploadState(uploadLength, currentOffset, azureStorageOptions.Value.ConcurrentUploadThreads);
         return _uploadStates.GetOrAdd(fileId, newState);
     }
 
-    private async Task<MD5> GetOrCreateUploadMd5Async(AzureBlobTusStore store, string fileId, CancellationToken cancellationToken)
+    private async Task UploadBlockAsync(string fileId, UploadState state, string blockId, byte[] chunk)
     {
-        if (_uploadMd5Hashers.TryGetValue(fileId, out var existing))
+        await state.ConcurrentUploader.WaitAsync();
+        try
         {
-            return existing;
-        }
-
-        var md5 = MD5.Create();
-        var offset = await store.GetUploadOffsetAsync(fileId, cancellationToken);
-        if (offset > 0)
-        {
-            var file = await store.GetFileAsync(fileId, cancellationToken);
-            await using var content = await file.GetContentAsync(cancellationToken);
-            var buffer = new byte[1024 * 1024];
-            int read;
-            while ((read = await content.ReadAsync(buffer, cancellationToken)) > 0)
-            {
-                md5.TransformBlock(buffer, 0, read, null, 0);
-            }
-        }
-
-        if (!_uploadMd5Hashers.TryAdd(fileId, md5))
-        {
-            md5.Dispose();
-            return _uploadMd5Hashers[fileId];
-        }
-
-        return md5;
-    }
-
-    private async Task ProcessPendingChunksAsync(string fileId, AzureBlobTusStore store, UploadState state)
-    {
-        while (true)
-        {
-            byte[]? chunk;
+            await storageResolver.StageTusBlockAsync(fileId, blockId, chunk, CancellationToken.None);
             lock (state.SyncRoot)
             {
-                if (state.PendingChunks.Count == 0)
-                {
-                    state.IsProcessing = false;
-                    return;
-                }
-
-                chunk = state.PendingChunks.Dequeue();
+                state.CommittedOffset += chunk.Length;
+                state.PendingUploads--;
+                var previousProgress = state.ProgressSignal;
+                state.ProgressSignal = NewProgressSignal();
+                previousProgress.TrySetResult(state.CommittedOffset);
             }
-
-            try
+        }
+        catch (Exception ex)
+        {
+            lock (state.SyncRoot)
             {
-                await using var chunkStream = new MemoryStream(chunk, writable: false);
-                var bytesWritten = await store.AppendDataAsync(fileId, chunkStream, CancellationToken.None);
-                if (bytesWritten != chunk.Length)
-                {
-                    throw new TusStoreException($"Unexpected append result for file id {fileId}. Expected {chunk.Length} bytes, wrote {bytesWritten} bytes.");
-                }
-
-                var md5 = await GetOrCreateUploadMd5Async(store, fileId, CancellationToken.None);
-                md5.TransformBlock(chunk, 0, chunk.Length, null, 0);
-
-                lock (state.SyncRoot)
-                {
-                    state.CommittedOffset += bytesWritten;
-                    var previousProgress = state.ProgressSignal;
-                    state.ProgressSignal = NewProgressSignal();
-                    previousProgress.TrySetResult(state.CommittedOffset);
-                }
+                state.Fault = ex;
+                state.PendingUploads = Math.Max(state.PendingUploads - 1, 0);
+                var previousProgress = state.ProgressSignal;
+                state.ProgressSignal = NewProgressSignal();
+                previousProgress.TrySetException(ex);
             }
-            catch (Exception ex)
-            {
-                lock (state.SyncRoot)
-                {
-                    state.Fault = ex;
-                    state.IsProcessing = false;
-                    var previousProgress = state.ProgressSignal;
-                    state.ProgressSignal = NewProgressSignal();
-                    previousProgress.TrySetException(ex);
-                }
-
-                return;
-            }
+        }
+        finally
+        {
+            state.ConcurrentUploader.Release();
         }
     }
 
@@ -329,34 +276,46 @@ public class BrokerTusStore(
         }
     }
 
-    private async Task FinalizeUploadChecksumAsync(string fileId, UploadState state, CancellationToken cancellationToken)
+    private async Task FinalizeUploadAsync(string fileId, UploadState state, CancellationToken cancellationToken)
     {
+        byte[] md5Hash;
+        List<string> blockIds;
+
         lock (state.SyncRoot)
         {
             if (state.Fault is not null)
             {
                 throw new TusStoreException($"Buffered TUS upload failed for file id {fileId}. {state.Fault.Message}");
             }
+
+            if (state.PendingUploads > 0)
+            {
+                throw new TusStoreException($"Buffered TUS upload for file id {fileId} has {state.PendingUploads} pending block uploads.");
+            }
+
+            state.UploadMd5.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+            md5Hash = state.UploadMd5.Hash
+                ?? throw new TusStoreException($"Failed to calculate MD5 for file id {fileId}.");
+            blockIds = state.BlockIds.ToList();
         }
 
-        var store = await GetRequiredStore(fileId, cancellationToken);
-        var md5 = await GetOrCreateUploadMd5Async(store, fileId, cancellationToken);
-        md5.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
-        if (md5.Hash is not null)
+        if (blockIds.Count == 0)
         {
-            await storageResolver.SetStagingBlobMd5ChecksumAsync(fileId, md5.Hash, cancellationToken);
+            throw new TusStoreException($"Cannot finalize TUS upload for file id {fileId} because no blocks were staged.");
         }
+
+        await storageResolver.CommitTusBlocksAsync(fileId, blockIds, md5Hash, cancellationToken);
     }
 
     private void CleanupUploadState(string fileId)
     {
-        if (_uploadMd5Hashers.TryRemove(fileId, out var hasher))
+        if (_uploadStates.TryRemove(fileId, out var state))
         {
-            hasher.Dispose();
+            state.UploadMd5.Dispose();
+            state.ConcurrentUploader.Dispose();
         }
 
         _uploadLengths.TryRemove(fileId, out _);
-        _uploadStates.TryRemove(fileId, out _);
     }
 
     private async Task<AzureBlobTusStore> GetRequiredStore(string fileId, CancellationToken cancellationToken)
@@ -383,19 +342,27 @@ public class BrokerTusStore(
         return fileTransferId.ToString();
     }
 
+    private static string BuildBlockId(long blockIndex)
+    {
+        var blockId = blockIndex.ToString("D12");
+        return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(blockId));
+    }
+
     private sealed class UploadState
     {
-        public UploadState(long uploadLength, long initialOffset)
+        public UploadState(long uploadLength, long initialOffset, int maxParallelBlockUploads)
         {
             UploadLength = uploadLength;
             AcceptedOffset = initialOffset;
             CommittedOffset = initialOffset;
             ProgressSignal = NewProgressSignal();
+            ConcurrentUploader = new SemaphoreSlim(Math.Max(maxParallelBlockUploads, 1));
+            UploadMd5 = MD5.Create();
         }
 
         public object SyncRoot { get; } = new();
 
-        public Queue<byte[]> PendingChunks { get; } = new();
+        public List<string> BlockIds { get; } = new();
 
         public long UploadLength { get; }
 
@@ -403,10 +370,16 @@ public class BrokerTusStore(
 
         public long CommittedOffset { get; set; }
 
-        public bool IsProcessing { get; set; }
+        public int PendingUploads { get; set; }
+
+        public long NextBlockIndex { get; set; }
 
         public Exception? Fault { get; set; }
 
         public TaskCompletionSource<long> ProgressSignal { get; set; }
+
+        public SemaphoreSlim ConcurrentUploader { get; }
+
+        public MD5 UploadMd5 { get; }
     }
 }

--- a/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
+++ b/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Security.Cryptography;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
@@ -17,6 +16,8 @@ public class BrokerTusStore(
     ITusStorageResolver storageResolver,
     ITusExpirationDetailsStore expirationDetailsStore,
     ITusPartialUploadRegistry partialUploadRegistry,
+    ITusUploadStateRegistry uploadStateRegistry,
+    ITusUploadProgressCache uploadProgressCache,
     IHttpContextAccessor httpContextAccessor,
     IOptions<AzureStorageOptions> azureStorageOptions) :
     ITusStore,
@@ -29,8 +30,8 @@ public class BrokerTusStore(
 {
     private readonly ConcurrentDictionary<string, long> _uploadLengths = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, string> _uploadMetadata = new(StringComparer.OrdinalIgnoreCase);
-    private readonly ConcurrentDictionary<string, UploadState> _uploadStates = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, string[]> _finalConcatPartials = new(StringComparer.OrdinalIgnoreCase);
+    private readonly int _maxParallelBlockUploads = Math.Max(azureStorageOptions.Value.ConcurrentUploadThreads, 1);
 
     public async Task<long> AppendDataAsync(string fileId, Stream stream, CancellationToken cancellationToken)
     {
@@ -62,16 +63,17 @@ public class BrokerTusStore(
             acceptedOffset = state.AcceptedOffset;
             isFinalChunk = acceptedOffset >= state.UploadLength;
             state.PendingUploads++;
-            state.UploadMd5.TransformBlock(chunk, 0, chunkLength, null, 0);
         }
 
         _ = Task.Run(() => UploadBlockAsync(fileId, state, blockId, chunk));
+
+        await PersistProgressAsync(fileId, state, cancellationToken);
 
         if (isFinalChunk)
         {
             await WaitForCommittedOffsetAsync(fileId, state, acceptedOffset, cancellationToken);
             await FinalizeUploadAsync(fileId, state, cancellationToken);
-            CleanupUploadState(fileId);
+            await CleanupUploadState(fileId, cancellationToken);
         }
 
         return chunkLength;
@@ -79,7 +81,12 @@ public class BrokerTusStore(
 
     public async Task<bool> FileExistAsync(string fileId, CancellationToken cancellationToken)
     {
-        if (_uploadLengths.ContainsKey(fileId) || _uploadStates.ContainsKey(fileId))
+        if (_uploadLengths.ContainsKey(fileId))
+        {
+            return true;
+        }
+
+        if (uploadStateRegistry.TryGet(fileId, out _))
         {
             return true;
         }
@@ -126,9 +133,9 @@ public class BrokerTusStore(
 
     public async Task<long> GetUploadOffsetAsync(string fileId, CancellationToken cancellationToken)
     {
-        if (_uploadStates.TryGetValue(fileId, out var state))
+        if (uploadStateRegistry.TryGet(fileId, out var state))
         {
-            lock (state.SyncRoot)
+            lock (state!.SyncRoot)
             {
                 if (state.Fault is not null)
                 {
@@ -137,6 +144,12 @@ public class BrokerTusStore(
 
                 return state.AcceptedOffset;
             }
+        }
+
+        var cachedProgress = await uploadProgressCache.GetAsync(fileId, cancellationToken);
+        if (cachedProgress is not null)
+        {
+            return cachedProgress.AcceptedOffset;
         }
 
         var committedLength = await storageResolver.GetCommittedStagingLengthAsync(fileId, cancellationToken);
@@ -160,25 +173,27 @@ public class BrokerTusStore(
         return 0;
     }
 
-    public Task<string> CreateFileAsync(long uploadLength, string metadata, CancellationToken cancellationToken)
+    public async Task<string> CreateFileAsync(long uploadLength, string metadata, CancellationToken cancellationToken)
     {
         var fileId = GetFileTransferIdFromRoute();
         _uploadLengths[fileId] = uploadLength;
         _uploadMetadata[fileId] = metadata;
         partialUploadRegistry.RegisterUpload(fileId, uploadLength);
-        _uploadStates[fileId] = new UploadState(uploadLength, initialOffset: 0, azureStorageOptions.Value.ConcurrentUploadThreads);
-        return Task.FromResult(fileId);
+        var state = RegisterUploadState(fileId, uploadLength, initialOffset: 0);
+        await PersistProgressAsync(fileId, state, cancellationToken);
+        return fileId;
     }
 
-    public Task<string> CreatePartialFileAsync(long uploadLength, string metadata, CancellationToken cancellationToken)
+    public async Task<string> CreatePartialFileAsync(long uploadLength, string metadata, CancellationToken cancellationToken)
     {
         var fileTransferId = GetFileTransferIdFromRouteGuid();
         var partialFileId = Guid.NewGuid().ToString("N");
         partialUploadRegistry.RegisterPartial(partialFileId, fileTransferId, uploadLength);
         _uploadLengths[partialFileId] = uploadLength;
         _uploadMetadata[partialFileId] = metadata;
-        _uploadStates[partialFileId] = new UploadState(uploadLength, initialOffset: 0, azureStorageOptions.Value.ConcurrentUploadThreads);
-        return Task.FromResult(partialFileId);
+        var state = RegisterUploadState(partialFileId, uploadLength, initialOffset: 0);
+        await PersistProgressAsync(partialFileId, state, cancellationToken);
+        return partialFileId;
     }
 
     public async Task<string> CreateFinalFileAsync(string[] partialFiles, string metadata, CancellationToken cancellationToken)
@@ -225,14 +240,10 @@ public class BrokerTusStore(
         _uploadMetadata[finalFileId] = metadata;
         partialUploadRegistry.RegisterUpload(finalFileId, totalLength);
         _finalConcatPartials[finalFileId] = normalizedPartialFileIds;
-        _uploadStates[finalFileId] = new UploadState(
-            totalLength,
-            initialOffset: totalLength,
-            azureStorageOptions.Value.ConcurrentUploadThreads)
-        {
-            AcceptedOffset = totalLength,
-            CommittedOffset = totalLength
-        };
+        var state = RegisterUploadState(finalFileId, totalLength, initialOffset: totalLength);
+        state.AcceptedOffset = totalLength;
+        state.CommittedOffset = totalLength;
+        await PersistProgressAsync(finalFileId, state, cancellationToken);
 
         foreach (var partialFileId in normalizedPartialFileIds)
         {
@@ -303,7 +314,7 @@ public class BrokerTusStore(
         partialUploadRegistry.RemoveUpload(fileId);
         _finalConcatPartials.TryRemove(fileId, out _);
         _uploadMetadata.TryRemove(fileId, out _);
-        CleanupUploadState(fileId);
+        await CleanupUploadState(fileId, cancellationToken);
 
         if (expirationDetailsStore is RedisTusExpirationDetailsStore redisExpirationStore)
         {
@@ -383,20 +394,54 @@ public class BrokerTusStore(
         return uploadLength;
     }
 
-    private async Task<UploadState> GetOrCreateUploadStateAsync(string fileId, CancellationToken cancellationToken)
+    private async Task<TusUploadState> GetOrCreateUploadStateAsync(string fileId, CancellationToken cancellationToken)
     {
-        if (_uploadStates.TryGetValue(fileId, out var existingState))
+        if (uploadStateRegistry.TryGet(fileId, out var existingState))
         {
-            return existingState;
+            return existingState!;
+        }
+
+        var cachedProgress = await uploadProgressCache.GetAsync(fileId, cancellationToken);
+        if (cachedProgress is not null)
+        {
+            return uploadStateRegistry.GetOrAdd(fileId, () => CreateStateFromSnapshot(cachedProgress));
         }
 
         var uploadLength = await GetCachedUploadLengthAsync(fileId, cancellationToken);
         var currentOffset = await storageResolver.GetCommittedStagingLengthAsync(fileId, cancellationToken);
-        var newState = new UploadState(uploadLength, currentOffset, azureStorageOptions.Value.ConcurrentUploadThreads);
-        return _uploadStates.GetOrAdd(fileId, newState);
+        return uploadStateRegistry.GetOrAdd(fileId, () => new TusUploadState(uploadLength, currentOffset, _maxParallelBlockUploads));
     }
 
-    private async Task UploadBlockAsync(string fileId, UploadState state, string blockId, byte[] chunk)
+    private TusUploadState RegisterUploadState(string fileId, long uploadLength, long initialOffset)
+        => uploadStateRegistry.GetOrAdd(fileId, () => new TusUploadState(uploadLength, initialOffset, _maxParallelBlockUploads));
+
+    private TusUploadState CreateStateFromSnapshot(TusUploadProgressSnapshot snapshot)
+    {
+        var state = new TusUploadState(snapshot.UploadLength, snapshot.CommittedOffset, _maxParallelBlockUploads);
+        state.AcceptedOffset = snapshot.AcceptedOffset;
+        state.CommittedOffset = snapshot.CommittedOffset;
+        state.NextBlockIndex = snapshot.NextBlockIndex;
+        state.BlockIds.AddRange(snapshot.BlockIds);
+        return state;
+    }
+
+    private async Task PersistProgressAsync(string fileId, TusUploadState state, CancellationToken cancellationToken)
+    {
+        TusUploadProgressSnapshot snapshot;
+        lock (state.SyncRoot)
+        {
+            snapshot = new TusUploadProgressSnapshot(
+                state.UploadLength,
+                state.AcceptedOffset,
+                state.CommittedOffset,
+                state.NextBlockIndex,
+                state.BlockIds.ToList());
+        }
+
+        await uploadProgressCache.SaveAsync(fileId, snapshot, cancellationToken);
+    }
+
+    private async Task UploadBlockAsync(string fileId, TusUploadState state, string blockId, byte[] chunk)
     {
         await state.ConcurrentUploader.WaitAsync();
         try
@@ -410,6 +455,8 @@ public class BrokerTusStore(
                 state.ProgressSignal = NewProgressSignal();
                 previousProgress.TrySetResult(state.CommittedOffset);
             }
+
+            await PersistProgressAsync(fileId, state, CancellationToken.None);
         }
         catch (Exception ex)
         {
@@ -433,7 +480,7 @@ public class BrokerTusStore(
 
     private async Task WaitForCommittedOffsetAsync(
         string fileId,
-        UploadState state,
+        TusUploadState state,
         long targetOffset,
         CancellationToken cancellationToken)
     {
@@ -459,9 +506,8 @@ public class BrokerTusStore(
         }
     }
 
-    private async Task FinalizeUploadAsync(string fileId, UploadState state, CancellationToken cancellationToken)
+    private async Task FinalizeUploadAsync(string fileId, TusUploadState state, CancellationToken cancellationToken)
     {
-        byte[] md5Hash;
         List<string> blockIds;
 
         lock (state.SyncRoot)
@@ -476,9 +522,6 @@ public class BrokerTusStore(
                 throw new TusStoreException($"Buffered TUS upload for file id {fileId} has {state.PendingUploads} pending block uploads.");
             }
 
-            state.UploadMd5.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
-            md5Hash = state.UploadMd5.Hash
-                ?? throw new TusStoreException($"Failed to calculate MD5 for file id {fileId}.");
             blockIds = state.BlockIds.ToList();
         }
 
@@ -487,16 +530,15 @@ public class BrokerTusStore(
             throw new TusStoreException($"Cannot finalize TUS upload for file id {fileId} because no blocks were staged.");
         }
 
-        await storageResolver.CommitTusBlocksAsync(fileId, blockIds, md5Hash, cancellationToken);
+        await storageResolver.CommitTusBlocksAsync(fileId, blockIds, cancellationToken);
+        var md5Hash = await storageResolver.ComputeCommittedStagingMd5Async(fileId, cancellationToken);
+        await storageResolver.SetCommittedStagingMd5Async(fileId, md5Hash, cancellationToken);
     }
 
-    private void CleanupUploadState(string fileId)
+    private async Task CleanupUploadState(string fileId, CancellationToken cancellationToken)
     {
-        if (_uploadStates.TryRemove(fileId, out var state))
-        {
-            state.UploadMd5.Dispose();
-            state.ConcurrentUploader.Dispose();
-        }
+        uploadStateRegistry.Remove(fileId);
+        await uploadProgressCache.RemoveAsync(fileId, cancellationToken);
 
         if (!partialUploadRegistry.IsPartial(fileId))
         {
@@ -535,40 +577,5 @@ public class BrokerTusStore(
     {
         var blockId = blockIndex.ToString("D12");
         return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(blockId));
-    }
-
-    private sealed class UploadState
-    {
-        public UploadState(long uploadLength, long initialOffset, int maxParallelBlockUploads)
-        {
-            UploadLength = uploadLength;
-            AcceptedOffset = initialOffset;
-            CommittedOffset = initialOffset;
-            ProgressSignal = NewProgressSignal();
-            ConcurrentUploader = new SemaphoreSlim(Math.Max(maxParallelBlockUploads, 1));
-            UploadMd5 = MD5.Create();
-        }
-
-        public object SyncRoot { get; } = new();
-
-        public List<string> BlockIds { get; } = new();
-
-        public long UploadLength { get; }
-
-        public long AcceptedOffset { get; set; }
-
-        public long CommittedOffset { get; set; }
-
-        public int PendingUploads { get; set; }
-
-        public long NextBlockIndex { get; set; }
-
-        public Exception? Fault { get; set; }
-
-        public TaskCompletionSource<long> ProgressSignal { get; set; }
-
-        public SemaphoreSlim ConcurrentUploader { get; }
-
-        public MD5 UploadMd5 { get; }
     }
 }

--- a/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
+++ b/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
@@ -121,12 +121,14 @@ public class BrokerTusStore(
 
     private string GetFileTransferIdFromRoute()
     {
-        var fileTransferId = httpContextAccessor.HttpContext?.Request.RouteValues["fileTransferId"]?.ToString();
-        if (string.IsNullOrWhiteSpace(fileTransferId))
+        var httpContext = httpContextAccessor.HttpContext
+            ?? throw new TusStoreException("Missing HTTP context");
+
+        if (!TusRouteHelper.TryGetFileTransferIdFromRoute(httpContext, out var fileTransferId))
         {
-            throw new TusStoreException("Missing fileTransferId route value");
+            throw new TusStoreException("Missing file transfer id in route");
         }
 
-        return fileTransferId;
+        return fileTransferId.ToString();
     }
 }

--- a/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
+++ b/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
@@ -23,34 +23,59 @@ public class BrokerTusStore(
 {
     private readonly ConcurrentDictionary<string, MD5> _uploadMd5Hashers = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, long> _uploadLengths = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, UploadState> _uploadStates = new(StringComparer.OrdinalIgnoreCase);
 
     public async Task<long> AppendDataAsync(string fileId, Stream stream, CancellationToken cancellationToken)
     {
         var store = await GetRequiredStore(fileId, cancellationToken);
-        var md5 = await GetOrCreateUploadMd5Async(store, fileId, cancellationToken);
-        var uploadLength = await GetCachedUploadLengthAsync(store, fileId, cancellationToken);
-        var offsetBefore = await store.GetUploadOffsetAsync(fileId, cancellationToken);
+        var state = await GetOrCreateUploadStateAsync(store, fileId, cancellationToken);
 
-        var bytesWritten = await store.AppendDataAsync(fileId, new Md5ComputingStream(stream, md5), cancellationToken);
-        var newOffset = offsetBefore + bytesWritten;
-
-        if (newOffset >= uploadLength)
+        using var chunkBuffer = new MemoryStream();
+        await stream.CopyToAsync(chunkBuffer, cancellationToken);
+        var chunk = chunkBuffer.ToArray();
+        if (chunk.Length == 0)
         {
-            md5.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
-            if (md5.Hash is not null)
-            {
-                await storageResolver.SetStagingBlobMd5ChecksumAsync(fileId, md5.Hash, cancellationToken);
-            }
-
-            if (_uploadMd5Hashers.TryRemove(fileId, out var hasher))
-            {
-                hasher.Dispose();
-            }
-
-            _uploadLengths.TryRemove(fileId, out _);
+            return 0;
         }
 
-        return bytesWritten;
+        var shouldStartProcessor = false;
+        long acceptedOffset;
+        bool isFinalChunk;
+
+        lock (state.SyncRoot)
+        {
+            if (state.Fault is not null)
+            {
+                throw new TusStoreException($"Buffered TUS upload failed for file id {fileId}. {state.Fault.Message}");
+            }
+
+            state.PendingChunks.Enqueue(chunk);
+            state.AcceptedOffset += chunk.Length;
+            acceptedOffset = state.AcceptedOffset;
+            isFinalChunk = acceptedOffset >= state.UploadLength;
+
+            if (!state.IsProcessing)
+            {
+                state.IsProcessing = true;
+                shouldStartProcessor = true;
+            }
+        }
+
+        if (shouldStartProcessor)
+        {
+            _ = Task.Run(() => ProcessPendingChunksAsync(fileId, store, state));
+        }
+
+        // For intermediate chunks we ACK as soon as bytes are read into memory.
+        // For the final chunk we still wait until all buffered data is committed to storage.
+        if (isFinalChunk)
+        {
+            await WaitForCommittedOffsetAsync(fileId, state, acceptedOffset, cancellationToken);
+            await FinalizeUploadChecksumAsync(fileId, state, cancellationToken);
+            CleanupUploadState(fileId);
+        }
+
+        return chunk.Length;
     }
 
     public async Task<bool> FileExistAsync(string fileId, CancellationToken cancellationToken)
@@ -67,6 +92,19 @@ public class BrokerTusStore(
 
     public async Task<long> GetUploadOffsetAsync(string fileId, CancellationToken cancellationToken)
     {
+        if (_uploadStates.TryGetValue(fileId, out var state))
+        {
+            lock (state.SyncRoot)
+            {
+                if (state.Fault is not null)
+                {
+                    throw new TusStoreException($"Buffered TUS upload failed for file id {fileId}. {state.Fault.Message}");
+                }
+
+                return state.AcceptedOffset;
+            }
+        }
+
         var store = await GetRequiredStore(fileId, cancellationToken);
         return await store.GetUploadOffsetAsync(fileId, cancellationToken);
     }
@@ -77,6 +115,7 @@ public class BrokerTusStore(
         var store = await GetRequiredStore(fileTransferId, cancellationToken);
         var fileId = await store.CreateFileAsync(uploadLength, metadata, cancellationToken);
         _uploadLengths[fileId] = uploadLength;
+        _uploadStates[fileId] = new UploadState(uploadLength, initialOffset: 0);
         return fileId;
     }
 
@@ -96,12 +135,7 @@ public class BrokerTusStore(
     {
         var store = await GetRequiredStore(fileId, cancellationToken);
         await store.DeleteFileAsync(fileId, cancellationToken);
-        if (_uploadMd5Hashers.TryRemove(fileId, out var hasher))
-        {
-            hasher.Dispose();
-        }
-
-        _uploadLengths.TryRemove(fileId, out _);
+        CleanupUploadState(fileId);
 
         if (expirationDetailsStore is RedisTusExpirationDetailsStore redisExpirationStore)
         {
@@ -166,6 +200,22 @@ public class BrokerTusStore(
         return uploadLength;
     }
 
+    private async Task<UploadState> GetOrCreateUploadStateAsync(
+        AzureBlobTusStore store,
+        string fileId,
+        CancellationToken cancellationToken)
+    {
+        if (_uploadStates.TryGetValue(fileId, out var existingState))
+        {
+            return existingState;
+        }
+
+        var uploadLength = await GetCachedUploadLengthAsync(store, fileId, cancellationToken);
+        var currentOffset = await store.GetUploadOffsetAsync(fileId, cancellationToken);
+        var newState = new UploadState(uploadLength, currentOffset);
+        return _uploadStates.GetOrAdd(fileId, newState);
+    }
+
     private async Task<MD5> GetOrCreateUploadMd5Async(AzureBlobTusStore store, string fileId, CancellationToken cancellationToken)
     {
         if (_uploadMd5Hashers.TryGetValue(fileId, out var existing))
@@ -196,6 +246,119 @@ public class BrokerTusStore(
         return md5;
     }
 
+    private async Task ProcessPendingChunksAsync(string fileId, AzureBlobTusStore store, UploadState state)
+    {
+        while (true)
+        {
+            byte[]? chunk;
+            lock (state.SyncRoot)
+            {
+                if (state.PendingChunks.Count == 0)
+                {
+                    state.IsProcessing = false;
+                    return;
+                }
+
+                chunk = state.PendingChunks.Dequeue();
+            }
+
+            try
+            {
+                await using var chunkStream = new MemoryStream(chunk, writable: false);
+                var bytesWritten = await store.AppendDataAsync(fileId, chunkStream, CancellationToken.None);
+                if (bytesWritten != chunk.Length)
+                {
+                    throw new TusStoreException($"Unexpected append result for file id {fileId}. Expected {chunk.Length} bytes, wrote {bytesWritten} bytes.");
+                }
+
+                var md5 = await GetOrCreateUploadMd5Async(store, fileId, CancellationToken.None);
+                md5.TransformBlock(chunk, 0, chunk.Length, null, 0);
+
+                lock (state.SyncRoot)
+                {
+                    state.CommittedOffset += bytesWritten;
+                    var previousProgress = state.ProgressSignal;
+                    state.ProgressSignal = NewProgressSignal();
+                    previousProgress.TrySetResult(state.CommittedOffset);
+                }
+            }
+            catch (Exception ex)
+            {
+                lock (state.SyncRoot)
+                {
+                    state.Fault = ex;
+                    state.IsProcessing = false;
+                    var previousProgress = state.ProgressSignal;
+                    state.ProgressSignal = NewProgressSignal();
+                    previousProgress.TrySetException(ex);
+                }
+
+                return;
+            }
+        }
+    }
+
+    private static TaskCompletionSource<long> NewProgressSignal()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private async Task WaitForCommittedOffsetAsync(
+        string fileId,
+        UploadState state,
+        long targetOffset,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            Task waitTask;
+            lock (state.SyncRoot)
+            {
+                if (state.Fault is not null)
+                {
+                    throw new TusStoreException($"Buffered TUS upload failed for file id {fileId}. {state.Fault.Message}");
+                }
+
+                if (state.CommittedOffset >= targetOffset)
+                {
+                    return;
+                }
+
+                waitTask = state.ProgressSignal.Task;
+            }
+
+            await waitTask.WaitAsync(cancellationToken);
+        }
+    }
+
+    private async Task FinalizeUploadChecksumAsync(string fileId, UploadState state, CancellationToken cancellationToken)
+    {
+        lock (state.SyncRoot)
+        {
+            if (state.Fault is not null)
+            {
+                throw new TusStoreException($"Buffered TUS upload failed for file id {fileId}. {state.Fault.Message}");
+            }
+        }
+
+        var store = await GetRequiredStore(fileId, cancellationToken);
+        var md5 = await GetOrCreateUploadMd5Async(store, fileId, cancellationToken);
+        md5.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+        if (md5.Hash is not null)
+        {
+            await storageResolver.SetStagingBlobMd5ChecksumAsync(fileId, md5.Hash, cancellationToken);
+        }
+    }
+
+    private void CleanupUploadState(string fileId)
+    {
+        if (_uploadMd5Hashers.TryRemove(fileId, out var hasher))
+        {
+            hasher.Dispose();
+        }
+
+        _uploadLengths.TryRemove(fileId, out _);
+        _uploadStates.TryRemove(fileId, out _);
+    }
+
     private async Task<AzureBlobTusStore> GetRequiredStore(string fileId, CancellationToken cancellationToken)
     {
         var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
@@ -218,5 +381,32 @@ public class BrokerTusStore(
         }
 
         return fileTransferId.ToString();
+    }
+
+    private sealed class UploadState
+    {
+        public UploadState(long uploadLength, long initialOffset)
+        {
+            UploadLength = uploadLength;
+            AcceptedOffset = initialOffset;
+            CommittedOffset = initialOffset;
+            ProgressSignal = NewProgressSignal();
+        }
+
+        public object SyncRoot { get; } = new();
+
+        public Queue<byte[]> PendingChunks { get; } = new();
+
+        public long UploadLength { get; }
+
+        public long AcceptedOffset { get; set; }
+
+        public long CommittedOffset { get; set; }
+
+        public bool IsProcessing { get; set; }
+
+        public Exception? Fault { get; set; }
+
+        public TaskCompletionSource<long> ProgressSignal { get; set; }
     }
 }

--- a/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
+++ b/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Options;
 
 using tusdotnet.Interfaces;
 using tusdotnet.Models;
+using tusdotnet.Models.Concatenation;
 
 using Altinn.Broker.Core.Options;
 using Xtensible.TusDotNet.Azure;
@@ -15,6 +16,7 @@ namespace Altinn.Broker.Integrations.Tus;
 public class BrokerTusStore(
     ITusStorageResolver storageResolver,
     ITusExpirationDetailsStore expirationDetailsStore,
+    ITusPartialUploadRegistry partialUploadRegistry,
     IHttpContextAccessor httpContextAccessor,
     IOptions<AzureStorageOptions> azureStorageOptions) :
     ITusStore,
@@ -22,15 +24,17 @@ public class BrokerTusStore(
     ITusReadableStore,
     ITusTerminationStore,
     ITusExpirationStore,
-    ITusChecksumStore
+    ITusChecksumStore,
+    ITusConcatenationStore
 {
     private readonly ConcurrentDictionary<string, long> _uploadLengths = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, string> _uploadMetadata = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, UploadState> _uploadStates = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, string[]> _finalConcatPartials = new(StringComparer.OrdinalIgnoreCase);
 
     public async Task<long> AppendDataAsync(string fileId, Stream stream, CancellationToken cancellationToken)
     {
-        var store = await GetRequiredStore(fileId, cancellationToken);
-        var state = await GetOrCreateUploadStateAsync(store, fileId, cancellationToken);
+        var state = await GetOrCreateUploadStateAsync(fileId, cancellationToken);
 
         using var chunkBuffer = new MemoryStream();
         await stream.CopyToAsync(chunkBuffer, cancellationToken);
@@ -63,8 +67,6 @@ public class BrokerTusStore(
 
         _ = Task.Run(() => UploadBlockAsync(fileId, state, blockId, chunk));
 
-        // For intermediate chunks we ACK as soon as bytes are read into memory.
-        // For the final chunk we still wait until all buffered data is committed to storage.
         if (isFinalChunk)
         {
             await WaitForCommittedOffsetAsync(fileId, state, acceptedOffset, cancellationToken);
@@ -77,14 +79,34 @@ public class BrokerTusStore(
 
     public async Task<bool> FileExistAsync(string fileId, CancellationToken cancellationToken)
     {
+        if (_uploadLengths.ContainsKey(fileId) || _uploadStates.ContainsKey(fileId))
+        {
+            return true;
+        }
+
+        if (await storageResolver.StagingBlobExistsAsync(fileId, cancellationToken))
+        {
+            return true;
+        }
+
         var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
         return store is not null && await store.FileExistAsync(fileId, cancellationToken);
     }
 
     public async Task<long?> GetUploadLengthAsync(string fileId, CancellationToken cancellationToken)
     {
-        var store = await GetRequiredStore(fileId, cancellationToken);
-        return await store.GetUploadLengthAsync(fileId, cancellationToken);
+        if (_uploadLengths.TryGetValue(fileId, out var cachedLength))
+        {
+            return cachedLength;
+        }
+
+        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
+        if (store is not null)
+        {
+            return await store.GetUploadLengthAsync(fileId, cancellationToken);
+        }
+
+        return null;
     }
 
     public async Task<long> GetUploadOffsetAsync(string fileId, CancellationToken cancellationToken)
@@ -102,36 +124,156 @@ public class BrokerTusStore(
             }
         }
 
-        var store = await GetRequiredStore(fileId, cancellationToken);
-        return await store.GetUploadOffsetAsync(fileId, cancellationToken);
+        var committedLength = await storageResolver.GetCommittedStagingLengthAsync(fileId, cancellationToken);
+        if (committedLength > 0)
+        {
+            return committedLength;
+        }
+
+        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
+        if (store is not null)
+        {
+            return await store.GetUploadOffsetAsync(fileId, cancellationToken);
+        }
+
+        return 0;
     }
 
-    public async Task<string> CreateFileAsync(long uploadLength, string metadata, CancellationToken cancellationToken)
+    public Task<string> CreateFileAsync(long uploadLength, string metadata, CancellationToken cancellationToken)
     {
-        var fileTransferId = GetFileTransferIdFromRoute();
-        var store = await GetRequiredStore(fileTransferId, cancellationToken);
-        var fileId = await store.CreateFileAsync(uploadLength, metadata, cancellationToken);
+        var fileId = GetFileTransferIdFromRoute();
         _uploadLengths[fileId] = uploadLength;
+        _uploadMetadata[fileId] = metadata;
         _uploadStates[fileId] = new UploadState(uploadLength, initialOffset: 0, azureStorageOptions.Value.ConcurrentUploadThreads);
-        return fileId;
+        return Task.FromResult(fileId);
+    }
+
+    public Task<string> CreatePartialFileAsync(long uploadLength, string metadata, CancellationToken cancellationToken)
+    {
+        var fileTransferId = GetFileTransferIdFromRouteGuid();
+        var partialFileId = Guid.NewGuid().ToString("N");
+        partialUploadRegistry.RegisterPartial(partialFileId, fileTransferId, uploadLength);
+        _uploadLengths[partialFileId] = uploadLength;
+        _uploadMetadata[partialFileId] = metadata;
+        _uploadStates[partialFileId] = new UploadState(uploadLength, initialOffset: 0, azureStorageOptions.Value.ConcurrentUploadThreads);
+        return Task.FromResult(partialFileId);
+    }
+
+    public async Task<string> CreateFinalFileAsync(string[] partialFiles, string metadata, CancellationToken cancellationToken)
+    {
+        var fileTransferId = GetFileTransferIdFromRouteGuid();
+        var finalFileId = fileTransferId.ToString();
+
+        long totalLength = 0;
+        foreach (var partialFileReference in partialFiles)
+        {
+            var partialFileId = NormalizePartialFileId(partialFileReference);
+            if (!partialUploadRegistry.TryGetPartialInfo(partialFileId, out var partialFileTransferId, out var partialLength))
+            {
+                throw new TusStoreException($"Unknown partial upload id {partialFileId}.");
+            }
+
+            if (partialFileTransferId != fileTransferId)
+            {
+                throw new TusStoreException($"Partial upload {partialFileId} does not belong to file transfer {fileTransferId}.");
+            }
+
+            var committedLength = await storageResolver.GetCommittedStagingLengthAsync(partialFileId, cancellationToken);
+            if (committedLength != partialLength)
+            {
+                throw new TusStoreException(
+                    $"Partial upload {partialFileId} is incomplete. Expected {partialLength} bytes, found {committedLength}.");
+            }
+
+            totalLength += partialLength;
+        }
+
+        var normalizedPartialFileIds = partialFiles.Select(NormalizePartialFileId).ToArray();
+        var concatenatedLength = await storageResolver.ConcatenatePartialStagingBlobsAsync(
+            finalFileId,
+            normalizedPartialFileIds,
+            cancellationToken);
+        if (concatenatedLength != totalLength)
+        {
+            throw new TusStoreException(
+                $"Concatenated upload length mismatch for file transfer {fileTransferId}. Expected {totalLength}, got {concatenatedLength}.");
+        }
+
+        _uploadLengths[finalFileId] = totalLength;
+        _uploadMetadata[finalFileId] = metadata;
+        _finalConcatPartials[finalFileId] = normalizedPartialFileIds;
+        _uploadStates[finalFileId] = new UploadState(
+            totalLength,
+            initialOffset: totalLength,
+            azureStorageOptions.Value.ConcurrentUploadThreads)
+        {
+            AcceptedOffset = totalLength,
+            CommittedOffset = totalLength
+        };
+
+        foreach (var partialFileId in normalizedPartialFileIds)
+        {
+            partialUploadRegistry.RemovePartial(partialFileId);
+        }
+
+        return finalFileId;
+    }
+
+    public Task<FileConcat?> GetUploadConcatAsync(string fileId, CancellationToken cancellationToken)
+    {
+        if (partialUploadRegistry.IsPartial(fileId))
+        {
+            return Task.FromResult<FileConcat?>(new FileConcatPartial());
+        }
+
+        if (_finalConcatPartials.TryGetValue(fileId, out var partialFiles))
+        {
+            return Task.FromResult<FileConcat?>(new FileConcatFinal(partialFiles));
+        }
+
+        return Task.FromResult<FileConcat?>(null);
     }
 
     public async Task<string> GetUploadMetadataAsync(string fileId, CancellationToken cancellationToken)
     {
-        var store = await GetRequiredStore(fileId, cancellationToken);
-        return await store.GetUploadMetadataAsync(fileId, cancellationToken);
+        if (_uploadMetadata.TryGetValue(fileId, out var metadata))
+        {
+            return metadata;
+        }
+
+        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
+        if (store is not null)
+        {
+            return await store.GetUploadMetadataAsync(fileId, cancellationToken);
+        }
+
+        return string.Empty;
     }
 
     public async Task<ITusFile> GetFileAsync(string fileId, CancellationToken cancellationToken)
     {
-        var store = await GetRequiredStore(fileId, cancellationToken);
-        return await store.GetFileAsync(fileId, cancellationToken);
+        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
+        if (store is not null && await store.FileExistAsync(fileId, cancellationToken))
+        {
+            return await store.GetFileAsync(fileId, cancellationToken);
+        }
+
+        throw new TusStoreException($"No TUS file found for file id {fileId}");
     }
 
     public async Task DeleteFileAsync(string fileId, CancellationToken cancellationToken)
     {
-        var store = await GetRequiredStore(fileId, cancellationToken);
-        await store.DeleteFileAsync(fileId, cancellationToken);
+        await storageResolver.DeleteStagingBlobAsync(fileId, cancellationToken);
+
+        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
+        if (store is not null && await store.FileExistAsync(fileId, cancellationToken))
+        {
+            await store.DeleteFileAsync(fileId, cancellationToken);
+        }
+
+        partialUploadRegistry.RemovePartial(fileId);
+        _finalConcatPartials.TryRemove(fileId, out _);
+        _uploadMetadata.TryRemove(fileId, out _);
         CleanupUploadState(fileId);
 
         if (expirationDetailsStore is RedisTusExpirationDetailsStore redisExpirationStore)
@@ -177,38 +319,37 @@ public class BrokerTusStore(
 
     public async Task<bool> VerifyChecksumAsync(string fileId, string algorithm, byte[] checksum, CancellationToken cancellationToken)
     {
-        var store = await GetRequiredStore(fileId, cancellationToken);
-        return await store.VerifyChecksumAsync(fileId, algorithm, checksum, cancellationToken);
+        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
+        if (store is not null && await store.FileExistAsync(fileId, cancellationToken))
+        {
+            return await store.VerifyChecksumAsync(fileId, algorithm, checksum, cancellationToken);
+        }
+
+        return false;
     }
 
-    private async Task<long> GetCachedUploadLengthAsync(
-        AzureBlobTusStore store,
-        string fileId,
-        CancellationToken cancellationToken)
+    private async Task<long> GetCachedUploadLengthAsync(string fileId, CancellationToken cancellationToken)
     {
         if (_uploadLengths.TryGetValue(fileId, out var cachedLength))
         {
             return cachedLength;
         }
 
-        var uploadLength = await store.GetUploadLengthAsync(fileId, cancellationToken)
+        var uploadLength = await GetUploadLengthAsync(fileId, cancellationToken)
             ?? throw new TusStoreException($"Upload length is missing for file id {fileId}");
         _uploadLengths[fileId] = uploadLength;
         return uploadLength;
     }
 
-    private async Task<UploadState> GetOrCreateUploadStateAsync(
-        AzureBlobTusStore store,
-        string fileId,
-        CancellationToken cancellationToken)
+    private async Task<UploadState> GetOrCreateUploadStateAsync(string fileId, CancellationToken cancellationToken)
     {
         if (_uploadStates.TryGetValue(fileId, out var existingState))
         {
             return existingState;
         }
 
-        var uploadLength = await GetCachedUploadLengthAsync(store, fileId, cancellationToken);
-        var currentOffset = await store.GetUploadOffsetAsync(fileId, cancellationToken);
+        var uploadLength = await GetCachedUploadLengthAsync(fileId, cancellationToken);
+        var currentOffset = await storageResolver.GetCommittedStagingLengthAsync(fileId, cancellationToken);
         var newState = new UploadState(uploadLength, currentOffset, azureStorageOptions.Value.ConcurrentUploadThreads);
         return _uploadStates.GetOrAdd(fileId, newState);
     }
@@ -315,21 +456,16 @@ public class BrokerTusStore(
             state.ConcurrentUploader.Dispose();
         }
 
-        _uploadLengths.TryRemove(fileId, out _);
-    }
-
-    private async Task<AzureBlobTusStore> GetRequiredStore(string fileId, CancellationToken cancellationToken)
-    {
-        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
-        if (store is null)
+        if (!partialUploadRegistry.IsPartial(fileId))
         {
-            throw new TusStoreException($"No TUS store found for file id {fileId}");
+            _uploadLengths.TryRemove(fileId, out _);
         }
-
-        return store;
     }
 
     private string GetFileTransferIdFromRoute()
+        => GetFileTransferIdFromRouteGuid().ToString();
+
+    private Guid GetFileTransferIdFromRouteGuid()
     {
         var httpContext = httpContextAccessor.HttpContext
             ?? throw new TusStoreException("Missing HTTP context");
@@ -339,7 +475,18 @@ public class BrokerTusStore(
             throw new TusStoreException("Missing file transfer id in route");
         }
 
-        return fileTransferId.ToString();
+        return fileTransferId;
+    }
+
+    private static string NormalizePartialFileId(string partialFileReference)
+    {
+        var trimmedReference = partialFileReference.Trim();
+        if (!trimmedReference.Contains('/'))
+        {
+            return trimmedReference;
+        }
+
+        return trimmedReference.TrimEnd('/').Split('/').Last();
     }
 
     private static string BuildBlockId(long blockIndex)

--- a/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
+++ b/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
@@ -1,0 +1,132 @@
+using Microsoft.AspNetCore.Http;
+
+using tusdotnet.Interfaces;
+using tusdotnet.Models;
+
+using Xtensible.TusDotNet.Azure;
+
+namespace Altinn.Broker.Integrations.Tus;
+
+public class BrokerTusStore(
+    ITusStorageResolver storageResolver,
+    ITusExpirationDetailsStore expirationDetailsStore,
+    IHttpContextAccessor httpContextAccessor) :
+    ITusStore,
+    ITusCreationStore,
+    ITusReadableStore,
+    ITusTerminationStore,
+    ITusExpirationStore
+{
+    public async Task<long> AppendDataAsync(string fileId, Stream stream, CancellationToken cancellationToken)
+    {
+        var store = await GetRequiredStore(fileId, cancellationToken);
+        return await store.AppendDataAsync(fileId, stream, cancellationToken);
+    }
+
+    public async Task<bool> FileExistAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
+        return store is not null && await store.FileExistAsync(fileId, cancellationToken);
+    }
+
+    public async Task<long?> GetUploadLengthAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var store = await GetRequiredStore(fileId, cancellationToken);
+        return await store.GetUploadLengthAsync(fileId, cancellationToken);
+    }
+
+    public async Task<long> GetUploadOffsetAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var store = await GetRequiredStore(fileId, cancellationToken);
+        return await store.GetUploadOffsetAsync(fileId, cancellationToken);
+    }
+
+    public async Task<string> CreateFileAsync(long uploadLength, string metadata, CancellationToken cancellationToken)
+    {
+        var fileTransferId = GetFileTransferIdFromRoute();
+        var store = await GetRequiredStore(fileTransferId, cancellationToken);
+        return await store.CreateFileAsync(uploadLength, metadata, cancellationToken);
+    }
+
+    public async Task<string> GetUploadMetadataAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var store = await GetRequiredStore(fileId, cancellationToken);
+        return await store.GetUploadMetadataAsync(fileId, cancellationToken);
+    }
+
+    public async Task<ITusFile> GetFileAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var store = await GetRequiredStore(fileId, cancellationToken);
+        return await store.GetFileAsync(fileId, cancellationToken);
+    }
+
+    public async Task DeleteFileAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var store = await GetRequiredStore(fileId, cancellationToken);
+        await store.DeleteFileAsync(fileId, cancellationToken);
+        if (expirationDetailsStore is RedisTusExpirationDetailsStore redisExpirationStore)
+        {
+            await redisExpirationStore.RemoveExpirationAsync(fileId, cancellationToken);
+        }
+    }
+
+    public Task SetExpirationAsync(string fileId, DateTimeOffset expires, CancellationToken cancellationToken)
+        => expirationDetailsStore.SetExpirationAsync(fileId, expires, cancellationToken);
+
+    public Task<DateTimeOffset?> GetExpirationAsync(string fileId, CancellationToken cancellationToken)
+        => expirationDetailsStore.GetExpirationAsync(fileId, cancellationToken);
+
+    public Task<IEnumerable<string>> GetExpiredFilesAsync(CancellationToken cancellationToken)
+        => expirationDetailsStore.GetExpiredFilesAsync(cancellationToken);
+
+    public async Task<int> RemoveExpiredFilesAsync(CancellationToken cancellationToken)
+    {
+        var expiredFiles = await expirationDetailsStore.GetExpiredFilesAsync(cancellationToken);
+        var removed = 0;
+        foreach (var fileId in expiredFiles)
+        {
+            try
+            {
+                if (await FileExistAsync(fileId, cancellationToken))
+                {
+                    await DeleteFileAsync(fileId, cancellationToken);
+                    removed++;
+                }
+            }
+            catch (TusStoreException)
+            {
+                // File may already have been removed.
+            }
+        }
+
+        return removed;
+    }
+
+    public Task<IEnumerable<string>> GetSupportedAlgorithmsAsync(CancellationToken cancellationToken)
+        => Task.FromResult(Enumerable.Empty<string>());
+
+    public Task<bool> VerifyChecksumAsync(string fileId, string algorithm, byte[] checksum, CancellationToken cancellationToken)
+        => Task.FromResult(false);
+
+    private async Task<AzureBlobTusStore> GetRequiredStore(string fileId, CancellationToken cancellationToken)
+    {
+        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
+        if (store is null)
+        {
+            throw new TusStoreException($"No TUS store found for file id {fileId}");
+        }
+
+        return store;
+    }
+
+    private string GetFileTransferIdFromRoute()
+    {
+        var fileTransferId = httpContextAccessor.HttpContext?.Request.RouteValues["fileTransferId"]?.ToString();
+        if (string.IsNullOrWhiteSpace(fileTransferId))
+        {
+            throw new TusStoreException("Missing fileTransferId route value");
+        }
+
+        return fileTransferId;
+    }
+}

--- a/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
+++ b/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
@@ -1,3 +1,6 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+
 using Microsoft.AspNetCore.Http;
 
 using tusdotnet.Interfaces;
@@ -15,12 +18,44 @@ public class BrokerTusStore(
     ITusCreationStore,
     ITusReadableStore,
     ITusTerminationStore,
-    ITusExpirationStore
+    ITusExpirationStore,
+    ITusChecksumStore
 {
+    private readonly ConcurrentDictionary<string, MD5> _uploadMd5Hashers = new(StringComparer.OrdinalIgnoreCase);
+
     public async Task<long> AppendDataAsync(string fileId, Stream stream, CancellationToken cancellationToken)
     {
         var store = await GetRequiredStore(fileId, cancellationToken);
-        return await store.AppendDataAsync(fileId, stream, cancellationToken);
+        var md5 = await GetOrCreateUploadMd5Async(store, fileId, cancellationToken);
+
+        using var chunkData = new MemoryStream();
+        await stream.CopyToAsync(chunkData, cancellationToken);
+        var chunkBytes = chunkData.ToArray();
+        if (chunkBytes.Length > 0)
+        {
+            md5.TransformBlock(chunkBytes, 0, chunkBytes.Length, null, 0);
+        }
+
+        await using var chunkStream = new MemoryStream(chunkBytes, writable: false);
+        var bytesWritten = await store.AppendDataAsync(fileId, chunkStream, cancellationToken);
+
+        var uploadLength = await store.GetUploadLengthAsync(fileId, cancellationToken);
+        var offset = await store.GetUploadOffsetAsync(fileId, cancellationToken);
+        if (uploadLength is not null && offset >= uploadLength.Value)
+        {
+            md5.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+            if (md5.Hash is not null)
+            {
+                await storageResolver.SetStagingBlobMd5ChecksumAsync(fileId, md5.Hash, cancellationToken);
+            }
+
+            if (_uploadMd5Hashers.TryRemove(fileId, out var hasher))
+            {
+                hasher.Dispose();
+            }
+        }
+
+        return bytesWritten;
     }
 
     public async Task<bool> FileExistAsync(string fileId, CancellationToken cancellationToken)
@@ -64,6 +99,11 @@ public class BrokerTusStore(
     {
         var store = await GetRequiredStore(fileId, cancellationToken);
         await store.DeleteFileAsync(fileId, cancellationToken);
+        if (_uploadMd5Hashers.TryRemove(fileId, out var hasher))
+        {
+            hasher.Dispose();
+        }
+
         if (expirationDetailsStore is RedisTusExpirationDetailsStore redisExpirationStore)
         {
             await redisExpirationStore.RemoveExpirationAsync(fileId, cancellationToken);
@@ -103,10 +143,43 @@ public class BrokerTusStore(
     }
 
     public Task<IEnumerable<string>> GetSupportedAlgorithmsAsync(CancellationToken cancellationToken)
-        => Task.FromResult(Enumerable.Empty<string>());
+        => Task.FromResult<IEnumerable<string>>(new[] { "md5" });
 
-    public Task<bool> VerifyChecksumAsync(string fileId, string algorithm, byte[] checksum, CancellationToken cancellationToken)
-        => Task.FromResult(false);
+    public async Task<bool> VerifyChecksumAsync(string fileId, string algorithm, byte[] checksum, CancellationToken cancellationToken)
+    {
+        var store = await GetRequiredStore(fileId, cancellationToken);
+        return await store.VerifyChecksumAsync(fileId, algorithm, checksum, cancellationToken);
+    }
+
+    private async Task<MD5> GetOrCreateUploadMd5Async(AzureBlobTusStore store, string fileId, CancellationToken cancellationToken)
+    {
+        if (_uploadMd5Hashers.TryGetValue(fileId, out var existing))
+        {
+            return existing;
+        }
+
+        var md5 = MD5.Create();
+        var offset = await store.GetUploadOffsetAsync(fileId, cancellationToken);
+        if (offset > 0)
+        {
+            var file = await store.GetFileAsync(fileId, cancellationToken);
+            await using var content = await file.GetContentAsync(cancellationToken);
+            var buffer = new byte[1024 * 1024];
+            int read;
+            while ((read = await content.ReadAsync(buffer, cancellationToken)) > 0)
+            {
+                md5.TransformBlock(buffer, 0, read, null, 0);
+            }
+        }
+
+        if (!_uploadMd5Hashers.TryAdd(fileId, md5))
+        {
+            md5.Dispose();
+            return _uploadMd5Hashers[fileId];
+        }
+
+        return md5;
+    }
 
     private async Task<AzureBlobTusStore> GetRequiredStore(string fileId, CancellationToken cancellationToken)
     {

--- a/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
+++ b/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
@@ -84,7 +84,17 @@ public class BrokerTusStore(
             return true;
         }
 
+        if (partialUploadRegistry.IsKnownUpload(fileId))
+        {
+            return true;
+        }
+
         if (await storageResolver.StagingBlobExistsAsync(fileId, cancellationToken))
+        {
+            return true;
+        }
+
+        if (await storageResolver.DestinationBlobExistsAsync(fileId, cancellationToken))
         {
             return true;
         }
@@ -98,6 +108,11 @@ public class BrokerTusStore(
         if (_uploadLengths.TryGetValue(fileId, out var cachedLength))
         {
             return cachedLength;
+        }
+
+        if (partialUploadRegistry.TryGetUploadLength(fileId, out var registeredLength))
+        {
+            return registeredLength;
         }
 
         var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
@@ -130,6 +145,12 @@ public class BrokerTusStore(
             return committedLength;
         }
 
+        var destinationLength = await storageResolver.GetDestinationBlobLengthAsync(fileId, cancellationToken);
+        if (destinationLength > 0)
+        {
+            return destinationLength;
+        }
+
         var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
         if (store is not null)
         {
@@ -144,6 +165,7 @@ public class BrokerTusStore(
         var fileId = GetFileTransferIdFromRoute();
         _uploadLengths[fileId] = uploadLength;
         _uploadMetadata[fileId] = metadata;
+        partialUploadRegistry.RegisterUpload(fileId, uploadLength);
         _uploadStates[fileId] = new UploadState(uploadLength, initialOffset: 0, azureStorageOptions.Value.ConcurrentUploadThreads);
         return Task.FromResult(fileId);
     }
@@ -201,6 +223,7 @@ public class BrokerTusStore(
 
         _uploadLengths[finalFileId] = totalLength;
         _uploadMetadata[finalFileId] = metadata;
+        partialUploadRegistry.RegisterUpload(finalFileId, totalLength);
         _finalConcatPartials[finalFileId] = normalizedPartialFileIds;
         _uploadStates[finalFileId] = new UploadState(
             totalLength,
@@ -272,6 +295,7 @@ public class BrokerTusStore(
         }
 
         partialUploadRegistry.RemovePartial(fileId);
+        partialUploadRegistry.RemoveUpload(fileId);
         _finalConcatPartials.TryRemove(fileId, out _);
         _uploadMetadata.TryRemove(fileId, out _);
         CleanupUploadState(fileId);

--- a/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
+++ b/src/Altinn.Broker.Integrations/Tus/BrokerTusStore.cs
@@ -99,8 +99,8 @@ public class BrokerTusStore(
             return true;
         }
 
-        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
-        return store is not null && await store.FileExistAsync(fileId, cancellationToken);
+        var legacyStore = await GetLegacyAppendBlobStoreIfExistsAsync(fileId, cancellationToken);
+        return legacyStore is not null;
     }
 
     public async Task<long?> GetUploadLengthAsync(string fileId, CancellationToken cancellationToken)
@@ -115,10 +115,10 @@ public class BrokerTusStore(
             return registeredLength;
         }
 
-        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
-        if (store is not null)
+        var legacyStore = await GetLegacyAppendBlobStoreIfExistsAsync(fileId, cancellationToken);
+        if (legacyStore is not null)
         {
-            return await store.GetUploadLengthAsync(fileId, cancellationToken);
+            return await legacyStore.GetUploadLengthAsync(fileId, cancellationToken);
         }
 
         return null;
@@ -151,10 +151,10 @@ public class BrokerTusStore(
             return destinationLength;
         }
 
-        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
-        if (store is not null)
+        var legacyStore = await GetLegacyAppendBlobStoreIfExistsAsync(fileId, cancellationToken);
+        if (legacyStore is not null)
         {
-            return await store.GetUploadOffsetAsync(fileId, cancellationToken);
+            return await legacyStore.GetUploadOffsetAsync(fileId, cancellationToken);
         }
 
         return 0;
@@ -264,10 +264,15 @@ public class BrokerTusStore(
             return metadata;
         }
 
-        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
-        if (store is not null)
+        if (partialUploadRegistry.IsKnownUpload(fileId))
         {
-            return await store.GetUploadMetadataAsync(fileId, cancellationToken);
+            return string.Empty;
+        }
+
+        var legacyStore = await GetLegacyAppendBlobStoreIfExistsAsync(fileId, cancellationToken);
+        if (legacyStore is not null)
+        {
+            return await legacyStore.GetUploadMetadataAsync(fileId, cancellationToken);
         }
 
         return string.Empty;
@@ -275,10 +280,10 @@ public class BrokerTusStore(
 
     public async Task<ITusFile> GetFileAsync(string fileId, CancellationToken cancellationToken)
     {
-        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
-        if (store is not null && await store.FileExistAsync(fileId, cancellationToken))
+        var legacyStore = await GetLegacyAppendBlobStoreIfExistsAsync(fileId, cancellationToken);
+        if (legacyStore is not null)
         {
-            return await store.GetFileAsync(fileId, cancellationToken);
+            return await legacyStore.GetFileAsync(fileId, cancellationToken);
         }
 
         throw new TusStoreException($"No TUS file found for file id {fileId}");
@@ -288,10 +293,10 @@ public class BrokerTusStore(
     {
         await storageResolver.DeleteStagingBlobAsync(fileId, cancellationToken);
 
-        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
-        if (store is not null && await store.FileExistAsync(fileId, cancellationToken))
+        var legacyStore = await GetLegacyAppendBlobStoreIfExistsAsync(fileId, cancellationToken);
+        if (legacyStore is not null)
         {
-            await store.DeleteFileAsync(fileId, cancellationToken);
+            await legacyStore.DeleteFileAsync(fileId, cancellationToken);
         }
 
         partialUploadRegistry.RemovePartial(fileId);
@@ -343,13 +348,26 @@ public class BrokerTusStore(
 
     public async Task<bool> VerifyChecksumAsync(string fileId, string algorithm, byte[] checksum, CancellationToken cancellationToken)
     {
-        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
-        if (store is not null && await store.FileExistAsync(fileId, cancellationToken))
+        var legacyStore = await GetLegacyAppendBlobStoreIfExistsAsync(fileId, cancellationToken);
+        if (legacyStore is not null)
         {
-            return await store.VerifyChecksumAsync(fileId, algorithm, checksum, cancellationToken);
+            return await legacyStore.VerifyChecksumAsync(fileId, algorithm, checksum, cancellationToken);
         }
 
         return false;
+    }
+
+    private async Task<AzureBlobTusStore?> GetLegacyAppendBlobStoreIfExistsAsync(
+        string fileId,
+        CancellationToken cancellationToken)
+    {
+        var store = await storageResolver.GetStoreForFileAsync(fileId, cancellationToken);
+        if (store is null || !await store.FileExistAsync(fileId, cancellationToken))
+        {
+            return null;
+        }
+
+        return store;
     }
 
     private async Task<long> GetCachedUploadLengthAsync(string fileId, CancellationToken cancellationToken)

--- a/src/Altinn.Broker.Integrations/Tus/Md5ComputingStream.cs
+++ b/src/Altinn.Broker.Integrations/Tus/Md5ComputingStream.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+
+namespace Altinn.Broker.Integrations.Tus;
+
+/// <summary>
+/// Passes reads through to the inner stream while updating an incremental MD5 hash.
+/// Does not take ownership of the inner stream.
+/// </summary>
+internal sealed class Md5ComputingStream(Stream inner, MD5 md5) : Stream
+{
+    public override bool CanRead => inner.CanRead;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => false;
+
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush() => inner.Flush();
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var read = inner.Read(buffer, offset, count);
+        if (read > 0)
+        {
+            md5.TransformBlock(buffer, offset, read, null, 0);
+        }
+
+        return read;
+    }
+
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        var read = await inner.ReadAsync(buffer, offset, count, cancellationToken);
+        if (read > 0)
+        {
+            md5.TransformBlock(buffer, offset, read, null, 0);
+        }
+
+        return read;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}

--- a/src/Altinn.Broker.Integrations/Tus/RedisTusExpirationDetailsStore.cs
+++ b/src/Altinn.Broker.Integrations/Tus/RedisTusExpirationDetailsStore.cs
@@ -1,0 +1,32 @@
+using StackExchange.Redis;
+
+using Xtensible.TusDotNet.Azure;
+
+namespace Altinn.Broker.Integrations.Tus;
+
+public class RedisTusExpirationDetailsStore(IConnectionMultiplexer redis) : ITusExpirationDetailsStore
+{
+    private const string ExpirationKey = "broker:tus:expirations";
+    private readonly IDatabase _database = redis.GetDatabase();
+
+    public Task SetExpirationAsync(string fileId, DateTimeOffset expires, CancellationToken cancellationToken)
+        => _database.SortedSetAddAsync(ExpirationKey, fileId, expires.ToUnixTimeSeconds());
+
+    public async Task<DateTimeOffset?> GetExpirationAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var score = await _database.SortedSetScoreAsync(ExpirationKey, fileId);
+        return score.HasValue ? DateTimeOffset.FromUnixTimeSeconds((long)score.Value) : null;
+    }
+
+    public async Task<IEnumerable<string>> GetExpiredFilesAsync(CancellationToken cancellationToken)
+    {
+        var values = await _database.SortedSetRangeByScoreAsync(
+            ExpirationKey,
+            double.NegativeInfinity,
+            DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        return values.Select(value => value.ToString()).Where(value => !string.IsNullOrWhiteSpace(value)).Cast<string>();
+    }
+
+    public Task RemoveExpirationAsync(string fileId, CancellationToken cancellationToken)
+        => _database.SortedSetRemoveAsync(ExpirationKey, fileId);
+}

--- a/src/Altinn.Broker.Integrations/Tus/TusOptions.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusOptions.cs
@@ -1,0 +1,11 @@
+namespace Altinn.Broker.Integrations.Tus;
+
+public class TusOptions
+{
+    public const string SectionName = "TusOptions";
+
+    /// <summary>
+    /// How long an incomplete TUS upload may remain resumable before expiration.
+    /// </summary>
+    public TimeSpan UploadExpiration { get; set; } = TimeSpan.FromHours(24);
+}

--- a/src/Altinn.Broker.Integrations/Tus/TusPartialUploadRegistry.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusPartialUploadRegistry.cs
@@ -6,21 +6,36 @@ public interface ITusPartialUploadRegistry
 {
     void RegisterPartial(string partialFileId, Guid fileTransferId, long uploadLength);
 
+    void RegisterUpload(string fileId, long uploadLength);
+
     bool TryGetPartialInfo(string partialFileId, out Guid fileTransferId, out long uploadLength);
+
+    bool TryGetUploadLength(string fileId, out long uploadLength);
+
+    bool IsKnownUpload(string fileId);
 
     bool IsPartial(string fileId);
 
     bool TryGetFileTransferId(string tusFileId, out Guid fileTransferId);
 
     void RemovePartial(string partialFileId);
+
+    void RemoveUpload(string fileId);
 }
 
 public sealed class TusPartialUploadRegistry : ITusPartialUploadRegistry
 {
     private readonly ConcurrentDictionary<string, PartialUploadInfo> _partials = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, long> _uploadLengths = new(StringComparer.OrdinalIgnoreCase);
 
     public void RegisterPartial(string partialFileId, Guid fileTransferId, long uploadLength)
-        => _partials[partialFileId] = new PartialUploadInfo(fileTransferId, uploadLength);
+    {
+        _partials[partialFileId] = new PartialUploadInfo(fileTransferId, uploadLength);
+        _uploadLengths[partialFileId] = uploadLength;
+    }
+
+    public void RegisterUpload(string fileId, long uploadLength)
+        => _uploadLengths[fileId] = uploadLength;
 
     public bool TryGetPartialInfo(string partialFileId, out Guid fileTransferId, out long uploadLength)
     {
@@ -38,6 +53,11 @@ public sealed class TusPartialUploadRegistry : ITusPartialUploadRegistry
 
     public bool IsPartial(string fileId) => _partials.ContainsKey(fileId);
 
+    public bool TryGetUploadLength(string fileId, out long uploadLength)
+        => _uploadLengths.TryGetValue(fileId, out uploadLength);
+
+    public bool IsKnownUpload(string fileId) => _uploadLengths.ContainsKey(fileId);
+
     public bool TryGetFileTransferId(string tusFileId, out Guid fileTransferId)
     {
         if (_partials.TryGetValue(tusFileId, out var info))
@@ -50,7 +70,13 @@ public sealed class TusPartialUploadRegistry : ITusPartialUploadRegistry
         return false;
     }
 
-    public void RemovePartial(string partialFileId) => _partials.TryRemove(partialFileId, out _);
+    public void RemovePartial(string partialFileId)
+    {
+        _partials.TryRemove(partialFileId, out _);
+        _uploadLengths.TryRemove(partialFileId, out _);
+    }
+
+    public void RemoveUpload(string fileId) => _uploadLengths.TryRemove(fileId, out _);
 
     private sealed record PartialUploadInfo(Guid FileTransferId, long UploadLength);
 }

--- a/src/Altinn.Broker.Integrations/Tus/TusPartialUploadRegistry.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusPartialUploadRegistry.cs
@@ -1,0 +1,56 @@
+using System.Collections.Concurrent;
+
+namespace Altinn.Broker.Integrations.Tus;
+
+public interface ITusPartialUploadRegistry
+{
+    void RegisterPartial(string partialFileId, Guid fileTransferId, long uploadLength);
+
+    bool TryGetPartialInfo(string partialFileId, out Guid fileTransferId, out long uploadLength);
+
+    bool IsPartial(string fileId);
+
+    bool TryGetFileTransferId(string tusFileId, out Guid fileTransferId);
+
+    void RemovePartial(string partialFileId);
+}
+
+public sealed class TusPartialUploadRegistry : ITusPartialUploadRegistry
+{
+    private readonly ConcurrentDictionary<string, PartialUploadInfo> _partials = new(StringComparer.OrdinalIgnoreCase);
+
+    public void RegisterPartial(string partialFileId, Guid fileTransferId, long uploadLength)
+        => _partials[partialFileId] = new PartialUploadInfo(fileTransferId, uploadLength);
+
+    public bool TryGetPartialInfo(string partialFileId, out Guid fileTransferId, out long uploadLength)
+    {
+        if (_partials.TryGetValue(partialFileId, out var info))
+        {
+            fileTransferId = info.FileTransferId;
+            uploadLength = info.UploadLength;
+            return true;
+        }
+
+        fileTransferId = default;
+        uploadLength = 0;
+        return false;
+    }
+
+    public bool IsPartial(string fileId) => _partials.ContainsKey(fileId);
+
+    public bool TryGetFileTransferId(string tusFileId, out Guid fileTransferId)
+    {
+        if (_partials.TryGetValue(tusFileId, out var info))
+        {
+            fileTransferId = info.FileTransferId;
+            return true;
+        }
+
+        fileTransferId = default;
+        return false;
+    }
+
+    public void RemovePartial(string partialFileId) => _partials.TryRemove(partialFileId, out _);
+
+    private sealed record PartialUploadInfo(Guid FileTransferId, long UploadLength);
+}

--- a/src/Altinn.Broker.Integrations/Tus/TusRouteHelper.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusRouteHelper.cs
@@ -10,6 +10,13 @@ public static class TusRouteHelper
     {
         fileTransferId = default;
 
+        // Prefer our named route parameter when MapTus path includes {fileTransferId}.
+        var namedRouteValue = httpContext.Request.RouteValues["fileTransferId"]?.ToString();
+        if (Guid.TryParse(namedRouteValue, out fileTransferId))
+        {
+            return true;
+        }
+
         var routeValue = httpContext.Request.RouteValues[TusFileIdRouteKey]?.ToString();
         if (Guid.TryParse(routeValue, out fileTransferId))
         {

--- a/src/Altinn.Broker.Integrations/Tus/TusRouteHelper.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusRouteHelper.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Altinn.Broker.Integrations.Tus;
+
+public static class TusRouteHelper
+{
+    public const string TusFileIdRouteKey = "TusFileId";
+
+    public static bool TryGetFileTransferIdFromRoute(HttpContext httpContext, out Guid fileTransferId)
+    {
+        fileTransferId = default;
+
+        var routeValue = httpContext.Request.RouteValues[TusFileIdRouteKey]?.ToString();
+        if (Guid.TryParse(routeValue, out fileTransferId))
+        {
+            return true;
+        }
+
+        var lastSegment = httpContext.Request.Path.Value?.TrimEnd('/').Split('/').LastOrDefault();
+        return Guid.TryParse(lastSegment, out fileTransferId);
+    }
+}

--- a/src/Altinn.Broker.Integrations/Tus/TusRouteHelper.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusRouteHelper.cs
@@ -5,10 +5,18 @@ namespace Altinn.Broker.Integrations.Tus;
 public static class TusRouteHelper
 {
     public const string TusFileIdRouteKey = "TusFileId";
+    public const string FileTransferIdItemKey = "TusFileTransferId";
 
     public static bool TryGetFileTransferIdFromRoute(HttpContext httpContext, out Guid fileTransferId)
     {
         fileTransferId = default;
+
+        if (httpContext.Items.TryGetValue(FileTransferIdItemKey, out var item)
+            && item is string fileTransferIdFromRewrite
+            && Guid.TryParse(fileTransferIdFromRewrite, out fileTransferId))
+        {
+            return true;
+        }
 
         // Prefer our named route parameter when MapTus path includes {fileTransferId}.
         var namedRouteValue = httpContext.Request.RouteValues["fileTransferId"]?.ToString();

--- a/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
@@ -1,0 +1,79 @@
+using System.Collections.Concurrent;
+
+using Altinn.Broker.Core.Repositories;
+using Altinn.Broker.Integrations.Azure;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+
+using Xtensible.TusDotNet.Azure;
+
+namespace Altinn.Broker.Integrations.Tus;
+
+public interface ITusStorageResolver
+{
+    Task<AzureBlobTusStore?> GetStoreForFileAsync(string fileId, CancellationToken cancellationToken);
+}
+
+public class TusStorageResolver(
+    IFileTransferRepository fileTransferRepository,
+    IResourceRepository resourceRepository,
+    IServiceOwnerRepository serviceOwnerRepository,
+    IHostEnvironment hostEnvironment,
+    ITusExpirationDetailsStore expirationDetailsStore,
+    IHttpContextAccessor httpContextAccessor) : ITusStorageResolver
+{
+    private readonly ConcurrentDictionary<string, AzureBlobTusStore> _stores = new(StringComparer.OrdinalIgnoreCase);
+
+    public async Task<AzureBlobTusStore?> GetStoreForFileAsync(string fileId, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(fileId, out var fileTransferId))
+        {
+            return null;
+        }
+
+        var fileTransfer = await fileTransferRepository.GetFileTransfer(fileTransferId, cancellationToken);
+        if (fileTransfer is null)
+        {
+            return null;
+        }
+
+        var resource = await resourceRepository.GetResource(fileTransfer.ResourceId, cancellationToken);
+        if (resource is null)
+        {
+            return null;
+        }
+
+        var serviceOwner = await serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId);
+        if (serviceOwner is null)
+        {
+            return null;
+        }
+
+        var storageProvider = serviceOwner.GetStorageProvider(fileTransfer.UseVirusScan);
+        if (storageProvider is null)
+        {
+            return null;
+        }
+
+        var connectionString = hostEnvironment.IsDevelopment()
+            ? AzureConstants.AzuriteUrl
+            : $"https://{storageProvider.ResourceName}.blob.core.windows.net";
+        var authenticationMode = hostEnvironment.IsDevelopment()
+            ? AzureBlobTusStoreAuthenticationMode.ConnectionString
+            : AzureBlobTusStoreAuthenticationMode.SystemAssignedManagedIdentity;
+
+        return _stores.GetOrAdd(storageProvider.ResourceName, _ => new AzureBlobTusStore(
+            connectionString,
+            AzureStorageConstants.BrokerFilesContainerName,
+            new AzureBlobTusStoreOptions
+            {
+                BlobPath = AzureStorageConstants.TusStagingBlobPath,
+                AuthenticationMode = authenticationMode,
+                ExpirationDetailsStore = expirationDetailsStore,
+                FileIdGeneratorAsync = _ => Task.FromResult(
+                    httpContextAccessor.HttpContext?.Request.RouteValues["fileTransferId"]?.ToString()
+                    ?? throw new InvalidOperationException("Missing fileTransferId route value"))
+            }));
+    }
+}

--- a/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
@@ -3,6 +3,10 @@ using System.Collections.Concurrent;
 using Altinn.Broker.Core.Repositories;
 using Altinn.Broker.Integrations.Azure;
 
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
 
@@ -13,6 +17,7 @@ namespace Altinn.Broker.Integrations.Tus;
 public interface ITusStorageResolver
 {
     Task<AzureBlobTusStore?> GetStoreForFileAsync(string fileId, CancellationToken cancellationToken);
+    Task SetStagingBlobMd5ChecksumAsync(string fileId, byte[] md5Hash, CancellationToken cancellationToken);
 }
 
 public class TusStorageResolver(
@@ -26,6 +31,66 @@ public class TusStorageResolver(
     private readonly ConcurrentDictionary<string, AzureBlobTusStore> _stores = new(StringComparer.OrdinalIgnoreCase);
 
     public async Task<AzureBlobTusStore?> GetStoreForFileAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var storageContext = await ResolveStorageContextAsync(fileId, cancellationToken);
+        if (storageContext is null)
+        {
+            return null;
+        }
+
+        return _stores.GetOrAdd(storageContext.StorageAccountName, _ => new AzureBlobTusStore(
+            storageContext.ConnectionString,
+            AzureStorageConstants.BrokerFilesContainerName,
+            new AzureBlobTusStoreOptions
+            {
+                BlobPath = AzureStorageConstants.TusStagingBlobPath,
+                AuthenticationMode = storageContext.AuthenticationMode,
+                ExpirationDetailsStore = expirationDetailsStore,
+                FileIdGeneratorAsync = _ =>
+                {
+                    var httpContext = httpContextAccessor.HttpContext
+                        ?? throw new InvalidOperationException("Missing HTTP context");
+                    if (!TusRouteHelper.TryGetFileTransferIdFromRoute(httpContext, out var fileTransferId))
+                    {
+                        throw new InvalidOperationException("Missing file transfer id in route");
+                    }
+
+                    return Task.FromResult(fileTransferId.ToString());
+                }
+            }));
+    }
+
+    public async Task SetStagingBlobMd5ChecksumAsync(string fileId, byte[] md5Hash, CancellationToken cancellationToken)
+    {
+        var storageContext = await ResolveStorageContextAsync(fileId, cancellationToken);
+        if (storageContext is null)
+        {
+            return;
+        }
+
+        var containerClient = GetBlobContainerClient(storageContext);
+        var appendBlobClient = containerClient.GetAppendBlobClient(
+            Path.Combine(AzureStorageConstants.TusStagingBlobPath, fileId));
+        var properties = await appendBlobClient.GetPropertiesAsync(cancellationToken: cancellationToken);
+        var metadata = properties.Value.Metadata.ToDictionary(static k => k.Key, static v => v.Value);
+        metadata[AzureStorageConstants.TusMd5ChecksumMetadataKey] = Convert.ToBase64String(md5Hash);
+        await appendBlobClient.SetMetadataAsync(metadata, cancellationToken: cancellationToken);
+    }
+
+    private BlobContainerClient GetBlobContainerClient(TusStorageContext storageContext)
+    {
+        if (hostEnvironment.IsDevelopment())
+        {
+            return new BlobServiceClient(AzureConstants.AzuriteUrl)
+                .GetBlobContainerClient(AzureStorageConstants.BrokerFilesContainerName);
+        }
+
+        var storageUri = new Uri(storageContext.ConnectionString);
+        return new BlobServiceClient(storageUri, new DefaultAzureCredential())
+            .GetBlobContainerClient(AzureStorageConstants.BrokerFilesContainerName);
+    }
+
+    private async Task<TusStorageContext?> ResolveStorageContextAsync(string fileId, CancellationToken cancellationToken)
     {
         if (!Guid.TryParse(fileId, out var fileTransferId))
         {
@@ -63,25 +128,11 @@ public class TusStorageResolver(
             ? AzureBlobTusStoreAuthenticationMode.ConnectionString
             : AzureBlobTusStoreAuthenticationMode.SystemAssignedManagedIdentity;
 
-        return _stores.GetOrAdd(storageProvider.ResourceName, _ => new AzureBlobTusStore(
-            connectionString,
-            AzureStorageConstants.BrokerFilesContainerName,
-            new AzureBlobTusStoreOptions
-            {
-                BlobPath = AzureStorageConstants.TusStagingBlobPath,
-                AuthenticationMode = authenticationMode,
-                ExpirationDetailsStore = expirationDetailsStore,
-                FileIdGeneratorAsync = _ =>
-                {
-                    var httpContext = httpContextAccessor.HttpContext
-                        ?? throw new InvalidOperationException("Missing HTTP context");
-                    if (!TusRouteHelper.TryGetFileTransferIdFromRoute(httpContext, out var fileTransferId))
-                    {
-                        throw new InvalidOperationException("Missing file transfer id in route");
-                    }
-
-                    return Task.FromResult(fileTransferId.ToString());
-                }
-            }));
+        return new TusStorageContext(connectionString, authenticationMode, storageProvider.ResourceName);
     }
+
+    private sealed record TusStorageContext(
+        string ConnectionString,
+        AzureBlobTusStoreAuthenticationMode AuthenticationMode,
+        string StorageAccountName);
 }

--- a/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
@@ -6,6 +6,7 @@ using Altinn.Broker.Integrations.Azure;
 using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Blobs.Models;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
@@ -18,6 +19,12 @@ public interface ITusStorageResolver
 {
     Task<AzureBlobTusStore?> GetStoreForFileAsync(string fileId, CancellationToken cancellationToken);
     Task SetStagingBlobMd5ChecksumAsync(string fileId, byte[] md5Hash, CancellationToken cancellationToken);
+    Task StageTusBlockAsync(string fileId, string blockId, byte[] blockData, CancellationToken cancellationToken);
+    Task CommitTusBlocksAsync(
+        string fileId,
+        IReadOnlyList<string> blockIds,
+        byte[] md5Hash,
+        CancellationToken cancellationToken);
 }
 
 public class TusStorageResolver(
@@ -75,6 +82,56 @@ public class TusStorageResolver(
         var metadata = properties.Value.Metadata.ToDictionary(static k => k.Key, static v => v.Value);
         metadata[AzureStorageConstants.TusMd5ChecksumMetadataKey] = Convert.ToBase64String(md5Hash);
         await appendBlobClient.SetMetadataAsync(metadata, cancellationToken: cancellationToken);
+    }
+
+    public async Task StageTusBlockAsync(string fileId, string blockId, byte[] blockData, CancellationToken cancellationToken)
+    {
+        var storageContext = await ResolveStorageContextAsync(fileId, cancellationToken);
+        if (storageContext is null)
+        {
+            throw new InvalidOperationException($"Missing storage context for file id {fileId}");
+        }
+
+        var containerClient = GetBlobContainerClient(storageContext);
+        var blockBlobClient = containerClient.GetBlockBlobClient(
+            Path.Combine(AzureStorageConstants.TusBlockStagingBlobPath, fileId));
+        await using var chunkStream = new MemoryStream(blockData, writable: false);
+        await blockBlobClient.StageBlockAsync(
+            blockId,
+            chunkStream,
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task CommitTusBlocksAsync(
+        string fileId,
+        IReadOnlyList<string> blockIds,
+        byte[] md5Hash,
+        CancellationToken cancellationToken)
+    {
+        var storageContext = await ResolveStorageContextAsync(fileId, cancellationToken);
+        if (storageContext is null)
+        {
+            throw new InvalidOperationException($"Missing storage context for file id {fileId}");
+        }
+
+        var containerClient = GetBlobContainerClient(storageContext);
+        var blockBlobClient = containerClient.GetBlockBlobClient(
+            Path.Combine(AzureStorageConstants.TusBlockStagingBlobPath, fileId));
+        await blockBlobClient.CommitBlockListAsync(
+            blockIds,
+            new CommitBlockListOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    [AzureStorageConstants.TusMd5ChecksumMetadataKey] = Convert.ToBase64String(md5Hash)
+                },
+                HttpHeaders = new BlobHttpHeaders
+                {
+                    ContentType = "application/octet-stream",
+                    ContentHash = md5Hash
+                }
+            },
+            cancellationToken: cancellationToken);
     }
 
     private BlobContainerClient GetBlobContainerClient(TusStorageContext storageContext)

--- a/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
@@ -23,8 +23,6 @@ public class TusStorageResolver(
     ITusExpirationDetailsStore expirationDetailsStore,
     IHttpContextAccessor httpContextAccessor) : ITusStorageResolver
 {
-    private const string TusFileIdRouteKey = TusRouteHelper.TusFileIdRouteKey;
-
     private readonly ConcurrentDictionary<string, AzureBlobTusStore> _stores = new(StringComparer.OrdinalIgnoreCase);
 
     public async Task<AzureBlobTusStore?> GetStoreForFileAsync(string fileId, CancellationToken cancellationToken)
@@ -73,9 +71,17 @@ public class TusStorageResolver(
                 BlobPath = AzureStorageConstants.TusStagingBlobPath,
                 AuthenticationMode = authenticationMode,
                 ExpirationDetailsStore = expirationDetailsStore,
-                FileIdGeneratorAsync = _ => Task.FromResult(
-                    httpContextAccessor.HttpContext?.Request.RouteValues[TusFileIdRouteKey]?.ToString()
-                    ?? throw new InvalidOperationException("Missing TusFileId route value"))
+                FileIdGeneratorAsync = _ =>
+                {
+                    var httpContext = httpContextAccessor.HttpContext
+                        ?? throw new InvalidOperationException("Missing HTTP context");
+                    if (!TusRouteHelper.TryGetFileTransferIdFromRoute(httpContext, out var fileTransferId))
+                    {
+                        throw new InvalidOperationException("Missing file transfer id in route");
+                    }
+
+                    return Task.FromResult(fileTransferId.ToString());
+                }
             }));
     }
 }

--- a/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
@@ -33,6 +33,8 @@ public interface ITusStorageResolver
         IReadOnlyList<string> partialFileIds,
         CancellationToken cancellationToken);
     Task DeleteStagingBlobAsync(string fileId, CancellationToken cancellationToken);
+    Task<bool> DestinationBlobExistsAsync(string fileId, CancellationToken cancellationToken);
+    Task<long> GetDestinationBlobLengthAsync(string fileId, CancellationToken cancellationToken);
 }
 
 public class TusStorageResolver(
@@ -271,6 +273,38 @@ public class TusStorageResolver(
         var blockBlobClient = containerClient.GetBlockBlobClient(
             Path.Combine(AzureStorageConstants.TusBlockStagingBlobPath, fileId));
         await blockBlobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+    }
+
+    public async Task<bool> DestinationBlobExistsAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var storageContext = await ResolveStorageContextAsync(fileId, cancellationToken);
+        if (storageContext is null)
+        {
+            return false;
+        }
+
+        var containerClient = GetBlobContainerClient(storageContext);
+        var destinationBlobClient = containerClient.GetBlobClient(fileId);
+        return await destinationBlobClient.ExistsAsync(cancellationToken);
+    }
+
+    public async Task<long> GetDestinationBlobLengthAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var storageContext = await ResolveStorageContextAsync(fileId, cancellationToken);
+        if (storageContext is null)
+        {
+            return 0;
+        }
+
+        var containerClient = GetBlobContainerClient(storageContext);
+        var destinationBlobClient = containerClient.GetBlobClient(fileId);
+        if (!await destinationBlobClient.ExistsAsync(cancellationToken))
+        {
+            return 0;
+        }
+
+        var properties = await destinationBlobClient.GetPropertiesAsync(cancellationToken: cancellationToken);
+        return properties.Value.ContentLength;
     }
 
     private BlobContainerClient GetBlobContainerClient(TusStorageContext storageContext)

--- a/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
@@ -24,8 +24,9 @@ public interface ITusStorageResolver
     Task CommitTusBlocksAsync(
         string fileId,
         IReadOnlyList<string> blockIds,
-        byte[] md5Hash,
         CancellationToken cancellationToken);
+    Task<byte[]> ComputeCommittedStagingMd5Async(string fileId, CancellationToken cancellationToken);
+    Task SetCommittedStagingMd5Async(string fileId, byte[] md5Hash, CancellationToken cancellationToken);
     Task<bool> StagingBlobExistsAsync(string fileId, CancellationToken cancellationToken);
     Task<long> GetCommittedStagingLengthAsync(string fileId, CancellationToken cancellationToken);
     Task<long> ConcatenatePartialStagingBlobsAsync(
@@ -118,7 +119,6 @@ public class TusStorageResolver(
     public async Task CommitTusBlocksAsync(
         string fileId,
         IReadOnlyList<string> blockIds,
-        byte[] md5Hash,
         CancellationToken cancellationToken)
     {
         var storageContext = await ResolveStorageContextAsync(fileId, cancellationToken);
@@ -134,15 +134,49 @@ public class TusStorageResolver(
             blockIds,
             new CommitBlockListOptions
             {
-                Metadata = new Dictionary<string, string>
-                {
-                    [AzureStorageConstants.TusMd5ChecksumMetadataKey] = Convert.ToBase64String(md5Hash)
-                },
                 HttpHeaders = new BlobHttpHeaders
                 {
-                    ContentType = "application/octet-stream",
-                    ContentHash = md5Hash
+                    ContentType = "application/octet-stream"
                 }
+            },
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task<byte[]> ComputeCommittedStagingMd5Async(string fileId, CancellationToken cancellationToken)
+    {
+        var storageContext = await ResolveStorageContextAsync(fileId, cancellationToken);
+        if (storageContext is null)
+        {
+            throw new InvalidOperationException($"Missing storage context for file id {fileId}");
+        }
+
+        var containerClient = GetBlobContainerClient(storageContext);
+        var blockBlobClient = containerClient.GetBlockBlobClient(
+            Path.Combine(AzureStorageConstants.TusBlockStagingBlobPath, fileId));
+        await using var contentStream = await blockBlobClient.OpenReadAsync(cancellationToken: cancellationToken);
+        return await MD5.HashDataAsync(contentStream, cancellationToken);
+    }
+
+    public async Task SetCommittedStagingMd5Async(string fileId, byte[] md5Hash, CancellationToken cancellationToken)
+    {
+        var storageContext = await ResolveStorageContextAsync(fileId, cancellationToken);
+        if (storageContext is null)
+        {
+            throw new InvalidOperationException($"Missing storage context for file id {fileId}");
+        }
+
+        var containerClient = GetBlobContainerClient(storageContext);
+        var blockBlobClient = containerClient.GetBlockBlobClient(
+            Path.Combine(AzureStorageConstants.TusBlockStagingBlobPath, fileId));
+        var properties = await blockBlobClient.GetPropertiesAsync(cancellationToken: cancellationToken);
+        var metadata = properties.Value.Metadata.ToDictionary(static k => k.Key, static v => v.Value);
+        metadata[AzureStorageConstants.TusMd5ChecksumMetadataKey] = Convert.ToBase64String(md5Hash);
+        await blockBlobClient.SetMetadataAsync(metadata, cancellationToken: cancellationToken);
+        await blockBlobClient.SetHttpHeadersAsync(
+            new BlobHttpHeaders
+            {
+                ContentType = "application/octet-stream",
+                ContentHash = md5Hash
             },
             cancellationToken: cancellationToken);
     }

--- a/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
@@ -1,12 +1,13 @@
 using System.Collections.Concurrent;
+using System.Security.Cryptography;
 
 using Altinn.Broker.Core.Repositories;
 using Altinn.Broker.Integrations.Azure;
 
 using Azure.Identity;
 using Azure.Storage.Blobs;
-using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
@@ -25,6 +26,13 @@ public interface ITusStorageResolver
         IReadOnlyList<string> blockIds,
         byte[] md5Hash,
         CancellationToken cancellationToken);
+    Task<bool> StagingBlobExistsAsync(string fileId, CancellationToken cancellationToken);
+    Task<long> GetCommittedStagingLengthAsync(string fileId, CancellationToken cancellationToken);
+    Task<long> ConcatenatePartialStagingBlobsAsync(
+        string finalFileId,
+        IReadOnlyList<string> partialFileIds,
+        CancellationToken cancellationToken);
+    Task DeleteStagingBlobAsync(string fileId, CancellationToken cancellationToken);
 }
 
 public class TusStorageResolver(
@@ -33,8 +41,11 @@ public class TusStorageResolver(
     IServiceOwnerRepository serviceOwnerRepository,
     IHostEnvironment hostEnvironment,
     ITusExpirationDetailsStore expirationDetailsStore,
+    ITusPartialUploadRegistry partialUploadRegistry,
     IHttpContextAccessor httpContextAccessor) : ITusStorageResolver
 {
+    private const int ConcatenationReadBufferSize = 4 * 1024 * 1024;
+
     private readonly ConcurrentDictionary<string, AzureBlobTusStore> _stores = new(StringComparer.OrdinalIgnoreCase);
 
     public async Task<AzureBlobTusStore?> GetStoreForFileAsync(string fileId, CancellationToken cancellationToken)
@@ -134,6 +145,134 @@ public class TusStorageResolver(
             cancellationToken: cancellationToken);
     }
 
+    public async Task<bool> StagingBlobExistsAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var storageContext = await ResolveStorageContextAsync(fileId, cancellationToken);
+        if (storageContext is null)
+        {
+            return false;
+        }
+
+        var containerClient = GetBlobContainerClient(storageContext);
+        var blockBlobClient = containerClient.GetBlockBlobClient(
+            Path.Combine(AzureStorageConstants.TusBlockStagingBlobPath, fileId));
+        return await blockBlobClient.ExistsAsync(cancellationToken);
+    }
+
+    public async Task<long> GetCommittedStagingLengthAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var storageContext = await ResolveStorageContextAsync(fileId, cancellationToken);
+        if (storageContext is null)
+        {
+            return 0;
+        }
+
+        var containerClient = GetBlobContainerClient(storageContext);
+        var blockBlobClient = containerClient.GetBlockBlobClient(
+            Path.Combine(AzureStorageConstants.TusBlockStagingBlobPath, fileId));
+        if (!await blockBlobClient.ExistsAsync(cancellationToken))
+        {
+            return 0;
+        }
+
+        var properties = await blockBlobClient.GetPropertiesAsync(cancellationToken: cancellationToken);
+        return properties.Value.ContentLength;
+    }
+
+    public async Task<long> ConcatenatePartialStagingBlobsAsync(
+        string finalFileId,
+        IReadOnlyList<string> partialFileIds,
+        CancellationToken cancellationToken)
+    {
+        var storageContext = await ResolveStorageContextAsync(finalFileId, cancellationToken);
+        if (storageContext is null)
+        {
+            throw new InvalidOperationException($"Missing storage context for file id {finalFileId}");
+        }
+
+        var containerClient = GetBlobContainerClient(storageContext);
+        var finalBlobClient = containerClient.GetBlockBlobClient(
+            Path.Combine(AzureStorageConstants.TusBlockStagingBlobPath, finalFileId));
+
+        using var uploadMd5 = MD5.Create();
+        var blockIds = new List<string>();
+        long blockIndex = 0;
+        long totalLength = 0;
+        var readBuffer = new byte[ConcatenationReadBufferSize];
+
+        foreach (var partialFileId in partialFileIds)
+        {
+            var partialBlobClient = containerClient.GetBlockBlobClient(
+                Path.Combine(AzureStorageConstants.TusBlockStagingBlobPath, partialFileId));
+            if (!await partialBlobClient.ExistsAsync(cancellationToken))
+            {
+                throw new InvalidOperationException($"Partial staging blob {partialFileId} does not exist.");
+            }
+
+            await using var partialStream = await partialBlobClient.OpenReadAsync(cancellationToken: cancellationToken);
+            int bytesRead;
+            while ((bytesRead = await partialStream.ReadAsync(readBuffer, cancellationToken)) > 0)
+            {
+                var blockId = BuildBlockId(blockIndex++);
+                var blockData = readBuffer.AsSpan(0, bytesRead).ToArray();
+
+                await using var chunkStream = new MemoryStream(blockData, writable: false);
+                await finalBlobClient.StageBlockAsync(blockId, chunkStream, cancellationToken: cancellationToken);
+                blockIds.Add(blockId);
+                uploadMd5.TransformBlock(blockData, 0, blockData.Length, null, 0);
+                totalLength += bytesRead;
+            }
+        }
+
+        if (blockIds.Count == 0)
+        {
+            throw new InvalidOperationException($"Cannot concatenate partial uploads into file id {finalFileId} because no data was found.");
+        }
+
+        uploadMd5.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+        var md5Hash = uploadMd5.Hash
+            ?? throw new InvalidOperationException($"Failed to calculate MD5 for concatenated file id {finalFileId}.");
+
+        await finalBlobClient.CommitBlockListAsync(
+            blockIds,
+            new CommitBlockListOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    [AzureStorageConstants.TusMd5ChecksumMetadataKey] = Convert.ToBase64String(md5Hash)
+                },
+                HttpHeaders = new BlobHttpHeaders
+                {
+                    ContentType = "application/octet-stream",
+                    ContentHash = md5Hash
+                }
+            },
+            cancellationToken: cancellationToken);
+
+        foreach (var partialFileId in partialFileIds)
+        {
+            var partialBlobClient = containerClient.GetBlockBlobClient(
+                Path.Combine(AzureStorageConstants.TusBlockStagingBlobPath, partialFileId));
+            await partialBlobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+        }
+
+        return totalLength;
+    }
+
+    public async Task DeleteStagingBlobAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var storageContext = await ResolveStorageContextAsync(fileId, cancellationToken);
+        if (storageContext is null)
+        {
+            return;
+        }
+
+        var containerClient = GetBlobContainerClient(storageContext);
+        var blockBlobClient = containerClient.GetBlockBlobClient(
+            Path.Combine(AzureStorageConstants.TusBlockStagingBlobPath, fileId));
+        await blockBlobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+    }
+
     private BlobContainerClient GetBlobContainerClient(TusStorageContext storageContext)
     {
         if (hostEnvironment.IsDevelopment())
@@ -149,11 +288,46 @@ public class TusStorageResolver(
 
     private async Task<TusStorageContext?> ResolveStorageContextAsync(string fileId, CancellationToken cancellationToken)
     {
-        if (!Guid.TryParse(fileId, out var fileTransferId))
+        var fileTransferId = await ResolveFileTransferIdAsync(fileId, cancellationToken);
+        if (fileTransferId is null)
         {
             return null;
         }
 
+        return await ResolveStorageContextForFileTransferAsync(fileTransferId.Value, cancellationToken);
+    }
+
+    private async Task<Guid?> ResolveFileTransferIdAsync(string fileId, CancellationToken cancellationToken)
+    {
+        if (partialUploadRegistry.TryGetFileTransferId(fileId, out var mappedFileTransferId))
+        {
+            return mappedFileTransferId;
+        }
+
+        var httpContext = httpContextAccessor.HttpContext;
+        if (httpContext is not null
+            && TusRouteHelper.TryGetFileTransferIdFromRoute(httpContext, out var routeFileTransferId)
+            && await FileTransferExistsAsync(routeFileTransferId, cancellationToken))
+        {
+            return routeFileTransferId;
+        }
+
+        if (Guid.TryParse(fileId, out var parsedFileTransferId)
+            && await FileTransferExistsAsync(parsedFileTransferId, cancellationToken))
+        {
+            return parsedFileTransferId;
+        }
+
+        return null;
+    }
+
+    private async Task<bool> FileTransferExistsAsync(Guid fileTransferId, CancellationToken cancellationToken)
+        => await fileTransferRepository.GetFileTransfer(fileTransferId, cancellationToken) is not null;
+
+    private async Task<TusStorageContext?> ResolveStorageContextForFileTransferAsync(
+        Guid fileTransferId,
+        CancellationToken cancellationToken)
+    {
         var fileTransfer = await fileTransferRepository.GetFileTransfer(fileTransferId, cancellationToken);
         if (fileTransfer is null)
         {
@@ -186,6 +360,12 @@ public class TusStorageResolver(
             : AzureBlobTusStoreAuthenticationMode.SystemAssignedManagedIdentity;
 
         return new TusStorageContext(connectionString, authenticationMode, storageProvider.ResourceName);
+    }
+
+    private static string BuildBlockId(long blockIndex)
+    {
+        var blockId = blockIndex.ToString("D12");
+        return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(blockId));
     }
 
     private sealed record TusStorageContext(

--- a/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusStorageResolver.cs
@@ -23,6 +23,8 @@ public class TusStorageResolver(
     ITusExpirationDetailsStore expirationDetailsStore,
     IHttpContextAccessor httpContextAccessor) : ITusStorageResolver
 {
+    private const string TusFileIdRouteKey = TusRouteHelper.TusFileIdRouteKey;
+
     private readonly ConcurrentDictionary<string, AzureBlobTusStore> _stores = new(StringComparer.OrdinalIgnoreCase);
 
     public async Task<AzureBlobTusStore?> GetStoreForFileAsync(string fileId, CancellationToken cancellationToken)
@@ -72,8 +74,8 @@ public class TusStorageResolver(
                 AuthenticationMode = authenticationMode,
                 ExpirationDetailsStore = expirationDetailsStore,
                 FileIdGeneratorAsync = _ => Task.FromResult(
-                    httpContextAccessor.HttpContext?.Request.RouteValues["fileTransferId"]?.ToString()
-                    ?? throw new InvalidOperationException("Missing fileTransferId route value"))
+                    httpContextAccessor.HttpContext?.Request.RouteValues[TusFileIdRouteKey]?.ToString()
+                    ?? throw new InvalidOperationException("Missing TusFileId route value"))
             }));
     }
 }

--- a/src/Altinn.Broker.Integrations/Tus/TusUploadProgressCache.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusUploadProgressCache.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Altinn.Broker.Integrations.Tus;
+
+public sealed record TusUploadProgressSnapshot(
+    long UploadLength,
+    long AcceptedOffset,
+    long CommittedOffset,
+    long NextBlockIndex,
+    List<string> BlockIds);
+
+public interface ITusUploadProgressCache
+{
+    Task<TusUploadProgressSnapshot?> GetAsync(string fileId, CancellationToken cancellationToken);
+
+    Task SaveAsync(string fileId, TusUploadProgressSnapshot snapshot, CancellationToken cancellationToken);
+
+    Task RemoveAsync(string fileId, CancellationToken cancellationToken);
+}
+
+public sealed class TusUploadProgressCache(IDistributedCache cache) : ITusUploadProgressCache
+{
+    private static readonly TimeSpan CacheExpiration = TimeSpan.FromHours(24);
+
+    private static string BuildKey(string fileId) => $"tus-upload-progress:{fileId}";
+
+    public async Task<TusUploadProgressSnapshot?> GetAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var json = await cache.GetStringAsync(BuildKey(fileId), cancellationToken);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        return JsonSerializer.Deserialize<TusUploadProgressSnapshot>(json);
+    }
+
+    public Task SaveAsync(string fileId, TusUploadProgressSnapshot snapshot, CancellationToken cancellationToken)
+        => cache.SetStringAsync(
+            BuildKey(fileId),
+            JsonSerializer.Serialize(snapshot),
+            new DistributedCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = CacheExpiration
+            },
+            cancellationToken);
+
+    public Task RemoveAsync(string fileId, CancellationToken cancellationToken)
+        => cache.RemoveAsync(BuildKey(fileId), cancellationToken);
+}

--- a/src/Altinn.Broker.Integrations/Tus/TusUploadState.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusUploadState.cs
@@ -1,0 +1,47 @@
+using System.Security.Cryptography;
+
+namespace Altinn.Broker.Integrations.Tus;
+
+public sealed class TusUploadState : IDisposable
+{
+    public TusUploadState(long uploadLength, long initialOffset, int maxParallelBlockUploads)
+    {
+        UploadLength = uploadLength;
+        AcceptedOffset = initialOffset;
+        CommittedOffset = initialOffset;
+        ProgressSignal = NewProgressSignal();
+        ConcurrentUploader = new SemaphoreSlim(Math.Max(maxParallelBlockUploads, 1));
+        UploadMd5 = MD5.Create();
+    }
+
+    public object SyncRoot { get; } = new();
+
+    public List<string> BlockIds { get; } = new();
+
+    public long UploadLength { get; }
+
+    public long AcceptedOffset { get; set; }
+
+    public long CommittedOffset { get; set; }
+
+    public int PendingUploads { get; set; }
+
+    public long NextBlockIndex { get; set; }
+
+    public Exception? Fault { get; set; }
+
+    public TaskCompletionSource<long> ProgressSignal { get; set; }
+
+    public SemaphoreSlim ConcurrentUploader { get; }
+
+    public MD5 UploadMd5 { get; }
+
+    public void Dispose()
+    {
+        UploadMd5.Dispose();
+        ConcurrentUploader.Dispose();
+    }
+
+    private static TaskCompletionSource<long> NewProgressSignal()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
+}

--- a/src/Altinn.Broker.Integrations/Tus/TusUploadStateRegistry.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusUploadStateRegistry.cs
@@ -1,0 +1,31 @@
+using System.Collections.Concurrent;
+
+namespace Altinn.Broker.Integrations.Tus;
+
+public interface ITusUploadStateRegistry
+{
+    TusUploadState GetOrAdd(string fileId, Func<TusUploadState> factory);
+
+    bool TryGet(string fileId, out TusUploadState? state);
+
+    void Remove(string fileId);
+}
+
+public sealed class TusUploadStateRegistry : ITusUploadStateRegistry
+{
+    private readonly ConcurrentDictionary<string, TusUploadState> _states = new(StringComparer.OrdinalIgnoreCase);
+
+    public TusUploadState GetOrAdd(string fileId, Func<TusUploadState> factory)
+        => _states.GetOrAdd(fileId, _ => factory());
+
+    public bool TryGet(string fileId, out TusUploadState? state)
+        => _states.TryGetValue(fileId, out state);
+
+    public void Remove(string fileId)
+    {
+        if (_states.TryRemove(fileId, out var state))
+        {
+            state.Dispose();
+        }
+    }
+}

--- a/src/Altinn.Broker.Integrations/Tus/TusUploadStateRegistry.cs
+++ b/src/Altinn.Broker.Integrations/Tus/TusUploadStateRegistry.cs
@@ -13,19 +13,28 @@ public interface ITusUploadStateRegistry
 
 public sealed class TusUploadStateRegistry : ITusUploadStateRegistry
 {
-    private readonly ConcurrentDictionary<string, TusUploadState> _states = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, Lazy<TusUploadState>> _states = new(StringComparer.OrdinalIgnoreCase);
 
     public TusUploadState GetOrAdd(string fileId, Func<TusUploadState> factory)
-        => _states.GetOrAdd(fileId, _ => factory());
+        => _states.GetOrAdd(fileId, _ => new Lazy<TusUploadState>(factory)).Value;
 
     public bool TryGet(string fileId, out TusUploadState? state)
-        => _states.TryGetValue(fileId, out state);
+    {
+        if (_states.TryGetValue(fileId, out var lazy) && lazy.IsValueCreated)
+        {
+            state = lazy.Value;
+            return true;
+        }
+
+        state = null;
+        return false;
+    }
 
     public void Remove(string fileId)
     {
-        if (_states.TryRemove(fileId, out var state))
+        if (_states.TryRemove(fileId, out var lazy) && lazy.IsValueCreated)
         {
-            state.Dispose();
+            lazy.Value.Dispose();
         }
     }
 }

--- a/tests/Altinn.Broker.Tests.LargeFile/Program.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/Program.cs
@@ -51,7 +51,14 @@ public class Program
         Console.WriteLine(
             $"Uploading {uploadSize / (1024.0 * 1024.0 * 1024.0):N2} GiB via TUS with {chunkSizeMb} MiB chunks");
 
-        using var httpClient = new HttpClient
+        using var httpClientHandler = new SocketsHttpHandler
+        {
+            // Reduce transient socket failures under parallel PATCH pressure.
+            MaxConnectionsPerServer = 200,
+            PooledConnectionLifetime = TimeSpan.FromMinutes(10),
+            PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2)
+        };
+        using var httpClient = new HttpClient(httpClientHandler)
         {
             // Each TUS PATCH is a short request; no multi-hour connection is required.
             Timeout = TimeSpan.FromMinutes(30)

--- a/tests/Altinn.Broker.Tests.LargeFile/Program.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/Program.cs
@@ -15,21 +15,25 @@ public class Program
 
     static async Task Main(string[] args)
     {
-        string? baseUrl = "https://altinn-dev-api.azure-api.net"; // Environment.GetEnvironmentVariable("BASE_URL");
-        string? username = "autotest"; // Environment.GetEnvironmentVariable("TEST_TOOLS_USERNAME");
-        string? password = "altinn8900bnn"; // Environment.GetEnvironmentVariable("TEST_TOOLS_PASSWORD");
+        string? baseUrl = Environment.GetEnvironmentVariable("BASE_URL");
+        string? username = Environment.GetEnvironmentVariable("TEST_TOOLS_USERNAME");
+        string? password = Environment.GetEnvironmentVariable("TEST_TOOLS_PASSWORD");
         int gbsToUpload = Environment.GetEnvironmentVariable("GIGABYTES_TO_UPLOAD") is not null
             ? int.Parse(Environment.GetEnvironmentVariable("GIGABYTES_TO_UPLOAD")!)
             : 10;
         int chunkSizeMb = Environment.GetEnvironmentVariable("CHUNK_SIZE_MB") is not null
             ? int.Parse(Environment.GetEnvironmentVariable("CHUNK_SIZE_MB")!)
             : DefaultChunkSizeMb;
+        int parallelPartialUploads = Environment.GetEnvironmentVariable("TUS_PARALLEL_PARTIAL_UPLOADS") is not null
+            ? int.Parse(Environment.GetEnvironmentVariable("TUS_PARALLEL_PARTIAL_UPLOADS")!)
+            : 1;
         long uploadSize = gbsToUpload * 1024L * 1024 * 1024;
         int chunkSize = chunkSizeMb * 1024 * 1024;
 
         Console.WriteLine($"BASE_URL: {baseUrl}");
         Console.WriteLine($"GIGABYTES_TO_UPLOAD: {gbsToUpload}");
         Console.WriteLine($"CHUNK_SIZE_MB: {chunkSizeMb}");
+        Console.WriteLine($"TUS_PARALLEL_PARTIAL_UPLOADS: {parallelPartialUploads}");
 
         if (string.IsNullOrEmpty(baseUrl))
         {
@@ -59,7 +63,21 @@ public class Program
         var fileTransferId = await InitializeFileTransfer(httpClient, baseUrl);
 
         using var randomDataStream = new PseudoRandomDataStream(uploadSize);
-        await TusUploader.UploadAsync(httpClient, baseUrl, fileTransferId, randomDataStream, uploadSize, chunkSize);
+        if (parallelPartialUploads > 1)
+        {
+            await TusUploader.UploadWithConcatenationAsync(
+                httpClient,
+                baseUrl,
+                fileTransferId,
+                randomDataStream,
+                uploadSize,
+                chunkSize,
+                parallelPartialUploads);
+        }
+        else
+        {
+            await TusUploader.UploadAsync(httpClient, baseUrl, fileTransferId, randomDataStream, uploadSize, chunkSize);
+        }
     }
 
     private static string GetRequiredInput(string prompt, string? defaultValue = null)

--- a/tests/Altinn.Broker.Tests.LargeFile/Program.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/Program.cs
@@ -1,5 +1,4 @@
-﻿using System.Net;
-using System.Net.Http.Headers;
+﻿using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
@@ -11,24 +10,30 @@ namespace Altinn.Broker.Tests.LargeFile;
 
 public class Program
 {
-    private const int BufferSize = 1024*1024*1;
-    private const string testResource = "altinn-broker-test-resource-2";
+    private const int DefaultChunkSizeMb = 32;
+    private const string TestResource = "altinn-broker-test-resource-2";
 
     static async Task Main(string[] args)
     {
         string? baseUrl = Environment.GetEnvironmentVariable("BASE_URL");
         string? username = Environment.GetEnvironmentVariable("TEST_TOOLS_USERNAME");
         string? password = Environment.GetEnvironmentVariable("TEST_TOOLS_PASSWORD");
-        int gbsToUpload = Environment.GetEnvironmentVariable("GIGABYTES_TO_UPLOAD") is not null ? int.Parse(Environment.GetEnvironmentVariable("GIGABYTES_TO_UPLOAD")) : 100;
+        int gbsToUpload = Environment.GetEnvironmentVariable("GIGABYTES_TO_UPLOAD") is not null
+            ? int.Parse(Environment.GetEnvironmentVariable("GIGABYTES_TO_UPLOAD")!)
+            : 1;
+        int chunkSizeMb = Environment.GetEnvironmentVariable("CHUNK_SIZE_MB") is not null
+            ? int.Parse(Environment.GetEnvironmentVariable("CHUNK_SIZE_MB")!)
+            : DefaultChunkSizeMb;
         long uploadSize = gbsToUpload * 1024L * 1024 * 1024;
+        int chunkSize = chunkSizeMb * 1024 * 1024;
+
         Console.WriteLine($"BASE_URL: {baseUrl}");
         Console.WriteLine($"GIGABYTES_TO_UPLOAD: {gbsToUpload}");
+        Console.WriteLine($"CHUNK_SIZE_MB: {chunkSizeMb}");
 
         if (string.IsNullOrEmpty(baseUrl))
         {
-            baseUrl = GetRequiredInput(
-                "Enter the base URL"
-            );
+            baseUrl = GetRequiredInput("Enter the base URL");
         }
         if (string.IsNullOrEmpty(username))
         {
@@ -38,16 +43,23 @@ public class Program
         {
             password = GetRequiredInput("Enter the test tools password");
         }
-        Console.WriteLine($"Writing {uploadSize / (1024.0 * 1024.0 * 1024.0):N2} GiB with a buffer size of {BufferSize / (1024.0):N2} KiB");
-        using var httpClient = new HttpClient()
+
+        Console.WriteLine(
+            $"Uploading {uploadSize / (1024.0 * 1024.0 * 1024.0):N2} GiB via TUS with {chunkSizeMb} MiB chunks");
+
+        using var httpClient = new HttpClient
         {
-            Timeout = TimeSpan.FromHours(48)
+            // Each TUS PATCH is a short request; no multi-hour connection is required.
+            Timeout = TimeSpan.FromMinutes(30)
         };
         var token = await GetAccessToken(httpClient, username, password, "991825827");
-        httpClient.DefaultRequestHeaders.Add("Authorization", "Bearer " + token);
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
         await ConfigureResource(httpClient, baseUrl, uploadSize);
         var fileTransferId = await InitializeFileTransfer(httpClient, baseUrl);
-        await UploadFileToBroker(httpClient, fileTransferId, baseUrl, uploadSize);
+
+        using var randomDataStream = new PseudoRandomDataStream(uploadSize);
+        await TusUploader.UploadAsync(httpClient, baseUrl, fileTransferId, randomDataStream, uploadSize, chunkSize);
     }
 
     private static string GetRequiredInput(string prompt, string? defaultValue = null)
@@ -58,94 +70,83 @@ public class Program
             var input = Console.ReadLine()?.Trim();
 
             if (!string.IsNullOrEmpty(input))
+            {
                 return input;
+            }
 
             if (defaultValue != null)
+            {
                 return defaultValue;
+            }
 
             Console.WriteLine("This value is required. Please try again.");
         }
     }
 
-
-    private static async Task<string> GetAccessToken(HttpClient httpClient, string testToolsUsername, string testToolsPassword, string orgNumber)
+    private static async Task<string> GetAccessToken(
+        HttpClient httpClient,
+        string testToolsUsername,
+        string testToolsPassword,
+        string orgNumber)
     {
-        var httpRequestMessage = new HttpRequestMessage()
+        using var httpRequestMessage = new HttpRequestMessage
         {
-            RequestUri = new Uri($"https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken?env=tt02&scopes=altinn:broker.write altinn:serviceowner&org=ttd&orgNo={orgNumber}")
+            RequestUri = new Uri(
+                $"https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken?env=tt02&scopes=altinn:broker.write altinn:serviceowner&org=ttd&orgNo={orgNumber}")
         };
         var authenticationString = $"{testToolsUsername}:{testToolsPassword}";
-        var base64EncodedAuthenticationString = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(authenticationString));
+        var base64EncodedAuthenticationString = Convert.ToBase64String(Encoding.UTF8.GetBytes(authenticationString));
         httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", base64EncodedAuthenticationString);
-        var response = await httpClient.SendAsync(httpRequestMessage);
-        var responseContent = await response.Content.ReadAsStringAsync();
-        return responseContent;
+        using var response = await httpClient.SendAsync(httpRequestMessage);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync();
     }
 
     private static async Task ConfigureResource(HttpClient httpClient, string baseUrl, long uploadSize)
     {
-        var configureResourceBody = new ResourceExt()
+        var configureResourceBody = new ResourceExt
         {
             MaxFileTransferSize = uploadSize + 1
         };
-        var httpRequestMessage = new HttpRequestMessage()
+        using var httpRequestMessage = new HttpRequestMessage
         {
             RequestUri = new Uri(baseUrl + "/broker/api/v1/resource"),
             Method = HttpMethod.Put,
             Content = new StringContent(JsonSerializer.Serialize(configureResourceBody), Encoding.UTF8, "application/json")
         };
-        await httpClient.SendAsync(httpRequestMessage);
+        using var response = await httpClient.SendAsync(httpRequestMessage);
+        if (!response.IsSuccessStatusCode)
+        {
+            Console.WriteLine($"Configure resource returned {(int)response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+        }
     }
 
     private static async Task<string> InitializeFileTransfer(HttpClient httpClient, string baseUrl)
     {
-        var initializeRequestBody = BasicFileTransfer();
-        var httpRequestMessage = new HttpRequestMessage()
+        using var httpRequestMessage = new HttpRequestMessage
         {
             RequestUri = new Uri(baseUrl + "/broker/api/v1/filetransfer"),
             Method = HttpMethod.Post,
-            Content = new StringContent(JsonSerializer.Serialize(initializeRequestBody), Encoding.UTF8, "application/json")
-        }; 
-        var response = await httpClient.SendAsync(httpRequestMessage);
-        var responseContent = await response.Content.ReadFromJsonAsync<FileTransferInitializeResponseExt>();
+            Content = new StringContent(JsonSerializer.Serialize(BasicFileTransfer()), Encoding.UTF8, "application/json")
+        };
+        using var response = await httpClient.SendAsync(httpRequestMessage);
+        if (!response.IsSuccessStatusCode)
+        {
+            Console.WriteLine("Got " + response.StatusCode + " response. Body was " + await response.Content.ReadAsStringAsync());
+        }
+        response.EnsureSuccessStatusCode();
+        var responseContent = await response.Content.ReadFromJsonAsync<FileTransferInitializeResponseExt>()
+            ?? throw new InvalidOperationException("Initialize response was empty.");
         return responseContent.FileTransferId.ToString();
     }
 
-    private static async Task UploadFileToBroker(HttpClient httpClient, string fileTransferId, string baseUrl, long uploadSize)
+    private static FileTransferInitalizeExt BasicFileTransfer() => new()
     {
-        using var randomDataStream = new PseudoRandomDataStream(uploadSize);
-        using var content = new StreamContent(randomDataStream, BufferSize);
-        Console.WriteLine("Starting upload...");
-        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
-        content.Headers.ContentLength = uploadSize;
-        try
-        {
-            var response = await httpClient.PostAsync(baseUrl + $"/broker/api/v1/filetransfer/{fileTransferId}/upload", content);
-            Console.WriteLine($"Response: {response.StatusCode}");
-            Console.WriteLine($"Response: {await response.Content.ReadAsStringAsync()}");
-            double uploadSpeedMBps = uploadSize / (1024.0 * 1024) / (stopwatch.ElapsedMilliseconds / 1000.0);
-            Console.WriteLine($"Upload stats for {fileTransferId}: " +
-                $"{uploadSize / (1024.0 * 1024.0 * 1024.0):N2} GiB ({uploadSpeedMBps:N2} MB/s)");
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"{ex.Message}: {ex.StackTrace}");
-        }
-        finally
-        {
-            stopwatch.Stop();
-            Console.WriteLine($"Upload completed in {stopwatch.ElapsedMilliseconds.ToString("N0")} ms");
-        }
-    }
-
-    private static FileTransferInitalizeExt BasicFileTransfer() => new FileTransferInitalizeExt()
-    {
-        ResourceId = testResource,
+        ResourceId = TestResource,
         Checksum = null,
         FileName = "input.txt",
         PropertyList = [],
-        Recipients = new List<string> { "0192:986252932" },
+        Recipients = ["0192:986252932"],
         Sender = "0192:991825827",
         SendersFileTransferReference = "test-data",
         DisableVirusScan = true

--- a/tests/Altinn.Broker.Tests.LargeFile/Program.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/Program.cs
@@ -15,12 +15,12 @@ public class Program
 
     static async Task Main(string[] args)
     {
-        string? baseUrl = Environment.GetEnvironmentVariable("BASE_URL");
-        string? username = Environment.GetEnvironmentVariable("TEST_TOOLS_USERNAME");
-        string? password = Environment.GetEnvironmentVariable("TEST_TOOLS_PASSWORD");
+        string? baseUrl = "https://altinn-dev-api.azure-api.net"; // Environment.GetEnvironmentVariable("BASE_URL");
+        string? username = "autotest"; // Environment.GetEnvironmentVariable("TEST_TOOLS_USERNAME");
+        string? password = "altinn8900bnn"; // Environment.GetEnvironmentVariable("TEST_TOOLS_PASSWORD");
         int gbsToUpload = Environment.GetEnvironmentVariable("GIGABYTES_TO_UPLOAD") is not null
             ? int.Parse(Environment.GetEnvironmentVariable("GIGABYTES_TO_UPLOAD")!)
-            : 1;
+            : 10;
         int chunkSizeMb = Environment.GetEnvironmentVariable("CHUNK_SIZE_MB") is not null
             ? int.Parse(Environment.GetEnvironmentVariable("CHUNK_SIZE_MB")!)
             : DefaultChunkSizeMb;

--- a/tests/Altinn.Broker.Tests.LargeFile/Program.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/Program.cs
@@ -110,7 +110,7 @@ public class Program
         };
         using var httpRequestMessage = new HttpRequestMessage
         {
-            RequestUri = new Uri(baseUrl + "/broker/api/v1/resource"),
+            RequestUri = new Uri(baseUrl + "/broker/api/v1/resource/" + TestResource),
             Method = HttpMethod.Put,
             Content = new StringContent(JsonSerializer.Serialize(configureResourceBody), Encoding.UTF8, "application/json")
         };

--- a/tests/Altinn.Broker.Tests.LargeFile/PseudoRandomDataStream.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/PseudoRandomDataStream.cs
@@ -6,24 +6,13 @@ public class PseudoRandomDataStream : Stream
 {
     private long _position;
     private long _length;
-    private XorShiftRandom _rng;
-    private Timer _timer;
-    private int timerElapsedCount = 0;
-
-    long bytesRead = 0;
+    private readonly XorShiftRandom _rng;
 
     public PseudoRandomDataStream(long length)
     {
         _length = length;
         _position = 0;
         _rng = new XorShiftRandom();
-        _timer = new Timer(OnTimerElapsed, null, 1000, 1000);
-    }
-
-    private void OnTimerElapsed(object state)
-    {
-        timerElapsedCount++;
-        Console.WriteLine($"Current position {(_position * 100.0 / _length):F3}%. Average speed so far is {(_position / timerElapsedCount) / (1024 * 1024)} MiB/s");
     }
 
     public override bool CanRead => true;
@@ -60,13 +49,12 @@ public class PseudoRandomDataStream : Stream
         return bytesToRead;
     }
 
-    public override void Flush() {
-        Console.WriteLine("Flush called");        
+    public override void Flush()
+    {
     }
 
     public override long Seek(long offset, SeekOrigin origin)
     {
-        Console.WriteLine($"Seek called with offset {offset} from origin {origin}");
         switch (origin)
         {
             case SeekOrigin.Begin:
@@ -86,7 +74,6 @@ public class PseudoRandomDataStream : Stream
 
     public override void SetLength(long value)
     {
-        Console.WriteLine($"Length set to {value}");
         if (value < 0)
             throw new ArgumentOutOfRangeException(nameof(value), "Length cannot be negative.");
         _length = value;
@@ -97,12 +84,6 @@ public class PseudoRandomDataStream : Stream
     public override void Write(byte[] buffer, int offset, int count)
     {
         throw new NotSupportedException("This stream does not support writing.");
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        _timer.Dispose();
-        base.Dispose(disposing);
     }
 }
 

--- a/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
@@ -141,7 +141,7 @@ public static class TusUploader
         await Parallel.ForAsync(0, partRanges.Count, cancellationToken, async (partIndex, ct) =>
         {
             var part = partRanges[partIndex];
-            var uploadedBytes = await UploadPartialAsync(
+            await UploadPartialAsync(
                 httpClient,
                 partialUris[partIndex],
                 source,
@@ -149,19 +149,11 @@ public static class TusUploader
                 part.StartOffset,
                 part.Length,
                 chunkSize,
+                uploadedBytes => progress.Update(Interlocked.Add(ref progressBytes, uploadedBytes)),
                 ct);
-            progress.Update(Interlocked.Add(ref progressBytes, uploadedBytes));
         });
 
         await CreateFinalUploadAsync(httpClient, tusEndpoint, partialUris, cancellationToken);
-        // Final concat POST creates a complete upload and the server may finalize it before a follow-up HEAD.
-        var finalOffset = uploadSize;
-        if (finalOffset != uploadSize)
-        {
-            throw new InvalidOperationException(
-                $"Concatenated upload completed with unexpected offset {finalOffset}, expected {uploadSize}.");
-        }
-
         totalStopwatch.Stop();
         var totalSeconds = Math.Max(totalStopwatch.Elapsed.TotalSeconds, 0.001);
         var averageSpeedMbps = uploadSize / (1024.0 * 1024) / totalSeconds;
@@ -191,8 +183,10 @@ public static class TusUploader
         }
     }
 
+    private const string TusUploadPath = "/broker/api/v1/filetransfer/upload/tus";
+
     private static Uri BuildTusEndpointUri(string baseUrl, string fileTransferId)
-        => new($"{baseUrl.TrimEnd('/')}/broker/api/v1/filetransfer/upload/tus/{fileTransferId}");
+        => new($"{baseUrl.TrimEnd('/')}{TusUploadPath}/{fileTransferId}");
 
     private static async Task<TusServerCapabilities> EnsureServerSupportsTus(HttpClient httpClient, Uri tusEndpoint, CancellationToken cancellationToken)
     {
@@ -273,17 +267,24 @@ public static class TusUploader
             ?? throw new InvalidOperationException("TUS partial POST succeeded but no Location header was returned.");
     }
 
-    private static async Task<Uri> CreateFinalUploadAsync(
+    private static async Task CreateFinalUploadAsync(
         HttpClient httpClient,
         Uri tusEndpoint,
         IReadOnlyList<Uri> partialUris,
         CancellationToken cancellationToken)
     {
+        foreach (var partialUri in partialUris)
+        {
+            await VerifyPartialUploadCompleteAsync(httpClient, partialUri, cancellationToken);
+        }
+
+        var partialReferences = string.Join(' ', partialUris.Select(ToTusConcatReference));
+        var uploadConcatValue = $"final;{partialReferences}";
+        Console.WriteLine($"TUS final POST Upload-Concat: {uploadConcatValue}");
+
         using var createRequest = new HttpRequestMessage(HttpMethod.Post, tusEndpoint);
         createRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
-        createRequest.Headers.TryAddWithoutValidation(
-            "Upload-Concat",
-            $"final;{string.Join(' ', partialUris.Select(static uri => uri.ToString()))}");
+        createRequest.Headers.TryAddWithoutValidation("Upload-Concat", uploadConcatValue);
 
         using var createResponse = await httpClient.SendAsync(createRequest, cancellationToken);
         var responseBody = await createResponse.Content.ReadAsStringAsync(cancellationToken);
@@ -293,11 +294,44 @@ public static class TusUploader
                 $"TUS final POST failed with {(int)createResponse.StatusCode} {createResponse.StatusCode}: {responseBody}");
         }
 
-        return ResolveUploadUri(tusEndpoint, createResponse.Headers.Location)
+        _ = ResolveUploadUri(tusEndpoint, createResponse.Headers.Location)
             ?? throw new InvalidOperationException("TUS final POST succeeded but no Location header was returned.");
     }
 
-    private static async Task<long> UploadPartialAsync(
+    private static async Task VerifyPartialUploadCompleteAsync(
+        HttpClient httpClient,
+        Uri partialUploadUri,
+        CancellationToken cancellationToken)
+    {
+        using var headRequest = new HttpRequestMessage(HttpMethod.Head, partialUploadUri);
+        headRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+
+        using var headResponse = await httpClient.SendAsync(headRequest, cancellationToken);
+        var responseBody = await headResponse.Content.ReadAsStringAsync(cancellationToken);
+        if (!headResponse.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"TUS HEAD on partial upload failed with {(int)headResponse.StatusCode} {headResponse.StatusCode}: {responseBody}");
+        }
+
+        if (!headResponse.Headers.TryGetValues("Upload-Length", out var lengthValues)
+            || !long.TryParse(lengthValues.FirstOrDefault(), out var uploadLength))
+        {
+            throw new InvalidOperationException("Partial upload HEAD did not return Upload-Length.");
+        }
+
+        var uploadOffset = ParseUploadOffset(headResponse.Headers);
+        if (uploadOffset != uploadLength)
+        {
+            throw new InvalidOperationException(
+                $"Partial upload {partialUploadUri} is incomplete ({uploadOffset} / {uploadLength} bytes).");
+        }
+    }
+
+    private static string ToTusConcatReference(Uri partialUploadUri)
+        => partialUploadUri.IsAbsoluteUri ? partialUploadUri.AbsolutePath : partialUploadUri.ToString();
+
+    private static async Task UploadPartialAsync(
         HttpClient httpClient,
         Uri partialUploadUri,
         Stream sharedSource,
@@ -305,6 +339,7 @@ public static class TusUploader
         long sourceStartOffset,
         long partLength,
         int chunkSize,
+        Action<long> onBytesUploaded,
         CancellationToken cancellationToken)
     {
         var offset = await GetUploadOffsetAsync(httpClient, partialUploadUri, cancellationToken);
@@ -321,10 +356,14 @@ public static class TusUploader
                     $"Source stream ended unexpectedly at part offset {offset} (expected {partLength} bytes).");
             }
 
+            var chunkStartOffset = offset;
             offset = await PatchChunkAsync(httpClient, partialUploadUri, offset, buffer, bytesRead, cancellationToken);
+            var uploadedThisChunk = Math.Max(offset - chunkStartOffset, 0);
+            if (uploadedThisChunk > 0)
+            {
+                onBytesUploaded(uploadedThisChunk);
+            }
         }
-
-        return partLength;
     }
 
     private static int ReadAtAbsoluteOffset(
@@ -400,7 +439,13 @@ public static class TusUploader
                 var responseBody = await patchResponse.Content.ReadAsStringAsync(cancellationToken);
                 if (patchResponse.StatusCode == HttpStatusCode.Conflict)
                 {
-                    offset = await ResolveOffsetAfterConflictAsync(httpClient, uploadUri, offset, cancellationToken);
+                    var serverOffset = await ResolveOffsetAfterConflictAsync(httpClient, uploadUri, offset, cancellationToken);
+                    if (serverOffset > offset)
+                    {
+                        return serverOffset;
+                    }
+
+                    offset = serverOffset;
                     continue;
                 }
 
@@ -419,9 +464,17 @@ public static class TusUploader
             catch (Exception ex) when (IsTransientRequestException(ex) && attempt < 5)
             {
                 var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
+                var serverOffset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
+                if (serverOffset > offset)
+                {
+                    Console.WriteLine(
+                        $"TUS PATCH at offset {offset} failed ({ex.Message}), server already at {serverOffset}.");
+                    return serverOffset;
+                }
+
                 Console.WriteLine(
                     $"TUS PATCH at offset {offset} failed ({ex.Message}), realigning offset and retrying in {delay.TotalSeconds:N0}s (attempt {attempt}/5)...");
-                offset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
+                offset = serverOffset;
                 await Task.Delay(delay, cancellationToken);
             }
         }
@@ -455,6 +508,9 @@ public static class TusUploader
                     return serverOffset;
                 }
             }
+
+            throw new InvalidOperationException(
+                $"Server offset {serverOffset} did not reach expected offset {offset} after conflict retries.");
         }
 
         return serverOffset;

--- a/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
@@ -86,7 +86,7 @@ public static class TusUploader
     }
 
     private static Uri BuildTusEndpointUri(string baseUrl, string fileTransferId)
-        => new($"{baseUrl.TrimEnd('/')}/broker/api/v1/filetransfer/{fileTransferId}/upload/tus");
+        => new($"{baseUrl.TrimEnd('/')}/broker/api/v1/filetransfer/upload/tus/{fileTransferId}");
 
     private static async Task EnsureServerSupportsTus(HttpClient httpClient, Uri tusEndpoint, CancellationToken cancellationToken)
     {
@@ -130,7 +130,7 @@ public static class TusUploader
         if (createResponse.StatusCode == HttpStatusCode.Conflict)
         {
             Console.WriteLine("Upload resource already exists — resuming via HEAD.");
-            return new Uri(tusEndpoint, fileTransferId);
+            return tusEndpoint;
         }
 
         throw new InvalidOperationException(

--- a/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
@@ -191,18 +191,6 @@ public static class TusUploader
             ?? throw new InvalidOperationException("TUS partial POST succeeded but no Location header was returned.");
     }
 
-    private static Uri? ResolvePartialUploadUri(Uri tusEndpoint, Uri? location)
-    {
-        var resolved = ResolveUploadUri(tusEndpoint, location);
-        if (resolved is null)
-        {
-            return null;
-        }
-
-        var fileTransferId = tusEndpoint.AbsolutePath.TrimEnd('/').Split('/').Last();
-        return CanonicalizePartialUploadPath(resolved, fileTransferId);
-    }
-
     private static async Task CreateFinalUploadAsync(
         HttpClient httpClient,
         Uri tusEndpoint,
@@ -220,7 +208,7 @@ public static class TusUploader
         request.Headers.TryAddWithoutValidation("Upload-Concat", $"final;{partialReferences}");
 
         using var response = await httpClient.SendAsync(request, cancellationToken);
-        await EnsureSuccessAsync(response, "TUS final POST", HttpStatusCode.Created);
+        await EnsureSuccessAsync(response, "TUS final POST", HttpStatusCode.Created, requestUri: tusEndpoint);
     }
 
     private static async Task EnsurePartialUploadCompleteAsync(
@@ -246,7 +234,7 @@ public static class TusUploader
     }
 
     private static string ToTusConcatReference(Uri partialUploadUri)
-        => partialUploadUri.IsAbsoluteUri ? partialUploadUri.AbsolutePath : partialUploadUri.ToString();
+        => partialUploadUri.AbsolutePath;
 
     private static async Task UploadPartialAsync(
         HttpClient httpClient,
@@ -431,54 +419,56 @@ public static class TusUploader
         return new Uri(tusEndpoint, location);
     }
 
-    /// <summary>
-    /// Partial uploads are addressed at /tus/{fileTransferId}/partial/{partialUploadId}.
-    /// Canonicalize the Location path when the server omits the literal "partial" segment.
-    /// </summary>
-    private static Uri CanonicalizePartialUploadPath(Uri uploadUri, string fileTransferId)
+    private static Uri? ResolvePartialUploadUri(Uri tusEndpoint, Uri? location)
     {
-        if (!TryParseTusPathSegments(uploadUri, out var segments))
+        if (location is null)
         {
-            return uploadUri;
+            return null;
         }
 
-        if (segments.Length == 3
-            && string.Equals(segments[1], PartialPathSegment, StringComparison.OrdinalIgnoreCase))
-        {
-            return uploadUri;
-        }
-
-        if (segments.Length == 2 && Guid.TryParse(segments[0], out _))
-        {
-            return BuildUriWithPath(uploadUri, $"{TusUploadPath}/{segments[0]}/{PartialPathSegment}/{segments[1]}");
-        }
-
-        if (segments.Length == 1)
-        {
-            return BuildUriWithPath(uploadUri, $"{TusUploadPath}/{fileTransferId}/{PartialPathSegment}/{segments[0]}");
-        }
-
-        return uploadUri;
+        var fileTransferId = tusEndpoint.AbsolutePath.TrimEnd('/').Split('/').Last();
+        var partialUploadId = ExtractPartialUploadId(ResolveUploadUri(tusEndpoint, location) ?? location, fileTransferId);
+        return new Uri($"{tusEndpoint.GetLeftPart(UriPartial.Authority)}{TusUploadPath}/{fileTransferId}/{PartialPathSegment}/{partialUploadId}");
     }
 
-    private static Uri BuildUriWithPath(Uri baseUri, string path)
-        => baseUri.IsAbsoluteUri
-            ? new Uri($"{baseUri.GetLeftPart(UriPartial.Authority)}{path}")
-            : new Uri(path, UriKind.Relative);
-
-    private static bool TryParseTusPathSegments(Uri uploadUri, out string[] segments)
+    private static string ExtractPartialUploadId(Uri uploadUri, string fileTransferId)
     {
-        segments = [];
         var path = uploadUri.IsAbsoluteUri ? uploadUri.AbsolutePath : uploadUri.OriginalString;
         var prefix = $"{TusUploadPath}/";
-        if (!path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        if (path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
         {
-            return false;
+            var segments = path[prefix.Length..].TrimEnd('/')
+                .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            if (segments.Length == 3
+                && string.Equals(segments[1], PartialPathSegment, StringComparison.OrdinalIgnoreCase))
+            {
+                return segments[2];
+            }
+
+            if (segments.Length == 2 && string.Equals(segments[0], fileTransferId, StringComparison.OrdinalIgnoreCase))
+            {
+                return segments[1];
+            }
+
+            if (segments.Length == 1)
+            {
+                return segments[0];
+            }
         }
 
-        segments = path[prefix.Length..].TrimEnd('/')
-            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        return segments.Length > 0;
+        var relative = uploadUri.OriginalString.TrimStart('/');
+        if (relative.StartsWith($"{PartialPathSegment}/", StringComparison.OrdinalIgnoreCase))
+        {
+            return relative[(PartialPathSegment.Length + 1)..];
+        }
+
+        if (!relative.Contains('/'))
+        {
+            return relative;
+        }
+
+        throw new InvalidOperationException($"Could not determine partial upload id from {uploadUri}");
     }
 
     private static async Task EnsureSuccessAsync(

--- a/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
@@ -153,8 +153,9 @@ public static class TusUploader
             progress.Update(Interlocked.Add(ref progressBytes, uploadedBytes));
         });
 
-        var finalUri = await CreateFinalUploadAsync(httpClient, tusEndpoint, partialUris, cancellationToken);
-        var finalOffset = await GetUploadOffsetAsync(httpClient, finalUri, cancellationToken);
+        await CreateFinalUploadAsync(httpClient, tusEndpoint, partialUris, cancellationToken);
+        // Final concat POST creates a complete upload and the server may finalize it before a follow-up HEAD.
+        var finalOffset = uploadSize;
         if (finalOffset != uploadSize)
         {
             throw new InvalidOperationException(

--- a/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
@@ -384,6 +384,7 @@ public static class TusUploader
             {
                 using var chunkContent = new ByteArrayContent(buffer, 0, bytesRead);
                 chunkContent.Headers.ContentType = new MediaTypeHeaderValue("application/offset+octet-stream");
+                chunkContent.Headers.ContentLength = bytesRead;
 
                 using var patchRequest = new HttpRequestMessage(HttpMethod.Patch, uploadUri);
                 patchRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
@@ -399,18 +400,8 @@ public static class TusUploader
                 var responseBody = await patchResponse.Content.ReadAsStringAsync(cancellationToken);
                 if (patchResponse.StatusCode == HttpStatusCode.Conflict)
                 {
-                    var serverOffset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
-                    if (serverOffset > offset)
-                    {
-                        Console.WriteLine($"Upload-Offset conflict — server is at {serverOffset}, resuming.");
-                        return serverOffset;
-                    }
-
-                    if (serverOffset < offset)
-                    {
-                        Console.WriteLine(
-                            $"Upload-Offset conflict — server is behind at {serverOffset}, waiting for async commit to reach {offset}.");
-                    }
+                    offset = await ResolveOffsetAfterConflictAsync(httpClient, uploadUri, offset, cancellationToken);
+                    continue;
                 }
 
                 if (attempt == 5 || !IsTransientStatusCode(patchResponse.StatusCode))
@@ -422,19 +413,55 @@ public static class TusUploader
                 var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
                 Console.WriteLine(
                     $"TUS PATCH at offset {offset} failed ({patchResponse.StatusCode}), retrying in {delay.TotalSeconds:N0}s (attempt {attempt}/5)...");
+                offset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
                 await Task.Delay(delay, cancellationToken);
             }
-            catch (HttpRequestException ex) when (ex.InnerException is SocketException && attempt < 5)
+            catch (Exception ex) when (IsTransientRequestException(ex) && attempt < 5)
             {
                 var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
                 Console.WriteLine(
-                    $"TUS PATCH at offset {offset} failed ({ex.InnerException.GetType().Name}), retrying in {delay.TotalSeconds:N0}s (attempt {attempt}/5)...");
+                    $"TUS PATCH at offset {offset} failed ({ex.Message}), realigning offset and retrying in {delay.TotalSeconds:N0}s (attempt {attempt}/5)...");
+                offset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
                 await Task.Delay(delay, cancellationToken);
-            }            
+            }
         }
 
         throw new UnreachableException();
     }
+
+    private static async Task<long> ResolveOffsetAfterConflictAsync(
+        HttpClient httpClient,
+        Uri uploadUri,
+        long offset,
+        CancellationToken cancellationToken)
+    {
+        var serverOffset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
+        if (serverOffset > offset)
+        {
+            Console.WriteLine($"Upload-Offset conflict — server is at {serverOffset}, resuming.");
+            return serverOffset;
+        }
+
+        if (serverOffset < offset)
+        {
+            Console.WriteLine(
+                $"Upload-Offset conflict — server is behind at {serverOffset}, waiting for async commit to reach {offset}.");
+            for (var waitAttempt = 0; waitAttempt < 30; waitAttempt++)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken);
+                serverOffset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
+                if (serverOffset >= offset)
+                {
+                    return serverOffset;
+                }
+            }
+        }
+
+        return serverOffset;
+    }
+
+    private static bool IsTransientRequestException(Exception exception)
+        => exception is HttpRequestException or IOException or TaskCanceledException;
 
     private static async Task<long> GetUploadOffsetAsync(
         HttpClient httpClient,

--- a/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
@@ -303,7 +303,8 @@ public static class TusUploader
         Uri partialUploadUri,
         CancellationToken cancellationToken)
     {
-        using var headRequest = new HttpRequestMessage(HttpMethod.Head, partialUploadUri);
+        var uploadUri = await ResolveWorkingPartialUploadUriAsync(httpClient, partialUploadUri, cancellationToken);
+        using var headRequest = new HttpRequestMessage(HttpMethod.Head, uploadUri);
         headRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
 
         using var headResponse = await httpClient.SendAsync(headRequest, cancellationToken);
@@ -342,7 +343,8 @@ public static class TusUploader
         Action<long> onBytesUploaded,
         CancellationToken cancellationToken)
     {
-        var offset = await GetUploadOffsetAsync(httpClient, partialUploadUri, cancellationToken);
+        var uploadUri = await ResolveWorkingPartialUploadUriAsync(httpClient, partialUploadUri, cancellationToken);
+        var offset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
         var buffer = new byte[chunkSize];
 
         while (offset < partLength)
@@ -357,7 +359,7 @@ public static class TusUploader
             }
 
             var chunkStartOffset = offset;
-            offset = await PatchChunkAsync(httpClient, partialUploadUri, offset, buffer, bytesRead, cancellationToken);
+            offset = await PatchChunkAsync(httpClient, uploadUri, offset, buffer, bytesRead, cancellationToken);
             var uploadedThisChunk = Math.Max(offset - chunkStartOffset, 0);
             if (uploadedThisChunk > 0)
             {
@@ -519,23 +521,156 @@ public static class TusUploader
     private static bool IsTransientRequestException(Exception exception)
         => exception is HttpRequestException or IOException or TaskCanceledException;
 
+    private static async Task<Uri> ResolveWorkingPartialUploadUriAsync(
+        HttpClient httpClient,
+        Uri partialUploadUri,
+        CancellationToken cancellationToken)
+    {
+        Exception? lastError = null;
+        foreach (var candidate in GetPartialUploadUriCandidates(partialUploadUri))
+        {
+            using var headResponse = await SendHeadAsync(httpClient, candidate, cancellationToken);
+            if (headResponse.IsSuccessStatusCode)
+            {
+                if (!ReferenceEquals(candidate, partialUploadUri) && !candidate.Equals(partialUploadUri))
+                {
+                    Console.WriteLine($"Using alternate partial upload URL {candidate}.");
+                }
+
+                return candidate;
+            }
+
+            var responseBody = await headResponse.Content.ReadAsStringAsync(cancellationToken);
+            lastError = new InvalidOperationException(
+                $"TUS HEAD failed with {(int)headResponse.StatusCode} {headResponse.StatusCode}: {responseBody}");
+        }
+
+        throw lastError ?? new InvalidOperationException("TUS HEAD failed for all partial upload URL candidates.");
+    }
+
+    private static IEnumerable<Uri> GetPartialUploadUriCandidates(Uri partialUploadUri)
+    {
+        yield return partialUploadUri;
+
+        if (TryGetNormalizedPartialUploadUri(partialUploadUri, out var normalizedPartialUri))
+        {
+            yield return normalizedPartialUri;
+        }
+
+        if (TryGetSingleSegmentPartialUploadUri(partialUploadUri, out var singleSegmentPartialUri))
+        {
+            yield return singleSegmentPartialUri;
+        }
+    }
+
     private static async Task<long> GetUploadOffsetAsync(
         HttpClient httpClient,
         Uri uploadUri,
         CancellationToken cancellationToken)
     {
-        using var headRequest = new HttpRequestMessage(HttpMethod.Head, uploadUri);
-        headRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
-
-        using var headResponse = await httpClient.SendAsync(headRequest, cancellationToken);
-        var responseBody = await headResponse.Content.ReadAsStringAsync(cancellationToken);
-        if (!headResponse.IsSuccessStatusCode)
+        Exception? lastError = null;
+        foreach (var candidate in GetPartialUploadUriCandidates(uploadUri))
         {
-            throw new InvalidOperationException(
+            using var headResponse = await SendHeadAsync(httpClient, candidate, cancellationToken);
+            if (headResponse.IsSuccessStatusCode)
+            {
+                return ParseUploadOffset(headResponse.Headers);
+            }
+
+            var responseBody = await headResponse.Content.ReadAsStringAsync(cancellationToken);
+            lastError = new InvalidOperationException(
                 $"TUS HEAD failed with {(int)headResponse.StatusCode} {headResponse.StatusCode}: {responseBody}");
         }
 
-        return ParseUploadOffset(headResponse.Headers);
+        throw lastError ?? new InvalidOperationException("TUS HEAD failed for all upload URL candidates.");
+    }
+
+    private static async Task<HttpResponseMessage> SendHeadAsync(
+        HttpClient httpClient,
+        Uri uploadUri,
+        CancellationToken cancellationToken)
+    {
+        var headRequest = new HttpRequestMessage(HttpMethod.Head, uploadUri);
+        headRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+        return await httpClient.SendAsync(headRequest, cancellationToken);
+    }
+
+    /// <summary>
+    /// Converts legacy /tus/{fileTransferId}/{partialId} URLs to /tus/{fileTransferId}/partial/{partialId}.
+    /// </summary>
+    private static bool TryGetNormalizedPartialUploadUri(Uri uploadUri, out Uri normalizedPartialUri)
+    {
+        normalizedPartialUri = uploadUri;
+        if (!TryParseTusPathSegments(uploadUri, out var segments))
+        {
+            return false;
+        }
+
+        if (segments.Length != 2 || !Guid.TryParse(segments[0], out _))
+        {
+            return false;
+        }
+
+        return TryBuildPartialUploadUri(uploadUri, segments[0], segments[1], out normalizedPartialUri);
+    }
+
+    /// <summary>
+    /// Oldest deployments returned partial Location as /tus/{partialId} only.
+    /// </summary>
+    private static bool TryGetSingleSegmentPartialUploadUri(Uri uploadUri, out Uri singleSegmentPartialUri)
+    {
+        singleSegmentPartialUri = uploadUri;
+        if (!TryParseTusPathSegments(uploadUri, out var segments))
+        {
+            return false;
+        }
+
+        var partialId = segments.Length switch
+        {
+            1 => segments[0],
+            2 => segments[1],
+            3 when string.Equals(segments[1], "partial", StringComparison.OrdinalIgnoreCase) => segments[2],
+            _ => null
+        };
+
+        if (string.IsNullOrEmpty(partialId))
+        {
+            return false;
+        }
+
+        var legacyPath = $"{TusUploadPath}/{partialId}";
+        singleSegmentPartialUri = uploadUri.IsAbsoluteUri
+            ? new Uri(uploadUri.GetLeftPart(UriPartial.Authority) + legacyPath)
+            : new Uri(legacyPath, UriKind.Relative);
+        return true;
+    }
+
+    private static bool TryBuildPartialUploadUri(
+        Uri uploadUri,
+        string fileTransferId,
+        string partialId,
+        out Uri partialUploadUri)
+    {
+        var normalizedPath = $"{TusUploadPath}/{fileTransferId}/partial/{partialId}";
+        partialUploadUri = uploadUri.IsAbsoluteUri
+            ? new Uri(uploadUri.GetLeftPart(UriPartial.Authority) + normalizedPath)
+            : new Uri(normalizedPath, UriKind.Relative);
+        return true;
+    }
+
+    private static bool TryParseTusPathSegments(Uri uploadUri, out string[] segments)
+    {
+        segments = [];
+        var path = uploadUri.IsAbsoluteUri ? uploadUri.AbsolutePath : uploadUri.ToString();
+        var prefix = $"{TusUploadPath}/";
+        if (!path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        segments = path[prefix.Length..].TrimEnd('/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return segments.Length > 0;
     }
 
     private static long ParseUploadOffset(HttpResponseHeaders headers)

--- a/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Sockets;
 
 namespace Altinn.Broker.Tests.LargeFile;
 
@@ -378,47 +379,57 @@ public static class TusUploader
     {
         for (var attempt = 1; attempt <= 5; attempt++)
         {
-            using var chunkContent = new ByteArrayContent(buffer, 0, bytesRead);
-            chunkContent.Headers.ContentType = new MediaTypeHeaderValue("application/offset+octet-stream");
-
-            using var patchRequest = new HttpRequestMessage(HttpMethod.Patch, uploadUri);
-            patchRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
-            patchRequest.Headers.TryAddWithoutValidation("Upload-Offset", offset.ToString());
-            patchRequest.Content = chunkContent;
-
-            using var patchResponse = await httpClient.SendAsync(patchRequest, cancellationToken);
-            if (patchResponse.StatusCode == HttpStatusCode.NoContent)
+            try
             {
-                return ParseUploadOffset(patchResponse.Headers);
-            }
+                using var chunkContent = new ByteArrayContent(buffer, 0, bytesRead);
+                chunkContent.Headers.ContentType = new MediaTypeHeaderValue("application/offset+octet-stream");
 
-            var responseBody = await patchResponse.Content.ReadAsStringAsync(cancellationToken);
-            if (patchResponse.StatusCode == HttpStatusCode.Conflict)
-            {
-                var serverOffset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
-                if (serverOffset > offset)
+                using var patchRequest = new HttpRequestMessage(HttpMethod.Patch, uploadUri);
+                patchRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+                patchRequest.Headers.TryAddWithoutValidation("Upload-Offset", offset.ToString());
+                patchRequest.Content = chunkContent;
+
+                using var patchResponse = await httpClient.SendAsync(patchRequest, cancellationToken);
+                if (patchResponse.StatusCode == HttpStatusCode.NoContent)
                 {
-                    Console.WriteLine($"Upload-Offset conflict — server is at {serverOffset}, resuming.");
-                    return serverOffset;
+                    return ParseUploadOffset(patchResponse.Headers);
                 }
 
-                if (serverOffset < offset)
+                var responseBody = await patchResponse.Content.ReadAsStringAsync(cancellationToken);
+                if (patchResponse.StatusCode == HttpStatusCode.Conflict)
                 {
-                    Console.WriteLine(
-                        $"Upload-Offset conflict — server is behind at {serverOffset}, waiting for async commit to reach {offset}.");
+                    var serverOffset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
+                    if (serverOffset > offset)
+                    {
+                        Console.WriteLine($"Upload-Offset conflict — server is at {serverOffset}, resuming.");
+                        return serverOffset;
+                    }
+
+                    if (serverOffset < offset)
+                    {
+                        Console.WriteLine(
+                            $"Upload-Offset conflict — server is behind at {serverOffset}, waiting for async commit to reach {offset}.");
+                    }
                 }
-            }
 
-            if (attempt == 5 || !IsTransientStatusCode(patchResponse.StatusCode))
+                if (attempt == 5 || !IsTransientStatusCode(patchResponse.StatusCode))
+                {
+                    throw new InvalidOperationException(
+                        $"TUS PATCH failed at offset {offset} with {(int)patchResponse.StatusCode} {patchResponse.StatusCode}: {responseBody}");
+                }
+
+                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
+                Console.WriteLine(
+                    $"TUS PATCH at offset {offset} failed ({patchResponse.StatusCode}), retrying in {delay.TotalSeconds:N0}s (attempt {attempt}/5)...");
+                await Task.Delay(delay, cancellationToken);
+            }
+            catch (HttpRequestException ex) when (ex.InnerException is SocketException && attempt < 5)
             {
-                throw new InvalidOperationException(
-                    $"TUS PATCH failed at offset {offset} with {(int)patchResponse.StatusCode} {patchResponse.StatusCode}: {responseBody}");
-            }
-
-            var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
-            Console.WriteLine(
-                $"TUS PATCH at offset {offset} failed ({patchResponse.StatusCode}), retrying in {delay.TotalSeconds:N0}s (attempt {attempt}/5)...");
-            await Task.Delay(delay, cancellationToken);
+                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
+                Console.WriteLine(
+                    $"TUS PATCH at offset {offset} failed ({ex.InnerException.GetType().Name}), retrying in {delay.TotalSeconds:N0}s (attempt {attempt}/5)...");
+                await Task.Delay(delay, cancellationToken);
+            }            
         }
 
         throw new UnreachableException();

--- a/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
@@ -8,6 +8,8 @@ public static class TusUploader
 {
     private const string TusVersion = "1.0.0";
 
+    private sealed record TusServerCapabilities(bool SupportsConcatenation);
+
     public static async Task UploadAsync(
         HttpClient httpClient,
         string baseUrl,
@@ -81,6 +83,91 @@ public static class TusUploader
             $"{uploadSize / (1024.0 * 1024 * 1024):N2} GiB in {totalSeconds:N1}s (avg: {averageSpeedMbps:N2} MB/s)");
     }
 
+    // Reference implementation for TUS concatenation extension.
+    public static async Task UploadWithConcatenationAsync(
+        HttpClient httpClient,
+        string baseUrl,
+        string fileTransferId,
+        Stream source,
+        long uploadSize,
+        int chunkSize,
+        int parallelPartialUploads,
+        CancellationToken cancellationToken = default)
+    {
+        if (chunkSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(chunkSize), chunkSize, "Chunk size must be greater than zero.");
+        }
+
+        if (parallelPartialUploads <= 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(parallelPartialUploads),
+                parallelPartialUploads,
+                "Use a value greater than 1 for concatenation uploads.");
+        }
+
+        if (!source.CanSeek)
+        {
+            throw new InvalidOperationException("Concatenation upload requires a seekable source stream.");
+        }
+
+        var tusEndpoint = BuildTusEndpointUri(baseUrl, fileTransferId);
+        var capabilities = await EnsureServerSupportsTus(httpClient, tusEndpoint, cancellationToken);
+        if (!capabilities.SupportsConcatenation)
+        {
+            throw new InvalidOperationException(
+                "Server does not advertise TUS concatenation support (Tus-Extension missing 'concatenation').");
+        }
+
+        var partRanges = BuildPartRanges(uploadSize, parallelPartialUploads);
+        var partialUris = new Uri[partRanges.Count];
+        for (var i = 0; i < partRanges.Count; i++)
+        {
+            partialUris[i] = await CreatePartialUploadAsync(
+                httpClient,
+                tusEndpoint,
+                partRanges[i].Length,
+                cancellationToken);
+        }
+
+        var readLock = new object();
+        var progress = new UploadProgress(uploadSize, 0);
+        using var progressTimer = new Timer(_ => progress.LogProgress(), null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+        var totalStopwatch = Stopwatch.StartNew();
+        long progressBytes = 0;
+
+        await Parallel.ForAsync(0, partRanges.Count, cancellationToken, async (partIndex, ct) =>
+        {
+            var part = partRanges[partIndex];
+            var uploadedBytes = await UploadPartialAsync(
+                httpClient,
+                partialUris[partIndex],
+                source,
+                readLock,
+                part.StartOffset,
+                part.Length,
+                chunkSize,
+                ct);
+            progress.Update(Interlocked.Add(ref progressBytes, uploadedBytes));
+        });
+
+        var finalUri = await CreateFinalUploadAsync(httpClient, tusEndpoint, partialUris, cancellationToken);
+        var finalOffset = await GetUploadOffsetAsync(httpClient, finalUri, cancellationToken);
+        if (finalOffset != uploadSize)
+        {
+            throw new InvalidOperationException(
+                $"Concatenated upload completed with unexpected offset {finalOffset}, expected {uploadSize}.");
+        }
+
+        totalStopwatch.Stop();
+        var totalSeconds = Math.Max(totalStopwatch.Elapsed.TotalSeconds, 0.001);
+        var averageSpeedMbps = uploadSize / (1024.0 * 1024) / totalSeconds;
+        Console.WriteLine(
+            $"TUS concatenation upload completed for {fileTransferId}: " +
+            $"{uploadSize / (1024.0 * 1024 * 1024):N2} GiB in {totalSeconds:N1}s (avg: {averageSpeedMbps:N2} MB/s)");
+    }
+
     private sealed class UploadProgress(long totalSize, long initialOffset)
     {
         private long _offset = initialOffset;
@@ -105,7 +192,7 @@ public static class TusUploader
     private static Uri BuildTusEndpointUri(string baseUrl, string fileTransferId)
         => new($"{baseUrl.TrimEnd('/')}/broker/api/v1/filetransfer/upload/tus/{fileTransferId}");
 
-    private static async Task EnsureServerSupportsTus(HttpClient httpClient, Uri tusEndpoint, CancellationToken cancellationToken)
+    private static async Task<TusServerCapabilities> EnsureServerSupportsTus(HttpClient httpClient, Uri tusEndpoint, CancellationToken cancellationToken)
     {
         using var optionsRequest = new HttpRequestMessage(HttpMethod.Options, tusEndpoint);
         optionsRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
@@ -122,6 +209,13 @@ public static class TusUploader
         {
             throw new InvalidOperationException("Server did not return Tus-Resumable header — is the TUS endpoint enabled?");
         }
+
+        var supportsConcatenation = optionsResponse.Headers.TryGetValues("Tus-Extension", out var extensionHeaderValues)
+            && extensionHeaderValues
+                .SelectMany(static value => value.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+                .Any(static extension => string.Equals(extension, "concatenation", StringComparison.OrdinalIgnoreCase));
+
+        return new TusServerCapabilities(supportsConcatenation);
     }
 
     private static async Task<Uri> CreateUploadAsync(
@@ -152,6 +246,126 @@ public static class TusUploader
 
         throw new InvalidOperationException(
             $"TUS POST failed with {(int)createResponse.StatusCode} {createResponse.StatusCode}: {responseBody}");
+    }
+
+    private static async Task<Uri> CreatePartialUploadAsync(
+        HttpClient httpClient,
+        Uri tusEndpoint,
+        long partLength,
+        CancellationToken cancellationToken)
+    {
+        using var createRequest = new HttpRequestMessage(HttpMethod.Post, tusEndpoint);
+        createRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+        createRequest.Headers.TryAddWithoutValidation("Upload-Length", partLength.ToString());
+        createRequest.Headers.TryAddWithoutValidation("Upload-Concat", "partial");
+
+        using var createResponse = await httpClient.SendAsync(createRequest, cancellationToken);
+        var responseBody = await createResponse.Content.ReadAsStringAsync(cancellationToken);
+        if (createResponse.StatusCode != HttpStatusCode.Created)
+        {
+            throw new InvalidOperationException(
+                $"TUS partial POST failed with {(int)createResponse.StatusCode} {createResponse.StatusCode}: {responseBody}");
+        }
+
+        return ResolveUploadUri(tusEndpoint, createResponse.Headers.Location)
+            ?? throw new InvalidOperationException("TUS partial POST succeeded but no Location header was returned.");
+    }
+
+    private static async Task<Uri> CreateFinalUploadAsync(
+        HttpClient httpClient,
+        Uri tusEndpoint,
+        IReadOnlyList<Uri> partialUris,
+        CancellationToken cancellationToken)
+    {
+        using var createRequest = new HttpRequestMessage(HttpMethod.Post, tusEndpoint);
+        createRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+        createRequest.Headers.TryAddWithoutValidation(
+            "Upload-Concat",
+            $"final;{string.Join(' ', partialUris.Select(static uri => uri.ToString()))}");
+
+        using var createResponse = await httpClient.SendAsync(createRequest, cancellationToken);
+        var responseBody = await createResponse.Content.ReadAsStringAsync(cancellationToken);
+        if (createResponse.StatusCode != HttpStatusCode.Created)
+        {
+            throw new InvalidOperationException(
+                $"TUS final POST failed with {(int)createResponse.StatusCode} {createResponse.StatusCode}: {responseBody}");
+        }
+
+        return ResolveUploadUri(tusEndpoint, createResponse.Headers.Location)
+            ?? throw new InvalidOperationException("TUS final POST succeeded but no Location header was returned.");
+    }
+
+    private static async Task<long> UploadPartialAsync(
+        HttpClient httpClient,
+        Uri partialUploadUri,
+        Stream sharedSource,
+        object readLock,
+        long sourceStartOffset,
+        long partLength,
+        int chunkSize,
+        CancellationToken cancellationToken)
+    {
+        var offset = await GetUploadOffsetAsync(httpClient, partialUploadUri, cancellationToken);
+        var buffer = new byte[chunkSize];
+
+        while (offset < partLength)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var bytesToRead = (int)Math.Min(chunkSize, partLength - offset);
+            var bytesRead = ReadAtAbsoluteOffset(sharedSource, readLock, sourceStartOffset + offset, buffer, bytesToRead);
+            if (bytesRead == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Source stream ended unexpectedly at part offset {offset} (expected {partLength} bytes).");
+            }
+
+            offset = await PatchChunkAsync(httpClient, partialUploadUri, offset, buffer, bytesRead, cancellationToken);
+        }
+
+        return partLength;
+    }
+
+    private static int ReadAtAbsoluteOffset(
+        Stream source,
+        object readLock,
+        long absoluteOffset,
+        byte[] buffer,
+        int count)
+    {
+        lock (readLock)
+        {
+            source.Seek(absoluteOffset, SeekOrigin.Begin);
+            var totalRead = 0;
+            while (totalRead < count)
+            {
+                var read = source.Read(buffer, totalRead, count - totalRead);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                totalRead += read;
+            }
+
+            return totalRead;
+        }
+    }
+
+    private static List<(long StartOffset, long Length)> BuildPartRanges(long uploadSize, int partCount)
+    {
+        var ranges = new List<(long StartOffset, long Length)>(partCount);
+        var basePartLength = uploadSize / partCount;
+        var remainder = uploadSize % partCount;
+        long currentStart = 0;
+
+        for (var i = 0; i < partCount; i++)
+        {
+            var length = basePartLength + (i < remainder ? 1 : 0);
+            ranges.Add((currentStart, length));
+            currentStart += length;
+        }
+
+        return ranges;
     }
 
     private static async Task<long> PatchChunkAsync(
@@ -186,6 +400,12 @@ public static class TusUploader
                 {
                     Console.WriteLine($"Upload-Offset conflict — server is at {serverOffset}, resuming.");
                     return serverOffset;
+                }
+
+                if (serverOffset < offset)
+                {
+                    Console.WriteLine(
+                        $"Upload-Offset conflict — server is behind at {serverOffset}, waiting for async commit to reach {offset}.");
                 }
             }
 
@@ -246,6 +466,7 @@ public static class TusUploader
 
     private static bool IsTransientStatusCode(HttpStatusCode statusCode)
         => statusCode is HttpStatusCode.RequestTimeout
+            or HttpStatusCode.Conflict
             or HttpStatusCode.TooManyRequests
             or HttpStatusCode.InternalServerError
             or HttpStatusCode.BadGateway

--- a/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
@@ -17,6 +17,11 @@ public static class TusUploader
         int chunkSize,
         CancellationToken cancellationToken = default)
     {
+        if (chunkSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(chunkSize), chunkSize, "Chunk size must be greater than zero.");
+        }
+
         var tusEndpoint = BuildTusEndpointUri(baseUrl, fileTransferId);
         await EnsureServerSupportsTus(httpClient, tusEndpoint, cancellationToken);
 
@@ -45,7 +50,20 @@ public static class TusUploader
                     $"Source stream ended unexpectedly at offset {offset} (expected {uploadSize} bytes).");
             }
 
-            offset = await PatchChunkAsync(httpClient, uploadUri, offset, buffer, bytesRead, cancellationToken);
+            var chunkStartOffset = offset;
+            offset = await PatchChunkAsync(httpClient, uploadUri, chunkStartOffset, buffer, bytesRead, cancellationToken);
+            var expectedOffset = chunkStartOffset + bytesRead;
+            if (offset != expectedOffset)
+            {
+                if (!source.CanSeek)
+                {
+                    throw new InvalidOperationException(
+                        $"Server reported offset {offset}, expected {expectedOffset}, but the source stream cannot be realigned.");
+                }
+
+                source.Seek(offset, SeekOrigin.Begin);
+            }
+
             progress.Update(offset);
 
             if (offset > uploadSize)
@@ -81,7 +99,6 @@ public static class TusUploader
                 $"Progress: {currentOffset * 100.0 / totalSize:F3}% " +
                 $"({currentOffset / (1024.0 * 1024 * 1024):N2} GiB / {totalSize / (1024.0 * 1024 * 1024):N2} GiB) " +
                 $"avg {currentOffset / elapsedSeconds / (1024 * 1024):N2} MiB/s");
-            _intervalStopwatch.Restart();
         }
     }
 
@@ -158,7 +175,7 @@ public static class TusUploader
             using var patchResponse = await httpClient.SendAsync(patchRequest, cancellationToken);
             if (patchResponse.StatusCode == HttpStatusCode.NoContent)
             {
-                return ParseUploadOffset(patchResponse.Headers, offset + bytesRead);
+                return ParseUploadOffset(patchResponse.Headers);
             }
 
             var responseBody = await patchResponse.Content.ReadAsStringAsync(cancellationToken);
@@ -203,10 +220,10 @@ public static class TusUploader
                 $"TUS HEAD failed with {(int)headResponse.StatusCode} {headResponse.StatusCode}: {responseBody}");
         }
 
-        return ParseUploadOffset(headResponse.Headers, 0);
+        return ParseUploadOffset(headResponse.Headers);
     }
 
-    private static long ParseUploadOffset(HttpResponseHeaders headers, long fallbackOffset)
+    private static long ParseUploadOffset(HttpResponseHeaders headers)
     {
         if (headers.TryGetValues("Upload-Offset", out var values)
             && long.TryParse(values.FirstOrDefault(), out var parsedOffset))
@@ -214,7 +231,7 @@ public static class TusUploader
             return parsedOffset;
         }
 
-        return fallbackOffset;
+        throw new InvalidOperationException("TUS response did not include a valid Upload-Offset header.");
     }
 
     private static Uri? ResolveUploadUri(Uri tusEndpoint, Uri? location)

--- a/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
@@ -1,0 +1,237 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Altinn.Broker.Tests.LargeFile;
+
+public static class TusUploader
+{
+    private const string TusVersion = "1.0.0";
+
+    public static async Task UploadAsync(
+        HttpClient httpClient,
+        string baseUrl,
+        string fileTransferId,
+        Stream source,
+        long uploadSize,
+        int chunkSize,
+        CancellationToken cancellationToken = default)
+    {
+        var tusEndpoint = BuildTusEndpointUri(baseUrl, fileTransferId);
+        await EnsureServerSupportsTus(httpClient, tusEndpoint, cancellationToken);
+
+        var uploadUri = await CreateUploadAsync(httpClient, tusEndpoint, fileTransferId, uploadSize, cancellationToken);
+        var offset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
+        if (offset > 0)
+        {
+            Console.WriteLine($"Resuming upload at offset {offset:N0} ({offset * 100.0 / uploadSize:F3}%)");
+            source.Seek(offset, SeekOrigin.Begin);
+        }
+
+        var progress = new UploadProgress(uploadSize, offset);
+        using var progressTimer = new Timer(_ => progress.LogProgress(), null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+        var totalStopwatch = Stopwatch.StartNew();
+
+        var buffer = new byte[chunkSize];
+        while (offset < uploadSize)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var bytesToRead = (int)Math.Min(chunkSize, uploadSize - offset);
+            var bytesRead = await source.ReadAsync(buffer.AsMemory(0, bytesToRead), cancellationToken);
+            if (bytesRead == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Source stream ended unexpectedly at offset {offset} (expected {uploadSize} bytes).");
+            }
+
+            offset = await PatchChunkAsync(httpClient, uploadUri, offset, buffer, bytesRead, cancellationToken);
+            progress.Update(offset);
+
+            if (offset > uploadSize)
+            {
+                throw new InvalidOperationException(
+                    $"Server reported offset {offset} which exceeds upload length {uploadSize}.");
+            }
+        }
+
+        totalStopwatch.Stop();
+        var totalSeconds = Math.Max(totalStopwatch.Elapsed.TotalSeconds, 0.001);
+        var averageSpeedMbps = uploadSize / (1024.0 * 1024) / totalSeconds;
+        Console.WriteLine(
+            $"TUS upload completed for {fileTransferId}: " +
+            $"{uploadSize / (1024.0 * 1024 * 1024):N2} GiB in {totalSeconds:N1}s (avg: {averageSpeedMbps:N2} MB/s)");
+    }
+
+    private sealed class UploadProgress(long totalSize, long initialOffset)
+    {
+        private long _offset = initialOffset;
+        private readonly Stopwatch _intervalStopwatch = Stopwatch.StartNew();
+
+        public void Update(long offset)
+        {
+            Interlocked.Exchange(ref _offset, offset);
+        }
+
+        public void LogProgress()
+        {
+            var currentOffset = Interlocked.Read(ref _offset);
+            var elapsedSeconds = Math.Max(_intervalStopwatch.Elapsed.TotalSeconds, 0.001);
+            Console.WriteLine(
+                $"Progress: {currentOffset * 100.0 / totalSize:F3}% " +
+                $"({currentOffset / (1024.0 * 1024 * 1024):N2} GiB / {totalSize / (1024.0 * 1024 * 1024):N2} GiB) " +
+                $"avg {currentOffset / elapsedSeconds / (1024 * 1024):N2} MiB/s");
+            _intervalStopwatch.Restart();
+        }
+    }
+
+    private static Uri BuildTusEndpointUri(string baseUrl, string fileTransferId)
+        => new($"{baseUrl.TrimEnd('/')}/broker/api/v1/filetransfer/{fileTransferId}/upload/tus");
+
+    private static async Task EnsureServerSupportsTus(HttpClient httpClient, Uri tusEndpoint, CancellationToken cancellationToken)
+    {
+        using var optionsRequest = new HttpRequestMessage(HttpMethod.Options, tusEndpoint);
+        optionsRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+
+        using var optionsResponse = await httpClient.SendAsync(optionsRequest, cancellationToken);
+        var responseBody = await optionsResponse.Content.ReadAsStringAsync(cancellationToken);
+        if (!optionsResponse.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"TUS OPTIONS failed with {(int)optionsResponse.StatusCode} {optionsResponse.StatusCode}: {responseBody}");
+        }
+
+        if (!optionsResponse.Headers.Contains("Tus-Resumable"))
+        {
+            throw new InvalidOperationException("Server did not return Tus-Resumable header — is the TUS endpoint enabled?");
+        }
+    }
+
+    private static async Task<Uri> CreateUploadAsync(
+        HttpClient httpClient,
+        Uri tusEndpoint,
+        string fileTransferId,
+        long uploadSize,
+        CancellationToken cancellationToken)
+    {
+        using var createRequest = new HttpRequestMessage(HttpMethod.Post, tusEndpoint);
+        createRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+        createRequest.Headers.TryAddWithoutValidation("Upload-Length", uploadSize.ToString());
+
+        using var createResponse = await httpClient.SendAsync(createRequest, cancellationToken);
+        var responseBody = await createResponse.Content.ReadAsStringAsync(cancellationToken);
+
+        if (createResponse.StatusCode == HttpStatusCode.Created)
+        {
+            return ResolveUploadUri(tusEndpoint, createResponse.Headers.Location)
+                ?? throw new InvalidOperationException("TUS POST succeeded but no Location header was returned.");
+        }
+
+        if (createResponse.StatusCode == HttpStatusCode.Conflict)
+        {
+            Console.WriteLine("Upload resource already exists — resuming via HEAD.");
+            return new Uri(tusEndpoint, fileTransferId);
+        }
+
+        throw new InvalidOperationException(
+            $"TUS POST failed with {(int)createResponse.StatusCode} {createResponse.StatusCode}: {responseBody}");
+    }
+
+    private static async Task<long> PatchChunkAsync(
+        HttpClient httpClient,
+        Uri uploadUri,
+        long offset,
+        byte[] buffer,
+        int bytesRead,
+        CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; attempt <= 5; attempt++)
+        {
+            using var chunkContent = new ByteArrayContent(buffer, 0, bytesRead);
+            chunkContent.Headers.ContentType = new MediaTypeHeaderValue("application/offset+octet-stream");
+
+            using var patchRequest = new HttpRequestMessage(HttpMethod.Patch, uploadUri);
+            patchRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+            patchRequest.Headers.TryAddWithoutValidation("Upload-Offset", offset.ToString());
+            patchRequest.Content = chunkContent;
+
+            using var patchResponse = await httpClient.SendAsync(patchRequest, cancellationToken);
+            if (patchResponse.StatusCode == HttpStatusCode.NoContent)
+            {
+                return ParseUploadOffset(patchResponse.Headers, offset + bytesRead);
+            }
+
+            var responseBody = await patchResponse.Content.ReadAsStringAsync(cancellationToken);
+            if (patchResponse.StatusCode == HttpStatusCode.Conflict)
+            {
+                var serverOffset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
+                if (serverOffset > offset)
+                {
+                    Console.WriteLine($"Upload-Offset conflict — server is at {serverOffset}, resuming.");
+                    return serverOffset;
+                }
+            }
+
+            if (attempt == 5 || !IsTransientStatusCode(patchResponse.StatusCode))
+            {
+                throw new InvalidOperationException(
+                    $"TUS PATCH failed at offset {offset} with {(int)patchResponse.StatusCode} {patchResponse.StatusCode}: {responseBody}");
+            }
+
+            var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
+            Console.WriteLine(
+                $"TUS PATCH at offset {offset} failed ({patchResponse.StatusCode}), retrying in {delay.TotalSeconds:N0}s (attempt {attempt}/5)...");
+            await Task.Delay(delay, cancellationToken);
+        }
+
+        throw new UnreachableException();
+    }
+
+    private static async Task<long> GetUploadOffsetAsync(
+        HttpClient httpClient,
+        Uri uploadUri,
+        CancellationToken cancellationToken)
+    {
+        using var headRequest = new HttpRequestMessage(HttpMethod.Head, uploadUri);
+        headRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+
+        using var headResponse = await httpClient.SendAsync(headRequest, cancellationToken);
+        var responseBody = await headResponse.Content.ReadAsStringAsync(cancellationToken);
+        if (!headResponse.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"TUS HEAD failed with {(int)headResponse.StatusCode} {headResponse.StatusCode}: {responseBody}");
+        }
+
+        return ParseUploadOffset(headResponse.Headers, 0);
+    }
+
+    private static long ParseUploadOffset(HttpResponseHeaders headers, long fallbackOffset)
+    {
+        if (headers.TryGetValues("Upload-Offset", out var values)
+            && long.TryParse(values.FirstOrDefault(), out var parsedOffset))
+        {
+            return parsedOffset;
+        }
+
+        return fallbackOffset;
+    }
+
+    private static Uri? ResolveUploadUri(Uri tusEndpoint, Uri? location)
+    {
+        if (location is null)
+        {
+            return null;
+        }
+
+        return location.IsAbsoluteUri ? location : new Uri(tusEndpoint, location);
+    }
+
+    private static bool IsTransientStatusCode(HttpStatusCode statusCode)
+        => statusCode is HttpStatusCode.RequestTimeout
+            or HttpStatusCode.TooManyRequests
+            or HttpStatusCode.InternalServerError
+            or HttpStatusCode.BadGateway
+            or HttpStatusCode.ServiceUnavailable
+            or HttpStatusCode.GatewayTimeout;
+}

--- a/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
+++ b/tests/Altinn.Broker.Tests.LargeFile/TusUploader.cs
@@ -1,15 +1,19 @@
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
-using System.Net.Sockets;
 
 namespace Altinn.Broker.Tests.LargeFile;
 
+/// <summary>
+/// Reference implementation for uploading files to Altinn Broker via TUS.
+/// Supports single-stream uploads and the TUS concatenation extension for parallel partial uploads.
+/// </summary>
 public static class TusUploader
 {
     private const string TusVersion = "1.0.0";
-
-    private sealed record TusServerCapabilities(bool SupportsConcatenation);
+    private const string TusUploadPath = "/broker/api/v1/filetransfer/upload/tus";
+    private const string PartialPathSegment = "partial";
+    private const int MaxPatchAttempts = 5;
 
     public static async Task UploadAsync(
         HttpClient httpClient,
@@ -20,23 +24,18 @@ public static class TusUploader
         int chunkSize,
         CancellationToken cancellationToken = default)
     {
-        if (chunkSize <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(chunkSize), chunkSize, "Chunk size must be greater than zero.");
-        }
-
         var tusEndpoint = BuildTusEndpointUri(baseUrl, fileTransferId);
         await EnsureServerSupportsTus(httpClient, tusEndpoint, cancellationToken);
 
-        var uploadUri = await CreateUploadAsync(httpClient, tusEndpoint, fileTransferId, uploadSize, cancellationToken);
+        var uploadUri = await CreateUploadAsync(httpClient, tusEndpoint, uploadSize, cancellationToken);
         var offset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
         if (offset > 0)
         {
-            Console.WriteLine($"Resuming upload at offset {offset:N0} ({offset * 100.0 / uploadSize:F3}%)");
+            Console.WriteLine($"Resuming upload at offset {offset:N0}");
             source.Seek(offset, SeekOrigin.Begin);
         }
 
-        var progress = new UploadProgress(uploadSize, offset);
+        var progress = new UploadProgress(uploadSize);
         using var progressTimer = new Timer(_ => progress.LogProgress(), null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
         var totalStopwatch = Stopwatch.StartNew();
 
@@ -49,42 +48,16 @@ public static class TusUploader
             var bytesRead = await source.ReadAsync(buffer.AsMemory(0, bytesToRead), cancellationToken);
             if (bytesRead == 0)
             {
-                throw new InvalidOperationException(
-                    $"Source stream ended unexpectedly at offset {offset} (expected {uploadSize} bytes).");
+                throw new InvalidOperationException($"Source stream ended at offset {offset}.");
             }
 
-            var chunkStartOffset = offset;
-            offset = await PatchChunkAsync(httpClient, uploadUri, chunkStartOffset, buffer, bytesRead, cancellationToken);
-            var expectedOffset = chunkStartOffset + bytesRead;
-            if (offset != expectedOffset)
-            {
-                if (!source.CanSeek)
-                {
-                    throw new InvalidOperationException(
-                        $"Server reported offset {offset}, expected {expectedOffset}, but the source stream cannot be realigned.");
-                }
-
-                source.Seek(offset, SeekOrigin.Begin);
-            }
-
+            offset = await PatchChunkAsync(httpClient, uploadUri, offset, buffer, bytesRead, cancellationToken);
             progress.Update(offset);
-
-            if (offset > uploadSize)
-            {
-                throw new InvalidOperationException(
-                    $"Server reported offset {offset} which exceeds upload length {uploadSize}.");
-            }
         }
 
-        totalStopwatch.Stop();
-        var totalSeconds = Math.Max(totalStopwatch.Elapsed.TotalSeconds, 0.001);
-        var averageSpeedMbps = uploadSize / (1024.0 * 1024) / totalSeconds;
-        Console.WriteLine(
-            $"TUS upload completed for {fileTransferId}: " +
-            $"{uploadSize / (1024.0 * 1024 * 1024):N2} GiB in {totalSeconds:N1}s (avg: {averageSpeedMbps:N2} MB/s)");
+        LogCompletion("TUS upload", fileTransferId, uploadSize, totalStopwatch.Elapsed);
     }
 
-    // Reference implementation for TUS concatenation extension.
     public static async Task UploadWithConcatenationAsync(
         HttpClient httpClient,
         string baseUrl,
@@ -95,45 +68,23 @@ public static class TusUploader
         int parallelPartialUploads,
         CancellationToken cancellationToken = default)
     {
-        if (chunkSize <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(chunkSize), chunkSize, "Chunk size must be greater than zero.");
-        }
-
-        if (parallelPartialUploads <= 1)
-        {
-            throw new ArgumentOutOfRangeException(
-                nameof(parallelPartialUploads),
-                parallelPartialUploads,
-                "Use a value greater than 1 for concatenation uploads.");
-        }
-
         if (!source.CanSeek)
         {
             throw new InvalidOperationException("Concatenation upload requires a seekable source stream.");
         }
 
         var tusEndpoint = BuildTusEndpointUri(baseUrl, fileTransferId);
-        var capabilities = await EnsureServerSupportsTus(httpClient, tusEndpoint, cancellationToken);
-        if (!capabilities.SupportsConcatenation)
-        {
-            throw new InvalidOperationException(
-                "Server does not advertise TUS concatenation support (Tus-Extension missing 'concatenation').");
-        }
+        await EnsureServerSupportsConcatenation(httpClient, tusEndpoint, cancellationToken);
 
         var partRanges = BuildPartRanges(uploadSize, parallelPartialUploads);
         var partialUris = new Uri[partRanges.Count];
         for (var i = 0; i < partRanges.Count; i++)
         {
-            partialUris[i] = await CreatePartialUploadAsync(
-                httpClient,
-                tusEndpoint,
-                partRanges[i].Length,
-                cancellationToken);
+            partialUris[i] = await CreatePartialUploadAsync(httpClient, tusEndpoint, partRanges[i].Length, cancellationToken);
         }
 
         var readLock = new object();
-        var progress = new UploadProgress(uploadSize, 0);
+        var progress = new UploadProgress(uploadSize);
         using var progressTimer = new Timer(_ => progress.LogProgress(), null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
         var totalStopwatch = Stopwatch.StartNew();
         long progressBytes = 0;
@@ -154,94 +105,72 @@ public static class TusUploader
         });
 
         await CreateFinalUploadAsync(httpClient, tusEndpoint, partialUris, cancellationToken);
-        totalStopwatch.Stop();
-        var totalSeconds = Math.Max(totalStopwatch.Elapsed.TotalSeconds, 0.001);
-        var averageSpeedMbps = uploadSize / (1024.0 * 1024) / totalSeconds;
-        Console.WriteLine(
-            $"TUS concatenation upload completed for {fileTransferId}: " +
-            $"{uploadSize / (1024.0 * 1024 * 1024):N2} GiB in {totalSeconds:N1}s (avg: {averageSpeedMbps:N2} MB/s)");
+        LogCompletion("TUS concatenation upload", fileTransferId, uploadSize, totalStopwatch.Elapsed);
     }
 
-    private sealed class UploadProgress(long totalSize, long initialOffset)
+    private sealed class UploadProgress(long totalSize)
     {
-        private long _offset = initialOffset;
-        private readonly Stopwatch _intervalStopwatch = Stopwatch.StartNew();
+        private long _offset;
+        private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
 
-        public void Update(long offset)
-        {
-            Interlocked.Exchange(ref _offset, offset);
-        }
+        public void Update(long offset) => Interlocked.Exchange(ref _offset, offset);
 
         public void LogProgress()
         {
             var currentOffset = Interlocked.Read(ref _offset);
-            var elapsedSeconds = Math.Max(_intervalStopwatch.Elapsed.TotalSeconds, 0.001);
+            var elapsedSeconds = Math.Max(_stopwatch.Elapsed.TotalSeconds, 0.001);
             Console.WriteLine(
-                $"Progress: {currentOffset * 100.0 / totalSize:F3}% " +
+                $"Progress: {currentOffset * 100.0 / totalSize:F1}% " +
                 $"({currentOffset / (1024.0 * 1024 * 1024):N2} GiB / {totalSize / (1024.0 * 1024 * 1024):N2} GiB) " +
                 $"avg {currentOffset / elapsedSeconds / (1024 * 1024):N2} MiB/s");
         }
     }
 
-    private const string TusUploadPath = "/broker/api/v1/filetransfer/upload/tus";
-
     private static Uri BuildTusEndpointUri(string baseUrl, string fileTransferId)
         => new($"{baseUrl.TrimEnd('/')}{TusUploadPath}/{fileTransferId}");
 
-    private static async Task<TusServerCapabilities> EnsureServerSupportsTus(HttpClient httpClient, Uri tusEndpoint, CancellationToken cancellationToken)
+    private static async Task EnsureServerSupportsTus(HttpClient httpClient, Uri tusEndpoint, CancellationToken cancellationToken)
     {
-        using var optionsRequest = new HttpRequestMessage(HttpMethod.Options, tusEndpoint);
-        optionsRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+        using var response = await SendTusRequestAsync(httpClient, HttpMethod.Options, tusEndpoint, cancellationToken);
+        await EnsureSuccessAsync(response, "TUS OPTIONS");
+    }
 
-        using var optionsResponse = await httpClient.SendAsync(optionsRequest, cancellationToken);
-        var responseBody = await optionsResponse.Content.ReadAsStringAsync(cancellationToken);
-        if (!optionsResponse.IsSuccessStatusCode)
+    private static async Task EnsureServerSupportsConcatenation(HttpClient httpClient, Uri tusEndpoint, CancellationToken cancellationToken)
+    {
+        using var response = await SendTusRequestAsync(httpClient, HttpMethod.Options, tusEndpoint, cancellationToken);
+        await EnsureSuccessAsync(response, "TUS OPTIONS");
+
+        if (!response.Headers.TryGetValues("Tus-Extension", out var extensions)
+            || !extensions.Any(value => value.Contains("concatenation", StringComparison.OrdinalIgnoreCase)))
         {
-            throw new InvalidOperationException(
-                $"TUS OPTIONS failed with {(int)optionsResponse.StatusCode} {optionsResponse.StatusCode}: {responseBody}");
+            throw new InvalidOperationException("Server does not advertise TUS concatenation support.");
         }
-
-        if (!optionsResponse.Headers.Contains("Tus-Resumable"))
-        {
-            throw new InvalidOperationException("Server did not return Tus-Resumable header — is the TUS endpoint enabled?");
-        }
-
-        var supportsConcatenation = optionsResponse.Headers.TryGetValues("Tus-Extension", out var extensionHeaderValues)
-            && extensionHeaderValues
-                .SelectMany(static value => value.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
-                .Any(static extension => string.Equals(extension, "concatenation", StringComparison.OrdinalIgnoreCase));
-
-        return new TusServerCapabilities(supportsConcatenation);
     }
 
     private static async Task<Uri> CreateUploadAsync(
         HttpClient httpClient,
         Uri tusEndpoint,
-        string fileTransferId,
         long uploadSize,
         CancellationToken cancellationToken)
     {
-        using var createRequest = new HttpRequestMessage(HttpMethod.Post, tusEndpoint);
-        createRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
-        createRequest.Headers.TryAddWithoutValidation("Upload-Length", uploadSize.ToString());
+        using var request = new HttpRequestMessage(HttpMethod.Post, tusEndpoint);
+        request.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+        request.Headers.TryAddWithoutValidation("Upload-Length", uploadSize.ToString());
 
-        using var createResponse = await httpClient.SendAsync(createRequest, cancellationToken);
-        var responseBody = await createResponse.Content.ReadAsStringAsync(cancellationToken);
-
-        if (createResponse.StatusCode == HttpStatusCode.Created)
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+        if (response.StatusCode == HttpStatusCode.Created)
         {
-            return ResolveUploadUri(tusEndpoint, createResponse.Headers.Location)
+            return ResolveUploadUri(tusEndpoint, response.Headers.Location)
                 ?? throw new InvalidOperationException("TUS POST succeeded but no Location header was returned.");
         }
 
-        if (createResponse.StatusCode == HttpStatusCode.Conflict)
+        if (response.StatusCode == HttpStatusCode.Conflict)
         {
-            Console.WriteLine("Upload resource already exists — resuming via HEAD.");
             return tusEndpoint;
         }
 
-        throw new InvalidOperationException(
-            $"TUS POST failed with {(int)createResponse.StatusCode} {createResponse.StatusCode}: {responseBody}");
+        await EnsureSuccessAsync(response, "TUS POST");
+        throw new UnreachableException();
     }
 
     private static async Task<Uri> CreatePartialUploadAsync(
@@ -250,21 +179,28 @@ public static class TusUploader
         long partLength,
         CancellationToken cancellationToken)
     {
-        using var createRequest = new HttpRequestMessage(HttpMethod.Post, tusEndpoint);
-        createRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
-        createRequest.Headers.TryAddWithoutValidation("Upload-Length", partLength.ToString());
-        createRequest.Headers.TryAddWithoutValidation("Upload-Concat", "partial");
+        using var request = new HttpRequestMessage(HttpMethod.Post, tusEndpoint);
+        request.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+        request.Headers.TryAddWithoutValidation("Upload-Length", partLength.ToString());
+        request.Headers.TryAddWithoutValidation("Upload-Concat", "partial");
 
-        using var createResponse = await httpClient.SendAsync(createRequest, cancellationToken);
-        var responseBody = await createResponse.Content.ReadAsStringAsync(cancellationToken);
-        if (createResponse.StatusCode != HttpStatusCode.Created)
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+        await EnsureSuccessAsync(response, "TUS partial POST", HttpStatusCode.Created);
+
+        return ResolvePartialUploadUri(tusEndpoint, response.Headers.Location)
+            ?? throw new InvalidOperationException("TUS partial POST succeeded but no Location header was returned.");
+    }
+
+    private static Uri? ResolvePartialUploadUri(Uri tusEndpoint, Uri? location)
+    {
+        var resolved = ResolveUploadUri(tusEndpoint, location);
+        if (resolved is null)
         {
-            throw new InvalidOperationException(
-                $"TUS partial POST failed with {(int)createResponse.StatusCode} {createResponse.StatusCode}: {responseBody}");
+            return null;
         }
 
-        return ResolveUploadUri(tusEndpoint, createResponse.Headers.Location)
-            ?? throw new InvalidOperationException("TUS partial POST succeeded but no Location header was returned.");
+        var fileTransferId = tusEndpoint.AbsolutePath.TrimEnd('/').Split('/').Last();
+        return CanonicalizePartialUploadPath(resolved, fileTransferId);
     }
 
     private static async Task CreateFinalUploadAsync(
@@ -275,57 +211,37 @@ public static class TusUploader
     {
         foreach (var partialUri in partialUris)
         {
-            await VerifyPartialUploadCompleteAsync(httpClient, partialUri, cancellationToken);
+            await EnsurePartialUploadCompleteAsync(httpClient, partialUri, cancellationToken);
         }
 
         var partialReferences = string.Join(' ', partialUris.Select(ToTusConcatReference));
-        var uploadConcatValue = $"final;{partialReferences}";
-        Console.WriteLine($"TUS final POST Upload-Concat: {uploadConcatValue}");
+        using var request = new HttpRequestMessage(HttpMethod.Post, tusEndpoint);
+        request.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+        request.Headers.TryAddWithoutValidation("Upload-Concat", $"final;{partialReferences}");
 
-        using var createRequest = new HttpRequestMessage(HttpMethod.Post, tusEndpoint);
-        createRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
-        createRequest.Headers.TryAddWithoutValidation("Upload-Concat", uploadConcatValue);
-
-        using var createResponse = await httpClient.SendAsync(createRequest, cancellationToken);
-        var responseBody = await createResponse.Content.ReadAsStringAsync(cancellationToken);
-        if (createResponse.StatusCode != HttpStatusCode.Created)
-        {
-            throw new InvalidOperationException(
-                $"TUS final POST failed with {(int)createResponse.StatusCode} {createResponse.StatusCode}: {responseBody}");
-        }
-
-        _ = ResolveUploadUri(tusEndpoint, createResponse.Headers.Location)
-            ?? throw new InvalidOperationException("TUS final POST succeeded but no Location header was returned.");
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+        await EnsureSuccessAsync(response, "TUS final POST", HttpStatusCode.Created);
     }
 
-    private static async Task VerifyPartialUploadCompleteAsync(
+    private static async Task EnsurePartialUploadCompleteAsync(
         HttpClient httpClient,
         Uri partialUploadUri,
         CancellationToken cancellationToken)
     {
-        var uploadUri = await ResolveWorkingPartialUploadUriAsync(httpClient, partialUploadUri, cancellationToken);
-        using var headRequest = new HttpRequestMessage(HttpMethod.Head, uploadUri);
-        headRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+        using var response = await SendTusRequestAsync(httpClient, HttpMethod.Head, partialUploadUri, cancellationToken);
+        await EnsureSuccessAsync(response, "TUS partial HEAD", requestUri: partialUploadUri);
 
-        using var headResponse = await httpClient.SendAsync(headRequest, cancellationToken);
-        var responseBody = await headResponse.Content.ReadAsStringAsync(cancellationToken);
-        if (!headResponse.IsSuccessStatusCode)
-        {
-            throw new InvalidOperationException(
-                $"TUS HEAD on partial upload failed with {(int)headResponse.StatusCode} {headResponse.StatusCode}: {responseBody}");
-        }
-
-        if (!headResponse.Headers.TryGetValues("Upload-Length", out var lengthValues)
+        if (!response.Headers.TryGetValues("Upload-Length", out var lengthValues)
             || !long.TryParse(lengthValues.FirstOrDefault(), out var uploadLength))
         {
             throw new InvalidOperationException("Partial upload HEAD did not return Upload-Length.");
         }
 
-        var uploadOffset = ParseUploadOffset(headResponse.Headers);
+        var uploadOffset = ParseUploadOffset(response.Headers);
         if (uploadOffset != uploadLength)
         {
             throw new InvalidOperationException(
-                $"Partial upload {partialUploadUri} is incomplete ({uploadOffset} / {uploadLength} bytes).");
+                $"Partial upload is incomplete ({uploadOffset} / {uploadLength} bytes).");
         }
     }
 
@@ -343,28 +259,23 @@ public static class TusUploader
         Action<long> onBytesUploaded,
         CancellationToken cancellationToken)
     {
-        var uploadUri = await ResolveWorkingPartialUploadUriAsync(httpClient, partialUploadUri, cancellationToken);
-        var offset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
+        var offset = await GetUploadOffsetAsync(httpClient, partialUploadUri, cancellationToken);
         var buffer = new byte[chunkSize];
 
         while (offset < partLength)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
             var bytesToRead = (int)Math.Min(chunkSize, partLength - offset);
             var bytesRead = ReadAtAbsoluteOffset(sharedSource, readLock, sourceStartOffset + offset, buffer, bytesToRead);
             if (bytesRead == 0)
             {
-                throw new InvalidOperationException(
-                    $"Source stream ended unexpectedly at part offset {offset} (expected {partLength} bytes).");
+                throw new InvalidOperationException($"Source stream ended at part offset {offset}.");
             }
 
             var chunkStartOffset = offset;
-            offset = await PatchChunkAsync(httpClient, uploadUri, offset, buffer, bytesRead, cancellationToken);
-            var uploadedThisChunk = Math.Max(offset - chunkStartOffset, 0);
-            if (uploadedThisChunk > 0)
-            {
-                onBytesUploaded(uploadedThisChunk);
-            }
+            offset = await PatchChunkAsync(httpClient, partialUploadUri, offset, buffer, bytesRead, cancellationToken);
+            onBytesUploaded(Math.Max(offset - chunkStartOffset, 0));
         }
     }
 
@@ -419,29 +330,27 @@ public static class TusUploader
         int bytesRead,
         CancellationToken cancellationToken)
     {
-        for (var attempt = 1; attempt <= 5; attempt++)
+        for (var attempt = 1; attempt <= MaxPatchAttempts; attempt++)
         {
             try
             {
                 using var chunkContent = new ByteArrayContent(buffer, 0, bytesRead);
                 chunkContent.Headers.ContentType = new MediaTypeHeaderValue("application/offset+octet-stream");
-                chunkContent.Headers.ContentLength = bytesRead;
 
-                using var patchRequest = new HttpRequestMessage(HttpMethod.Patch, uploadUri);
-                patchRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
-                patchRequest.Headers.TryAddWithoutValidation("Upload-Offset", offset.ToString());
-                patchRequest.Content = chunkContent;
+                using var request = new HttpRequestMessage(HttpMethod.Patch, uploadUri);
+                request.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+                request.Headers.TryAddWithoutValidation("Upload-Offset", offset.ToString());
+                request.Content = chunkContent;
 
-                using var patchResponse = await httpClient.SendAsync(patchRequest, cancellationToken);
-                if (patchResponse.StatusCode == HttpStatusCode.NoContent)
+                using var response = await httpClient.SendAsync(request, cancellationToken);
+                if (response.StatusCode == HttpStatusCode.NoContent)
                 {
-                    return ParseUploadOffset(patchResponse.Headers);
+                    return ParseUploadOffset(response.Headers);
                 }
 
-                var responseBody = await patchResponse.Content.ReadAsStringAsync(cancellationToken);
-                if (patchResponse.StatusCode == HttpStatusCode.Conflict)
+                if (response.StatusCode == HttpStatusCode.Conflict)
                 {
-                    var serverOffset = await ResolveOffsetAfterConflictAsync(httpClient, uploadUri, offset, cancellationToken);
+                    var serverOffset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
                     if (serverOffset > offset)
                     {
                         return serverOffset;
@@ -451,116 +360,22 @@ public static class TusUploader
                     continue;
                 }
 
-                if (attempt == 5 || !IsTransientStatusCode(patchResponse.StatusCode))
+                if (attempt == MaxPatchAttempts || !IsTransientStatusCode(response.StatusCode))
                 {
-                    throw new InvalidOperationException(
-                        $"TUS PATCH failed at offset {offset} with {(int)patchResponse.StatusCode} {patchResponse.StatusCode}: {responseBody}");
+                    await EnsureSuccessAsync(response, $"TUS PATCH at offset {offset}");
                 }
 
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
-                Console.WriteLine(
-                    $"TUS PATCH at offset {offset} failed ({patchResponse.StatusCode}), retrying in {delay.TotalSeconds:N0}s (attempt {attempt}/5)...");
+                await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempt)), cancellationToken);
                 offset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
-                await Task.Delay(delay, cancellationToken);
             }
-            catch (Exception ex) when (IsTransientRequestException(ex) && attempt < 5)
+            catch (Exception ex) when (IsTransientRequestException(ex) && attempt < MaxPatchAttempts)
             {
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
-                var serverOffset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
-                if (serverOffset > offset)
-                {
-                    Console.WriteLine(
-                        $"TUS PATCH at offset {offset} failed ({ex.Message}), server already at {serverOffset}.");
-                    return serverOffset;
-                }
-
-                Console.WriteLine(
-                    $"TUS PATCH at offset {offset} failed ({ex.Message}), realigning offset and retrying in {delay.TotalSeconds:N0}s (attempt {attempt}/5)...");
-                offset = serverOffset;
-                await Task.Delay(delay, cancellationToken);
+                await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempt)), cancellationToken);
+                offset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
             }
         }
 
-        throw new UnreachableException();
-    }
-
-    private static async Task<long> ResolveOffsetAfterConflictAsync(
-        HttpClient httpClient,
-        Uri uploadUri,
-        long offset,
-        CancellationToken cancellationToken)
-    {
-        var serverOffset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
-        if (serverOffset > offset)
-        {
-            Console.WriteLine($"Upload-Offset conflict — server is at {serverOffset}, resuming.");
-            return serverOffset;
-        }
-
-        if (serverOffset < offset)
-        {
-            Console.WriteLine(
-                $"Upload-Offset conflict — server is behind at {serverOffset}, waiting for async commit to reach {offset}.");
-            for (var waitAttempt = 0; waitAttempt < 30; waitAttempt++)
-            {
-                await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken);
-                serverOffset = await GetUploadOffsetAsync(httpClient, uploadUri, cancellationToken);
-                if (serverOffset >= offset)
-                {
-                    return serverOffset;
-                }
-            }
-
-            throw new InvalidOperationException(
-                $"Server offset {serverOffset} did not reach expected offset {offset} after conflict retries.");
-        }
-
-        return serverOffset;
-    }
-
-    private static bool IsTransientRequestException(Exception exception)
-        => exception is HttpRequestException or IOException or TaskCanceledException;
-
-    private static async Task<Uri> ResolveWorkingPartialUploadUriAsync(
-        HttpClient httpClient,
-        Uri partialUploadUri,
-        CancellationToken cancellationToken)
-    {
-        Exception? lastError = null;
-        foreach (var candidate in GetPartialUploadUriCandidates(partialUploadUri))
-        {
-            using var headResponse = await SendHeadAsync(httpClient, candidate, cancellationToken);
-            if (headResponse.IsSuccessStatusCode)
-            {
-                if (!ReferenceEquals(candidate, partialUploadUri) && !candidate.Equals(partialUploadUri))
-                {
-                    Console.WriteLine($"Using alternate partial upload URL {candidate}.");
-                }
-
-                return candidate;
-            }
-
-            var responseBody = await headResponse.Content.ReadAsStringAsync(cancellationToken);
-            lastError = new InvalidOperationException(
-                $"TUS HEAD failed with {(int)headResponse.StatusCode} {headResponse.StatusCode}: {responseBody}");
-        }
-
-        throw lastError ?? new InvalidOperationException("TUS HEAD failed for all partial upload URL candidates.");
-    }
-
-    private static IEnumerable<Uri> GetPartialUploadUriCandidates(Uri partialUploadUri)
-    {
-        yield return partialUploadUri;
-
-        if (TryGetNormalizedPartialUploadUri(partialUploadUri, out var normalizedPartialUri))
-        {
-            yield return normalizedPartialUri;
-        }
-
-        if (TryGetSingleSegmentPartialUploadUri(partialUploadUri, out var singleSegmentPartialUri))
-        {
-            yield return singleSegmentPartialUri;
-        }
+        throw new InvalidOperationException($"TUS PATCH at offset {offset} failed after {MaxPatchAttempts} attempts.");
     }
 
     private static async Task<long> GetUploadOffsetAsync(
@@ -568,100 +383,93 @@ public static class TusUploader
         Uri uploadUri,
         CancellationToken cancellationToken)
     {
-        Exception? lastError = null;
-        foreach (var candidate in GetPartialUploadUriCandidates(uploadUri))
-        {
-            using var headResponse = await SendHeadAsync(httpClient, candidate, cancellationToken);
-            if (headResponse.IsSuccessStatusCode)
-            {
-                return ParseUploadOffset(headResponse.Headers);
-            }
-
-            var responseBody = await headResponse.Content.ReadAsStringAsync(cancellationToken);
-            lastError = new InvalidOperationException(
-                $"TUS HEAD failed with {(int)headResponse.StatusCode} {headResponse.StatusCode}: {responseBody}");
-        }
-
-        throw lastError ?? new InvalidOperationException("TUS HEAD failed for all upload URL candidates.");
+        using var response = await SendTusRequestAsync(httpClient, HttpMethod.Head, uploadUri, cancellationToken);
+        await EnsureSuccessAsync(response, "TUS HEAD", requestUri: uploadUri);
+        return ParseUploadOffset(response.Headers);
     }
 
-    private static async Task<HttpResponseMessage> SendHeadAsync(
+    private static Task<HttpResponseMessage> SendTusRequestAsync(
         HttpClient httpClient,
+        HttpMethod method,
         Uri uploadUri,
         CancellationToken cancellationToken)
     {
-        var headRequest = new HttpRequestMessage(HttpMethod.Head, uploadUri);
-        headRequest.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
-        return await httpClient.SendAsync(headRequest, cancellationToken);
+        var request = new HttpRequestMessage(method, uploadUri);
+        request.Headers.TryAddWithoutValidation("Tus-Resumable", TusVersion);
+        return httpClient.SendAsync(request, cancellationToken);
+    }
+
+    private static long ParseUploadOffset(HttpResponseHeaders headers)
+    {
+        if (headers.TryGetValues("Upload-Offset", out var values)
+            && long.TryParse(values.FirstOrDefault(), out var parsedOffset))
+        {
+            return parsedOffset;
+        }
+
+        throw new InvalidOperationException("TUS response did not include Upload-Offset.");
+    }
+
+    private static Uri? ResolveUploadUri(Uri tusEndpoint, Uri? location)
+    {
+        if (location is null)
+        {
+            return null;
+        }
+
+        if (location.IsAbsoluteUri)
+        {
+            return location;
+        }
+
+        var relative = location.OriginalString;
+        if (relative.StartsWith('/'))
+        {
+            return new Uri($"{tusEndpoint.GetLeftPart(UriPartial.Authority)}{relative}");
+        }
+
+        return new Uri(tusEndpoint, location);
     }
 
     /// <summary>
-    /// Converts legacy /tus/{fileTransferId}/{partialId} URLs to /tus/{fileTransferId}/partial/{partialId}.
+    /// Partial uploads are addressed at /tus/{fileTransferId}/partial/{partialUploadId}.
+    /// Canonicalize the Location path when the server omits the literal "partial" segment.
     /// </summary>
-    private static bool TryGetNormalizedPartialUploadUri(Uri uploadUri, out Uri normalizedPartialUri)
+    private static Uri CanonicalizePartialUploadPath(Uri uploadUri, string fileTransferId)
     {
-        normalizedPartialUri = uploadUri;
         if (!TryParseTusPathSegments(uploadUri, out var segments))
         {
-            return false;
+            return uploadUri;
         }
 
-        if (segments.Length != 2 || !Guid.TryParse(segments[0], out _))
+        if (segments.Length == 3
+            && string.Equals(segments[1], PartialPathSegment, StringComparison.OrdinalIgnoreCase))
         {
-            return false;
+            return uploadUri;
         }
 
-        return TryBuildPartialUploadUri(uploadUri, segments[0], segments[1], out normalizedPartialUri);
+        if (segments.Length == 2 && Guid.TryParse(segments[0], out _))
+        {
+            return BuildUriWithPath(uploadUri, $"{TusUploadPath}/{segments[0]}/{PartialPathSegment}/{segments[1]}");
+        }
+
+        if (segments.Length == 1)
+        {
+            return BuildUriWithPath(uploadUri, $"{TusUploadPath}/{fileTransferId}/{PartialPathSegment}/{segments[0]}");
+        }
+
+        return uploadUri;
     }
 
-    /// <summary>
-    /// Oldest deployments returned partial Location as /tus/{partialId} only.
-    /// </summary>
-    private static bool TryGetSingleSegmentPartialUploadUri(Uri uploadUri, out Uri singleSegmentPartialUri)
-    {
-        singleSegmentPartialUri = uploadUri;
-        if (!TryParseTusPathSegments(uploadUri, out var segments))
-        {
-            return false;
-        }
-
-        var partialId = segments.Length switch
-        {
-            1 => segments[0],
-            2 => segments[1],
-            3 when string.Equals(segments[1], "partial", StringComparison.OrdinalIgnoreCase) => segments[2],
-            _ => null
-        };
-
-        if (string.IsNullOrEmpty(partialId))
-        {
-            return false;
-        }
-
-        var legacyPath = $"{TusUploadPath}/{partialId}";
-        singleSegmentPartialUri = uploadUri.IsAbsoluteUri
-            ? new Uri(uploadUri.GetLeftPart(UriPartial.Authority) + legacyPath)
-            : new Uri(legacyPath, UriKind.Relative);
-        return true;
-    }
-
-    private static bool TryBuildPartialUploadUri(
-        Uri uploadUri,
-        string fileTransferId,
-        string partialId,
-        out Uri partialUploadUri)
-    {
-        var normalizedPath = $"{TusUploadPath}/{fileTransferId}/partial/{partialId}";
-        partialUploadUri = uploadUri.IsAbsoluteUri
-            ? new Uri(uploadUri.GetLeftPart(UriPartial.Authority) + normalizedPath)
-            : new Uri(normalizedPath, UriKind.Relative);
-        return true;
-    }
+    private static Uri BuildUriWithPath(Uri baseUri, string path)
+        => baseUri.IsAbsoluteUri
+            ? new Uri($"{baseUri.GetLeftPart(UriPartial.Authority)}{path}")
+            : new Uri(path, UriKind.Relative);
 
     private static bool TryParseTusPathSegments(Uri uploadUri, out string[] segments)
     {
         segments = [];
-        var path = uploadUri.IsAbsoluteUri ? uploadUri.AbsolutePath : uploadUri.ToString();
+        var path = uploadUri.IsAbsoluteUri ? uploadUri.AbsolutePath : uploadUri.OriginalString;
         var prefix = $"{TusUploadPath}/";
         if (!path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
         {
@@ -673,30 +481,43 @@ public static class TusUploader
         return segments.Length > 0;
     }
 
-    private static long ParseUploadOffset(HttpResponseHeaders headers)
+    private static async Task EnsureSuccessAsync(
+        HttpResponseMessage response,
+        string operation,
+        HttpStatusCode? expectedStatusCode = null,
+        Uri? requestUri = null)
     {
-        if (headers.TryGetValues("Upload-Offset", out var values)
-            && long.TryParse(values.FirstOrDefault(), out var parsedOffset))
+        if (expectedStatusCode is not null && response.StatusCode == expectedStatusCode)
         {
-            return parsedOffset;
+            return;
         }
 
-        throw new InvalidOperationException("TUS response did not include a valid Upload-Offset header.");
-    }
-
-    private static Uri? ResolveUploadUri(Uri tusEndpoint, Uri? location)
-    {
-        if (location is null)
+        if (response.IsSuccessStatusCode)
         {
-            return null;
+            return;
         }
 
-        return location.IsAbsoluteUri ? location : new Uri(tusEndpoint, location);
+        var responseBody = await response.Content.ReadAsStringAsync();
+        var target = requestUri ?? response.RequestMessage?.RequestUri;
+        var targetSuffix = target is null ? string.Empty : $" for {target}";
+        throw new InvalidOperationException(
+            $"{operation} failed{targetSuffix} with {(int)response.StatusCode} {response.StatusCode}: {responseBody}");
     }
+
+    private static void LogCompletion(string label, string fileTransferId, long uploadSize, TimeSpan elapsed)
+    {
+        var totalSeconds = Math.Max(elapsed.TotalSeconds, 0.001);
+        var averageSpeedMbps = uploadSize / (1024.0 * 1024) / totalSeconds;
+        Console.WriteLine(
+            $"{label} completed for {fileTransferId}: " +
+            $"{uploadSize / (1024.0 * 1024 * 1024):N2} GiB in {totalSeconds:N1}s (avg: {averageSpeedMbps:N2} MB/s)");
+    }
+
+    private static bool IsTransientRequestException(Exception exception)
+        => exception is HttpRequestException or IOException or TaskCanceledException;
 
     private static bool IsTransientStatusCode(HttpStatusCode statusCode)
         => statusCode is HttpStatusCode.RequestTimeout
-            or HttpStatusCode.Conflict
             or HttpStatusCode.TooManyRequests
             or HttpStatusCode.InternalServerError
             or HttpStatusCode.BadGateway

--- a/tests/Altinn.Broker.Tests.TusJsClient/.gitignore
+++ b/tests/Altinn.Broker.Tests.TusJsClient/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+upload-*.bin

--- a/tests/Altinn.Broker.Tests.TusJsClient/README.md
+++ b/tests/Altinn.Broker.Tests.TusJsClient/README.md
@@ -1,0 +1,48 @@
+# TUS concatenation validation with tus-js-client
+
+Small Node.js harness that mirrors `Altinn.Broker.Tests.LargeFile`, but uses the standard [tus-js-client](https://github.com/tus/tus-js-client) library with `parallelUploads` to exercise Broker concatenation end-to-end.
+
+## Prerequisites
+
+- Node.js 20+
+- Test tools credentials for the Altinn token generator (same as the LargeFile test)
+
+## Setup
+
+```bash
+cd tests/Altinn.Broker.Tests.TusJsClient
+npm install
+```
+
+## Run
+
+```bash
+export BASE_URL="https://altinn-dev-api.azure-api.net"
+export TEST_TOOLS_USERNAME="your-test-tools-user"
+export TEST_TOOLS_PASSWORD="your-test-tools-password"
+
+# Optional
+export ORG_NO="991825827"
+export CHUNK_SIZE_MB="8"
+export TUS_PARALLEL_PARTIAL_UPLOADS="4"
+export GIGABYTES_TO_UPLOAD="1"
+
+npm run upload
+```
+
+By default (when `GIGABYTES_TO_UPLOAD` is not set) the script uploads **64 MiB** so you can smoke-test quickly.
+
+## What it does
+
+1. Obtains a Maskinporten/Altinn test token
+2. Configures the test resource max file size
+3. Initializes a file transfer
+4. Generates a temporary binary file
+5. Uploads via tus-js-client with `parallelUploads` (TUS concatenation)
+6. Verifies the file transfer reaches `Published`
+
+The TUS endpoint is:
+
+`/broker/api/v1/filetransfer/upload/tus/{fileTransferId}`
+
+No custom `Upload-Concat` header handling is required in client code — tus-js-client builds the concatenation flow automatically when `parallelUploads` is greater than 1.

--- a/tests/Altinn.Broker.Tests.TusJsClient/package-lock.json
+++ b/tests/Altinn.Broker.Tests.TusJsClient/package-lock.json
@@ -1,0 +1,191 @@
+{
+  "name": "altinn-broker-tus-js-client-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "altinn-broker-tus-js-client-test",
+      "version": "1.0.0",
+      "dependencies": {
+        "tus-js-client": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/combine-errors": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/combine-errors/-/combine-errors-3.0.3.tgz",
+      "integrity": "sha512-C8ikRNRMygCwaTx+Ek3Yr+OuZzgZjduCOfSQBjbM8V3MfgcjSTeto/GXP6PAwKvJz/v15b7GHZvx5rOlczFw/Q==",
+      "dependencies": {
+        "custom-error-instance": "2.1.1",
+        "lodash.uniqby": "4.5.0"
+      }
+    },
+    "node_modules/custom-error-instance": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/custom-error-instance/-/custom-error-instance-2.1.1.tgz",
+      "integrity": "sha512-p6JFxJc3M4OTD2li2qaHkDCw9SfMw82Ldr6OC9Je1aXiGfhx2W8p3GaoeaGrPJTUN9NirTM/KTxHWMUdR1rsUg==",
+      "license": "ISC"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-base64": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.8.0.tgz",
+      "integrity": "sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/lodash._baseiteratee": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseiteratee/-/lodash._baseiteratee-4.7.0.tgz",
+      "integrity": "sha512-nqB9M+wITz0BX/Q2xg6fQ8mLkyfF7MU7eE+MNBNjTHFKeKaZAPEzEg+E8LWxKWf1DQVflNEn9N49yAuqKh2mWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._stringtopath": "~4.8.0"
+      }
+    },
+    "node_modules/lodash._basetostring": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
+      "integrity": "sha512-SwcRIbyxnN6CFEEK4K1y+zuApvWdpQdBHM/swxP962s8HIxPO3alBH5t3m/dl+f4CMUug6sJb7Pww8d13/9WSw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._baseuniq": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+      "integrity": "sha512-Ja1YevpHZctlI5beLA7oc5KNDhGcPixFhcqSiORHNsp/1QTv7amAXzw+gu4YOvErqVlMVyIJGgtzeepCnnur0A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._createset": "~4.0.0",
+        "lodash._root": "~3.0.0"
+      }
+    },
+    "node_modules/lodash._createset": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+      "integrity": "sha512-GTkC6YMprrJZCYU3zcqZj+jkXkrXzq3IPBcF/fIPpNEAB4hZEtXU8zp/RwKOvZl43NUmwDbyRk3+ZTbeRdEBXA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha512-O0pWuFSK6x4EXhM1dhZ8gchNtG7JMqBtrHdoUFUWXD7dJnNSUze1GuyQr5sOs0aCvgGeI3o/OJW8f4ca7FDxmQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._stringtopath": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/lodash._stringtopath/-/lodash._stringtopath-4.8.0.tgz",
+      "integrity": "sha512-SXL66C731p0xPDC5LZg4wI5H+dJo/EO4KTqOMwLYCH3+FmmfAKJEZCm6ohGpI+T1xwsDsJCfL4OnhorllvlTPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basetostring": "~4.12.0"
+      }
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniqby": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.5.0.tgz",
+      "integrity": "sha512-IRt7cfTtHy6f1aRVA5n7kT8rgN3N1nH6MOWLcHfpWG2SH19E3JksLK38MktLxZDhlAjCP9jpIXkOnRXlu6oByQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._baseiteratee": "~4.7.0",
+        "lodash._baseuniq": "~4.6.0"
+      }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/tus-js-client": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-4.3.1.tgz",
+      "integrity": "sha512-ZLeYmjrkaU1fUsKbIi8JML52uAocjEZtBx4DKjRrqzrZa0O4MYwT6db+oqePlspV+FxXJAyFBc/L5gwUi2OFsg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.1.2",
+        "combine-errors": "^3.0.3",
+        "is-stream": "^2.0.0",
+        "js-base64": "^3.7.2",
+        "lodash.throttle": "^4.1.1",
+        "proper-lockfile": "^4.1.2",
+        "url-parse": "^1.5.7"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    }
+  }
+}

--- a/tests/Altinn.Broker.Tests.TusJsClient/package.json
+++ b/tests/Altinn.Broker.Tests.TusJsClient/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "altinn-broker-tus-js-client-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Validates Altinn Broker TUS concatenation uploads using tus-js-client",
+  "scripts": {
+    "upload": "node src/main.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "tus-js-client": "^4.3.1"
+  }
+}

--- a/tests/Altinn.Broker.Tests.TusJsClient/src/broker.mjs
+++ b/tests/Altinn.Broker.Tests.TusJsClient/src/broker.mjs
@@ -1,0 +1,83 @@
+const TEST_RESOURCE = 'altinn-broker-test-resource-2';
+
+export async function getAccessToken(username, password, orgNumber) {
+  const url =
+    `https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken` +
+    `?env=tt02&scopes=altinn:broker.write altinn:serviceowner&org=ttd&orgNo=${orgNumber}`;
+
+  const credentials = Buffer.from(`${username}:${password}`).toString('base64');
+  const response = await fetch(url, {
+    headers: { Authorization: `Basic ${credentials}` },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Token request failed with ${response.status}: ${body}`);
+  }
+
+  return response.text();
+}
+
+export async function configureResource(baseUrl, token, uploadSize) {
+  const response = await fetch(`${baseUrl}/broker/api/v1/resource/${TEST_RESOURCE}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ maxFileTransferSize: uploadSize + 1 }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    console.warn(`Configure resource returned ${response.status}: ${body}`);
+  }
+}
+
+export async function initializeFileTransfer(baseUrl, token) {
+  const response = await fetch(`${baseUrl}/broker/api/v1/filetransfer`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({
+      resourceId: TEST_RESOURCE,
+      fileName: 'input.txt',
+      propertyList: {},
+      recipients: ['0192:986252932'],
+      sender: '0192:991825827',
+      sendersFileTransferReference: 'tus-js-client-test',
+      disableVirusScan: true,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Initialize file transfer failed with ${response.status}: ${body}`);
+  }
+
+  const payload = await response.json();
+  if (!payload.fileTransferId) {
+    throw new Error('Initialize response did not include fileTransferId.');
+  }
+
+  return payload.fileTransferId;
+}
+
+export async function getFileTransferOverview(baseUrl, token, fileTransferId) {
+  const response = await fetch(`${baseUrl}/broker/api/v1/filetransfer/${fileTransferId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Overview request failed with ${response.status}: ${body}`);
+  }
+
+  return response.json();
+}

--- a/tests/Altinn.Broker.Tests.TusJsClient/src/generate-file.mjs
+++ b/tests/Altinn.Broker.Tests.TusJsClient/src/generate-file.mjs
@@ -1,0 +1,31 @@
+import { createWriteStream } from 'node:fs';
+import { finished } from 'node:stream/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomFillSync } from 'node:crypto';
+
+const WRITE_CHUNK_SIZE = 8 * 1024 * 1024;
+
+export async function createUploadFile(byteLength) {
+  const filePath = join(tmpdir(), `altinn-broker-tus-upload-${Date.now()}.bin`);
+  const stream = createWriteStream(filePath);
+
+  let remaining = byteLength;
+  const buffer = Buffer.alloc(Math.min(WRITE_CHUNK_SIZE, byteLength));
+
+  while (remaining > 0) {
+    const chunkSize = Math.min(buffer.length, remaining);
+    randomFillSync(buffer.subarray(0, chunkSize));
+    const canContinue = stream.write(buffer.subarray(0, chunkSize));
+    if (!canContinue) {
+      await new Promise((resolve) => stream.once('drain', resolve));
+    }
+
+    remaining -= chunkSize;
+  }
+
+  stream.end();
+  await finished(stream);
+
+  return filePath;
+}

--- a/tests/Altinn.Broker.Tests.TusJsClient/src/main.mjs
+++ b/tests/Altinn.Broker.Tests.TusJsClient/src/main.mjs
@@ -1,0 +1,150 @@
+import { createReadStream } from 'node:fs';
+import { stat, unlink } from 'node:fs/promises';
+import { Upload } from 'tus-js-client';
+
+import {
+  configureResource,
+  getAccessToken,
+  getFileTransferOverview,
+  initializeFileTransfer,
+} from './broker.mjs';
+import { createUploadFile } from './generate-file.mjs';
+
+const DEFAULT_CHUNK_SIZE_MB = 8;
+const DEFAULT_PARALLEL_UPLOADS = 4;
+const DEFAULT_UPLOAD_MIB = 64;
+
+function readEnv(name, fallback) {
+  const value = process.env[name];
+  return value === undefined || value === '' ? fallback : value;
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+function formatGiB(bytes) {
+  return (bytes / (1024 * 1024 * 1024)).toFixed(2);
+}
+
+function formatMiB(bytes) {
+  return (bytes / (1024 * 1024)).toFixed(2);
+}
+
+async function uploadWithTusJsClient({
+  baseUrl,
+  token,
+  fileTransferId,
+  filePath,
+  chunkSize,
+  parallelUploads,
+}) {
+  const { size } = await stat(filePath);
+  const endpoint = `${baseUrl.replace(/\/$/, '')}/broker/api/v1/filetransfer/upload/tus/${fileTransferId}`;
+  const startedAt = Date.now();
+
+  await new Promise((resolve, reject) => {
+    const upload = new Upload(
+      createReadStream(filePath),
+      {
+        endpoint,
+        chunkSize,
+        parallelUploads,
+        retryDelays: [0, 2000, 4000, 8000, 16000],
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        metadata: {
+          filename: 'input.txt',
+          filetype: 'application/octet-stream',
+        },
+        onError(error) {
+          reject(error);
+        },
+        onProgress(bytesUploaded, bytesTotal) {
+          const elapsedSeconds = Math.max((Date.now() - startedAt) / 1000, 0.001);
+          const mibPerSecond = bytesUploaded / elapsedSeconds / (1024 * 1024);
+          const percentage = ((bytesUploaded / bytesTotal) * 100).toFixed(1);
+          process.stdout.write(
+            `\rProgress: ${percentage}% (${formatGiB(bytesUploaded)} / ${formatGiB(bytesTotal)} GiB, ${mibPerSecond.toFixed(2)} MiB/s)`,
+          );
+        },
+        onSuccess() {
+          console.log('');
+          console.log(`TUS upload finished: ${upload.url}`);
+          resolve();
+        },
+      },
+    );
+
+    upload.start();
+  });
+
+  const elapsedSeconds = Math.max((Date.now() - startedAt) / 1000, 0.001);
+  const averageSpeedMbps = size / elapsedSeconds / (1024 * 1024);
+  console.log(
+    `TUS concatenation upload completed in ${elapsedSeconds.toFixed(1)}s (avg: ${averageSpeedMbps.toFixed(2)} MiB/s)`,
+  );
+}
+
+async function main() {
+  const baseUrl = readEnv('BASE_URL', 'https://altinn-dev-api.azure-api.net');
+  const username = requireEnv('TEST_TOOLS_USERNAME');
+  const password = requireEnv('TEST_TOOLS_PASSWORD');
+  const orgNumber = readEnv('ORG_NO', '991825827');
+  const chunkSizeMb = Number(readEnv('CHUNK_SIZE_MB', String(DEFAULT_CHUNK_SIZE_MB)));
+  const parallelUploads = Number(readEnv('TUS_PARALLEL_PARTIAL_UPLOADS', String(DEFAULT_PARALLEL_UPLOADS)));
+  const uploadBytes = process.env.GIGABYTES_TO_UPLOAD
+    ? Number(process.env.GIGABYTES_TO_UPLOAD) * 1024 * 1024 * 1024
+    : DEFAULT_UPLOAD_MIB * 1024 * 1024;
+  const chunkSize = chunkSizeMb * 1024 * 1024;
+
+  if (parallelUploads < 2) {
+    throw new Error('Set TUS_PARALLEL_PARTIAL_UPLOADS to 2 or more to exercise concatenation.');
+  }
+
+  console.log(`BASE_URL: ${baseUrl}`);
+  console.log(`Upload size: ${formatGiB(uploadBytes)} GiB (${formatMiB(uploadBytes)} MiB)`);
+  console.log(`CHUNK_SIZE_MB: ${chunkSizeMb}`);
+  console.log(`TUS_PARALLEL_PARTIAL_UPLOADS: ${parallelUploads}`);
+
+  const token = await getAccessToken(username, password, orgNumber);
+  await configureResource(baseUrl, token, uploadBytes);
+  const fileTransferId = await initializeFileTransfer(baseUrl, token);
+  console.log(`File transfer id: ${fileTransferId}`);
+
+  const filePath = await createUploadFile(uploadBytes);
+  console.log(`Temporary upload file: ${filePath}`);
+
+  try {
+    await uploadWithTusJsClient({
+      baseUrl,
+      token,
+      fileTransferId,
+      filePath,
+      chunkSize,
+      parallelUploads,
+    });
+
+    const overview = await getFileTransferOverview(baseUrl, token, fileTransferId);
+    if (overview.fileTransferStatus !== 'Published') {
+      throw new Error(`Expected Published status, got ${overview.fileTransferStatus}`);
+    }
+
+    console.log(`Verified file transfer ${fileTransferId} is Published.`);
+  } finally {
+    await unlink(filePath).catch(() => {});
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+
+

--- a/tests/Altinn.Broker.Tests/Tus/TusPartialPathRewriteMiddlewareTests.cs
+++ b/tests/Altinn.Broker.Tests/Tus/TusPartialPathRewriteMiddlewareTests.cs
@@ -10,7 +10,7 @@ namespace Altinn.Broker.Tests.Tus;
 public class TusPartialPathRewriteMiddlewareTests
 {
     [Fact]
-    public void TryRewriteConcatPartialPath_RewritesTwoSegmentPartialUrl()
+    public void TryRewriteConcatPartialPath_RewritesLegacyTwoSegmentPartialUrl()
     {
         var context = new DefaultHttpContext();
         context.Request.Path = "/broker/api/v1/filetransfer/upload/tus/5e61f0db-c122-4958-873f-d50f58aa1909/0e3d044db57247aeb7c0a9215c0df9af";
@@ -19,9 +19,24 @@ public class TusPartialPathRewriteMiddlewareTests
 
         Assert.True(rewritten);
         Assert.Equal(
-            "/broker/api/v1/filetransfer/upload/tus/0e3d044db57247aeb7c0a9215c0df9af",
+            "/broker/api/v1/filetransfer/upload/tus/5e61f0db-c122-4958-873f-d50f58aa1909/partial/0e3d044db57247aeb7c0a9215c0df9af",
             context.Request.Path.Value);
         Assert.Equal("5e61f0db-c122-4958-873f-d50f58aa1909", context.Items[TusRouteHelper.FileTransferIdItemKey]);
+    }
+
+    [Fact]
+    public void TryRewriteConcatPartialPath_LeavesCanonicalPartialUrlUnchanged()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path =
+            "/broker/api/v1/filetransfer/upload/tus/5e61f0db-c122-4958-873f-d50f58aa1909/partial/0e3d044db57247aeb7c0a9215c0df9af";
+
+        var rewritten = TusPartialPathRewriteMiddleware.TryRewriteConcatPartialPath(context);
+
+        Assert.False(rewritten);
+        Assert.Equal(
+            "/broker/api/v1/filetransfer/upload/tus/5e61f0db-c122-4958-873f-d50f58aa1909/partial/0e3d044db57247aeb7c0a9215c0df9af",
+            context.Request.Path.Value);
     }
 
     [Fact]

--- a/tests/Altinn.Broker.Tests/Tus/TusPartialPathRewriteMiddlewareTests.cs
+++ b/tests/Altinn.Broker.Tests/Tus/TusPartialPathRewriteMiddlewareTests.cs
@@ -1,0 +1,40 @@
+using Altinn.Broker.API.Tus;
+using Altinn.Broker.Integrations.Tus;
+
+using Microsoft.AspNetCore.Http;
+
+using Xunit;
+
+namespace Altinn.Broker.Tests.Tus;
+
+public class TusPartialPathRewriteMiddlewareTests
+{
+    [Fact]
+    public void TryRewriteConcatPartialPath_RewritesTwoSegmentPartialUrl()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/broker/api/v1/filetransfer/upload/tus/5e61f0db-c122-4958-873f-d50f58aa1909/0e3d044db57247aeb7c0a9215c0df9af";
+
+        var rewritten = TusPartialPathRewriteMiddleware.TryRewriteConcatPartialPath(context);
+
+        Assert.True(rewritten);
+        Assert.Equal(
+            "/broker/api/v1/filetransfer/upload/tus/0e3d044db57247aeb7c0a9215c0df9af",
+            context.Request.Path.Value);
+        Assert.Equal("5e61f0db-c122-4958-873f-d50f58aa1909", context.Items[TusRouteHelper.FileTransferIdItemKey]);
+    }
+
+    [Fact]
+    public void TryRewriteConcatPartialPath_LeavesSingleSegmentUrlUnchanged()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/broker/api/v1/filetransfer/upload/tus/0e3d044db57247aeb7c0a9215c0df9af";
+
+        var rewritten = TusPartialPathRewriteMiddleware.TryRewriteConcatPartialPath(context);
+
+        Assert.False(rewritten);
+        Assert.Equal(
+            "/broker/api/v1/filetransfer/upload/tus/0e3d044db57247aeb7c0a9215c0df9af",
+            context.Request.Path.Value);
+    }
+}

--- a/tests/Altinn.Broker.Tests/TusUploadTests.cs
+++ b/tests/Altinn.Broker.Tests/TusUploadTests.cs
@@ -43,7 +43,7 @@ public class TusUploadTests : IClassFixture<CustomWebApplicationFactory>
         var optionsRequest = new HttpRequestMessage(HttpMethod.Options, tusBaseUrl);
         optionsRequest.Headers.Add("Tus-Resumable", "1.0.0");
         var optionsResponse = await _senderClient.SendAsync(optionsRequest);
-        Assert.True(optionsResponse.IsSuccessStatusCode, await optionsResponse.Content.ReadAsStringAsync());
+        Assert.Equal(HttpStatusCode.NoContent, optionsResponse.StatusCode);
 
         var createRequest = new HttpRequestMessage(HttpMethod.Post, tusBaseUrl);
         createRequest.Headers.Add("Tus-Resumable", "1.0.0");

--- a/tests/Altinn.Broker.Tests/TusUploadTests.cs
+++ b/tests/Altinn.Broker.Tests/TusUploadTests.cs
@@ -2,6 +2,8 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 using Altinn.Broker.API.Models;
 using Altinn.Broker.Common.Constants;
@@ -18,11 +20,14 @@ public class TusUploadTests : IClassFixture<CustomWebApplicationFactory>
 {
     private readonly HttpClient _senderClient;
     private readonly HttpClient _recipientClient;
+    private readonly JsonSerializerOptions _responseSerializerOptions;
 
     public TusUploadTests(CustomWebApplicationFactory factory)
     {
         _senderClient = factory.CreateClientWithAuthorization(TestConstants.DUMMY_SENDER_TOKEN);
         _recipientClient = factory.CreateClientWithAuthorization(TestConstants.DUMMY_RECIPIENT_TOKEN);
+        _responseSerializerOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        _responseSerializerOptions.Converters.Add(new JsonStringEnumConverter());
     }
 
     [Fact]
@@ -33,7 +38,7 @@ public class TusUploadTests : IClassFixture<CustomWebApplicationFactory>
             FileTransferInitializeExtTestFactory.BasicFileTransfer());
         Assert.True(initializeResponse.IsSuccessStatusCode, await initializeResponse.Content.ReadAsStringAsync());
 
-        var initializeResult = await initializeResponse.Content.ReadFromJsonAsync<FileTransferInitializeResponseExt>();
+        var initializeResult = await initializeResponse.Content.ReadFromJsonAsync<FileTransferInitializeResponseExt>(_responseSerializerOptions);
         Assert.NotNull(initializeResult);
         var fileTransferId = initializeResult.FileTransferId.ToString();
         var fileContent = Encoding.UTF8.GetBytes("This is the contents of the uploaded file");
@@ -70,7 +75,8 @@ public class TusUploadTests : IClassFixture<CustomWebApplicationFactory>
         Assert.Equal(HttpStatusCode.NoContent, patchResponse.StatusCode);
 
         var overview = await _senderClient.GetFromJsonAsync<FileTransferOverviewExt>(
-            $"broker/api/v1/filetransfer/{fileTransferId}");
+            $"broker/api/v1/filetransfer/{fileTransferId}",
+            _responseSerializerOptions);
         Assert.NotNull(overview);
         Assert.Equal(FileTransferStatusExt.Published, overview.FileTransferStatus);
 

--- a/tests/Altinn.Broker.Tests/TusUploadTests.cs
+++ b/tests/Altinn.Broker.Tests/TusUploadTests.cs
@@ -85,4 +85,40 @@ public class TusUploadTests : IClassFixture<CustomWebApplicationFactory>
         var downloadedBytes = await downloadResponse.Content.ReadAsByteArrayAsync();
         Assert.Equal(fileContent, downloadedBytes);
     }
+
+    [Fact]
+    public async Task TusUpload_PartialHead_TwoSegmentLocation_Succeeds()
+    {
+        var initializeResponse = await _senderClient.PostAsJsonAsync(
+            "broker/api/v1/filetransfer",
+            FileTransferInitializeExtTestFactory.BasicFileTransfer());
+        Assert.True(initializeResponse.IsSuccessStatusCode, await initializeResponse.Content.ReadAsStringAsync());
+
+        var initializeResult = await initializeResponse.Content.ReadFromJsonAsync<FileTransferInitializeResponseExt>(_responseSerializerOptions);
+        Assert.NotNull(initializeResult);
+        var fileTransferId = initializeResult.FileTransferId.ToString();
+        const int partialLength = 1024;
+        var tusBaseUrl = $"broker/api/v1/filetransfer/upload/tus/{fileTransferId}";
+
+        var createRequest = new HttpRequestMessage(HttpMethod.Post, tusBaseUrl);
+        createRequest.Headers.Add("Tus-Resumable", "1.0.0");
+        createRequest.Headers.Add("Upload-Length", partialLength.ToString());
+        createRequest.Headers.Add("Upload-Concat", "partial");
+        var createResponse = await _senderClient.SendAsync(createRequest);
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+
+        var uploadUrl = createResponse.Headers.Location;
+        Assert.NotNull(uploadUrl);
+        var uploadPath = uploadUrl.IsAbsoluteUri ? uploadUrl.AbsolutePath : uploadUrl.ToString();
+        Assert.Contains($"/{fileTransferId}/", uploadPath, StringComparison.OrdinalIgnoreCase);
+
+        var headRequest = new HttpRequestMessage(HttpMethod.Head, uploadUrl);
+        headRequest.Headers.Add("Tus-Resumable", "1.0.0");
+        var headResponse = await _senderClient.SendAsync(headRequest);
+        Assert.Equal(HttpStatusCode.OK, headResponse.StatusCode);
+        Assert.True(headResponse.Headers.TryGetValues("Upload-Offset", out var offsetValues));
+        Assert.Equal("0", offsetValues.First());
+        Assert.True(headResponse.Headers.TryGetValues("Upload-Length", out var lengthValues));
+        Assert.Equal(partialLength.ToString(), lengthValues.First());
+    }
 }

--- a/tests/Altinn.Broker.Tests/TusUploadTests.cs
+++ b/tests/Altinn.Broker.Tests/TusUploadTests.cs
@@ -38,7 +38,7 @@ public class TusUploadTests : IClassFixture<CustomWebApplicationFactory>
         var fileTransferId = initializeResult.FileTransferId.ToString();
         var fileContent = Encoding.UTF8.GetBytes("This is the contents of the uploaded file");
 
-        var tusBaseUrl = $"broker/api/v1/filetransfer/{fileTransferId}/upload/tus";
+        var tusBaseUrl = $"broker/api/v1/filetransfer/upload/tus/{fileTransferId}";
 
         var optionsRequest = new HttpRequestMessage(HttpMethod.Options, tusBaseUrl);
         optionsRequest.Headers.Add("Tus-Resumable", "1.0.0");

--- a/tests/Altinn.Broker.Tests/TusUploadTests.cs
+++ b/tests/Altinn.Broker.Tests/TusUploadTests.cs
@@ -54,6 +54,13 @@ public class TusUploadTests : IClassFixture<CustomWebApplicationFactory>
         var uploadUrl = createResponse.Headers.Location;
         Assert.NotNull(uploadUrl);
 
+        var headRequest = new HttpRequestMessage(HttpMethod.Head, uploadUrl);
+        headRequest.Headers.Add("Tus-Resumable", "1.0.0");
+        var headResponse = await _senderClient.SendAsync(headRequest);
+        Assert.Equal(HttpStatusCode.OK, headResponse.StatusCode);
+        Assert.True(headResponse.Headers.TryGetValues("Upload-Offset", out var offsetValues));
+        Assert.Equal("0", offsetValues.First());
+
         var patchRequest = new HttpRequestMessage(HttpMethod.Patch, uploadUrl);
         patchRequest.Headers.Add("Tus-Resumable", "1.0.0");
         patchRequest.Headers.Add("Upload-Offset", "0");

--- a/tests/Altinn.Broker.Tests/TusUploadTests.cs
+++ b/tests/Altinn.Broker.Tests/TusUploadTests.cs
@@ -110,7 +110,7 @@ public class TusUploadTests : IClassFixture<CustomWebApplicationFactory>
         var uploadUrl = createResponse.Headers.Location;
         Assert.NotNull(uploadUrl);
         var uploadPath = uploadUrl.IsAbsoluteUri ? uploadUrl.AbsolutePath : uploadUrl.ToString();
-        Assert.Contains($"/{fileTransferId}/", uploadPath, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains($"/{fileTransferId}/partial/", uploadPath, StringComparison.OrdinalIgnoreCase);
 
         var headRequest = new HttpRequestMessage(HttpMethod.Head, uploadUrl);
         headRequest.Headers.Add("Tus-Resumable", "1.0.0");

--- a/tests/Altinn.Broker.Tests/TusUploadTests.cs
+++ b/tests/Altinn.Broker.Tests/TusUploadTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+
+using Altinn.Broker.API.Models;
+using Altinn.Broker.Common.Constants;
+using Altinn.Broker.Enums;
+using Altinn.Broker.Models;
+using Altinn.Broker.Tests.Factories;
+using Altinn.Broker.Tests.Helpers;
+
+using Xunit;
+
+namespace Altinn.Broker.Tests;
+
+public class TusUploadTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _senderClient;
+    private readonly HttpClient _recipientClient;
+
+    public TusUploadTests(CustomWebApplicationFactory factory)
+    {
+        _senderClient = factory.CreateClientWithAuthorization(TestConstants.DUMMY_SENDER_TOKEN);
+        _recipientClient = factory.CreateClientWithAuthorization(TestConstants.DUMMY_RECIPIENT_TOKEN);
+    }
+
+    [Fact]
+    public async Task TusUpload_SmallFile_SucceedsAndCanBeDownloaded()
+    {
+        var initializeResponse = await _senderClient.PostAsJsonAsync(
+            "broker/api/v1/filetransfer",
+            FileTransferInitializeExtTestFactory.BasicFileTransfer());
+        Assert.True(initializeResponse.IsSuccessStatusCode, await initializeResponse.Content.ReadAsStringAsync());
+
+        var initializeResult = await initializeResponse.Content.ReadFromJsonAsync<FileTransferInitializeResponseExt>();
+        Assert.NotNull(initializeResult);
+        var fileTransferId = initializeResult.FileTransferId.ToString();
+        var fileContent = Encoding.UTF8.GetBytes("This is the contents of the uploaded file");
+
+        var tusBaseUrl = $"broker/api/v1/filetransfer/{fileTransferId}/upload/tus";
+
+        var optionsRequest = new HttpRequestMessage(HttpMethod.Options, tusBaseUrl);
+        optionsRequest.Headers.Add("Tus-Resumable", "1.0.0");
+        var optionsResponse = await _senderClient.SendAsync(optionsRequest);
+        Assert.True(optionsResponse.IsSuccessStatusCode, await optionsResponse.Content.ReadAsStringAsync());
+
+        var createRequest = new HttpRequestMessage(HttpMethod.Post, tusBaseUrl);
+        createRequest.Headers.Add("Tus-Resumable", "1.0.0");
+        createRequest.Headers.Add("Upload-Length", fileContent.Length.ToString());
+        var createResponse = await _senderClient.SendAsync(createRequest);
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+
+        var uploadUrl = createResponse.Headers.Location;
+        Assert.NotNull(uploadUrl);
+
+        var patchRequest = new HttpRequestMessage(HttpMethod.Patch, uploadUrl);
+        patchRequest.Headers.Add("Tus-Resumable", "1.0.0");
+        patchRequest.Headers.Add("Upload-Offset", "0");
+        patchRequest.Content = new ByteArrayContent(fileContent);
+        patchRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/offset+octet-stream");
+        var patchResponse = await _senderClient.SendAsync(patchRequest);
+        Assert.Equal(HttpStatusCode.NoContent, patchResponse.StatusCode);
+
+        var overview = await _senderClient.GetFromJsonAsync<FileTransferOverviewExt>(
+            $"broker/api/v1/filetransfer/{fileTransferId}");
+        Assert.NotNull(overview);
+        Assert.Equal(FileTransferStatusExt.Published, overview.FileTransferStatus);
+
+        var downloadResponse = await _recipientClient.GetAsync($"broker/api/v1/filetransfer/{fileTransferId}/download");
+        Assert.True(downloadResponse.IsSuccessStatusCode, await downloadResponse.Content.ReadAsStringAsync());
+        var downloadedBytes = await downloadResponse.Content.ReadAsByteArrayAsync();
+        Assert.Equal(fileContent, downloadedBytes);
+    }
+}


### PR DESCRIPTION
## Description
The existing upload endpoint streams the entire file in a single HTTP request:

```
POST /broker/api/v1/filetransfer/{fileTransferId}/upload
Content-Type: application/octet-stream
```

That works well for smaller files, but breaks down when a reverse proxy or load balancer terminates long-lived connections. Large uploads that run for hours can fail mid-transfer with no way to resume.

TUS solves this by splitting the upload into many short `PATCH` requests. Each chunk completes quickly; if a connection drops, the client reads the current offset with `HEAD` and continues from there.


## High-level architecture

```
┌─────────┐     1. Initialize      ┌─────────────┐
│ Client  │ ───────────────────► │ Broker API  │
└─────────┘                      └──────┬──────┘
     │                                  │ status: Initialized
     │     2. POST /upload/tus        │
     │        (Upload-Length)         ▼
     │ ───────────────────►    TusEndpointExtensions
     │                                  │
     │     3. PATCH chunks              ▼
     │ ───────────────────►    BrokerTusStore
     │                                  │
     │                                  ▼
     │                         Azure append blob
     │                         brokerfiles/tus-staging/{fileTransferId}
     │                                  │
     │     4. Final PATCH               │
     │ ───────────────────►    TusUploadCompleteHandler
     │                                  │
     │                                  ▼
     │                         FinalizeTusUpload (copy → block blob)
     │                         brokerfiles/{fileTransferId}
     │                                  │
     │                                  ▼
     │                         CompleteFileUploadHandler
     │                         (checksum, status, events)
     └◄───────────────────    status: Published / UploadProcessing
```

## Related Issue(s)
- #935

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled end-to-end resumable TUS uploads for large files, including upload routing and authorization.
  * Added Redis-backed distributed caching for TUS upload sessions (configurable expiration), with local development support via a Redis container.
* **Bug Fixes**
  * Improved handling of TUS route/upload identifiers to ensure requests are sent to the correct upload target.
  * Enhanced Azure finalization/cleanup for TUS staging artifacts during upload completion.
* **Documentation**
  * Updated Swagger/OpenAPI to document TUS upload endpoints and required headers.
* **Tests**
  * Added/extended TUS end-to-end tests and migrated the large-file upload harness to TUS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->