### PR TITLE
Fix for cleanup use case tests

### DIFF
--- a/src/Altinn.Broker.Application/CleanupUseCaseTests/CleanupUseCaseTestsHandler.cs
+++ b/src/Altinn.Broker.Application/CleanupUseCaseTests/CleanupUseCaseTestsHandler.cs
@@ -68,18 +68,10 @@ public class CleanupUseCaseTestsHandler(
             return;
         }
 
-        var resource = await resourceRepository.GetResource(resourceId, cancellationToken);
-        if (resource is null)
-        {
-            logger.LogError("Resource {resourceId} not found; skipping blob deletion during use case test cleanup", resourceId);
-            return;
-        }
-        var serviceOwner = await serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId);
-        if (serviceOwner is null)
-        {
-            logger.LogError("Service owner {serviceOwnerId} not found; skipping blob deletion during use case test cleanup", resource.ServiceOwnerId);
-            return;
-        }
+        var resource = await resourceRepository.GetResource(resourceId, cancellationToken)
+            ?? throw new InvalidOperationException($"Resource {resourceId} not found; aborting use case test cleanup to avoid orphaning blobs");
+        var serviceOwner = await serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId)
+            ?? throw new InvalidOperationException($"Service owner {resource.ServiceOwnerId} not found; aborting use case test cleanup to avoid orphaning blobs");
 
         foreach (var fileTransfer in fileTransfersToDelete)
         {

--- a/src/Altinn.Broker.Application/CleanupUseCaseTests/CleanupUseCaseTestsHandler.cs
+++ b/src/Altinn.Broker.Application/CleanupUseCaseTests/CleanupUseCaseTestsHandler.cs
@@ -12,7 +12,10 @@ namespace Altinn.Broker.Application.CleanupUseCaseTests;
 public class CleanupUseCaseTestsHandler(
     IBackgroundJobClient backgroundJobClient,
     ILogger<CleanupUseCaseTestsHandler> logger,
-    IFileTransferRepository fileTransferRepository
+    IFileTransferRepository fileTransferRepository,
+    IResourceRepository resourceRepository,
+    IServiceOwnerRepository serviceOwnerRepository,
+    IBrokerStorageService brokerStorageService
 ) : IHandler<CleanupUseCaseTestsRequest, CleanupUseCaseTestsResponse>
 {
     private const string ResourceId = "bruksmonster-broker";
@@ -27,10 +30,10 @@ public class CleanupUseCaseTestsHandler(
         }
 
         var fileTransferIds = await fileTransferRepository.GetFileTransfersByResourceId(ResourceId, minAge, cancellationToken);
-        
+
         return await TransactionWithRetriesPolicy.Execute(async (ct) =>
         {
-            var deleteFileTransfersJobId = backgroundJobClient.Enqueue<CleanupUseCaseTestsHandler>(h => h.DeleteFileTransfers(fileTransferIds, ResourceId, CancellationToken.None));
+            var deleteFileTransfersJobId = backgroundJobClient.Enqueue<CleanupUseCaseTestsHandler>(h => h.DeleteFileTransfers(fileTransferIds, ResourceId, minAge, CancellationToken.None));
             await Task.CompletedTask;
 
             var response = new CleanupUseCaseTestsResponse
@@ -44,15 +47,50 @@ public class CleanupUseCaseTestsHandler(
     }
 
 
-	public async Task DeleteFileTransfers(List<Guid> fileTransferIds, string resourceId, CancellationToken cancellationToken)
+	public async Task DeleteFileTransfers(List<Guid> fileTransferIds, string resourceId, DateTimeOffset minAge, CancellationToken cancellationToken)
     {
+        await DeleteRemainingUseCaseBlobs(resourceId, minAge, cancellationToken);
+
         await TransactionWithRetriesPolicy.Execute(async (ct) =>
         {
             int deletedFileTransfers = await fileTransferRepository.HardDeleteFileTransfersByIds(fileTransferIds, cancellationToken);
             logger.LogInformation("Deleted {deletedFileTransfers} file transfers for resourceId {resourceId}", deletedFileTransfers, resourceId);
-			
+
             return Task.CompletedTask;
         }, logger, cancellationToken);
     }
-}
 
+    private async Task DeleteRemainingUseCaseBlobs(string resourceId, DateTimeOffset minAge, CancellationToken cancellationToken)
+    {
+        var fileTransfersToDelete = await fileTransferRepository.GetNonPurgedFileTransfersByResourceId(resourceId, minAge, cancellationToken);
+        if (fileTransfersToDelete.Count == 0)
+        {
+            return;
+        }
+
+        var resource = await resourceRepository.GetResource(resourceId, cancellationToken);
+        if (resource is null)
+        {
+            logger.LogError("Resource {resourceId} not found; skipping blob deletion during use case test cleanup", resourceId);
+            return;
+        }
+        var serviceOwner = await serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId);
+        if (serviceOwner is null)
+        {
+            logger.LogError("Service owner {serviceOwnerId} not found; skipping blob deletion during use case test cleanup", resource.ServiceOwnerId);
+            return;
+        }
+
+        foreach (var fileTransfer in fileTransfersToDelete)
+        {
+            try
+            {
+                await brokerStorageService.DeleteFile(serviceOwner, fileTransfer, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to delete blob for file transfer {fileTransferId} during use case test cleanup", fileTransfer.FileTransferId);
+            }
+        }
+    }
+}

--- a/src/Altinn.Broker.Application/CleanupUseCaseTests/CleanupUseCaseTestsHandler.cs
+++ b/src/Altinn.Broker.Application/CleanupUseCaseTests/CleanupUseCaseTestsHandler.cs
@@ -49,23 +49,27 @@ public class CleanupUseCaseTestsHandler(
 
 	public async Task DeleteFileTransfers(List<Guid> fileTransferIds, string resourceId, DateTimeOffset minAge, CancellationToken cancellationToken)
     {
-        await DeleteRemainingUseCaseBlobs(resourceId, minAge, cancellationToken);
+        var blobDeletionFailures = await DeleteRemainingUseCaseBlobs(resourceId, minAge, cancellationToken);
+
+        var fileTransferIdsToDelete = blobDeletionFailures.Count == 0
+            ? fileTransferIds
+            : fileTransferIds.Where(id => !blobDeletionFailures.Contains(id)).ToList();
 
         await TransactionWithRetriesPolicy.Execute(async (ct) =>
         {
-            int deletedFileTransfers = await fileTransferRepository.HardDeleteFileTransfersByIds(fileTransferIds, cancellationToken);
-            logger.LogInformation("Deleted {deletedFileTransfers} file transfers for resourceId {resourceId}", deletedFileTransfers, resourceId);
+            int deletedFileTransfers = await fileTransferRepository.HardDeleteFileTransfersByIds(fileTransferIdsToDelete, cancellationToken);
+            logger.LogInformation("Deleted {deletedFileTransfers} file transfers for resourceId {resourceId} ({keptForRetry} kept for retry due to blob deletion failures)", deletedFileTransfers, resourceId, blobDeletionFailures.Count);
 
             return Task.CompletedTask;
         }, logger, cancellationToken);
     }
 
-    private async Task DeleteRemainingUseCaseBlobs(string resourceId, DateTimeOffset minAge, CancellationToken cancellationToken)
+    private async Task<HashSet<Guid>> DeleteRemainingUseCaseBlobs(string resourceId, DateTimeOffset minAge, CancellationToken cancellationToken)
     {
         var fileTransfersToDelete = await fileTransferRepository.GetNonPurgedFileTransfersByResourceId(resourceId, minAge, cancellationToken);
         if (fileTransfersToDelete.Count == 0)
         {
-            return;
+            return new HashSet<Guid>();
         }
 
         var resource = await resourceRepository.GetResource(resourceId, cancellationToken)
@@ -73,6 +77,7 @@ public class CleanupUseCaseTestsHandler(
         var serviceOwner = await serviceOwnerRepository.GetServiceOwner(resource.ServiceOwnerId)
             ?? throw new InvalidOperationException($"Service owner {resource.ServiceOwnerId} not found; aborting use case test cleanup to avoid orphaning blobs");
 
+        HashSet<Guid> failedFileTransferIds = [];
         foreach (var fileTransfer in fileTransfersToDelete)
         {
             try
@@ -81,8 +86,10 @@ public class CleanupUseCaseTestsHandler(
             }
             catch (Exception ex)
             {
+                failedFileTransferIds.Add(fileTransfer.FileTransferId);
                 logger.LogError(ex, "Failed to delete blob for file transfer {fileTransferId} during use case test cleanup", fileTransfer.FileTransferId);
             }
         }
+        return failedFileTransferIds;
     }
 }

--- a/src/Altinn.Broker.Core/Repositories/IFileTransferRepository.cs
+++ b/src/Altinn.Broker.Core/Repositories/IFileTransferRepository.cs
@@ -33,6 +33,7 @@ public interface IFileTransferRepository
     Task<(List<FileTransferEntity> FileTransfers, Dictionary<Guid, string> ServiceOwnerIds)> GetFileTransfersForReportWithServiceOwnerIds(CancellationToken cancellationToken);
 
     Task<List<Guid>> GetFileTransfersByResourceId(string resourceId, DateTimeOffset minAge, CancellationToken cancellationToken);
+    Task<List<FileTransferEntity>> GetNonPurgedFileTransfersByResourceId(string resourceId, DateTimeOffset minAge, CancellationToken cancellationToken);
     Task<int> HardDeleteFileTransfersByIds(IEnumerable<Guid> fileTransferIds, CancellationToken cancellationToken);
     Task<List<AggregatedDailySummaryData>> GetAggregatedDailySummaryData(CancellationToken cancellationToken, string[]? resourceIdFilter = null);
 }

--- a/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
+++ b/src/Altinn.Broker.Persistence/Repositories/FileTransferRepository.cs
@@ -855,6 +855,43 @@ LEFT JOIN LATERAL (
         }, cancellationToken);
     }
 
+    public async Task<List<FileTransferEntity>> GetNonPurgedFileTransfersByResourceId(string resourceId, DateTimeOffset minAge, CancellationToken cancellationToken)
+    {
+        await using var command = dataSource.CreateCommand(
+            "SELECT file_transfer_id_pk, resource_id, use_virus_scan " +
+            "FROM broker.file_transfer " +
+            "WHERE resource_id = @resourceId AND created < @minAge " +
+            "AND latest_file_status_id IS DISTINCT FROM @purgedStatus");
+
+        command.Parameters.AddWithValue("@resourceId", resourceId);
+        command.Parameters.AddWithValue("@minAge", minAge);
+        command.Parameters.AddWithValue("@purgedStatus", (int)FileTransferStatus.Purged);
+
+        return await commandExecutor.ExecuteWithRetry(async (ct) =>
+        {
+            var result = new List<FileTransferEntity>();
+
+            await using var reader = await command.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct))
+            {
+                result.Add(new FileTransferEntity
+                {
+                    FileTransferId = reader.GetGuid(reader.GetOrdinal("file_transfer_id_pk")),
+                    ResourceId = reader.GetString(reader.GetOrdinal("resource_id")),
+                    UseVirusScan = reader.GetBoolean(reader.GetOrdinal("use_virus_scan")),
+                    Sender = null!,
+                    FileTransferStatusEntity = null!,
+                    RecipientCurrentStatuses = [],
+                    FileName = string.Empty,
+                    Created = default,
+                    ExpirationTime = default,
+                });
+            }
+
+            return result;
+        }, cancellationToken);
+    }
+
     public async Task<int> HardDeleteFileTransfersByIds(IEnumerable<Guid> fileTransferIds, CancellationToken cancellationToken)
     {
         var idsArray = fileTransferIds.ToArray();
@@ -862,7 +899,7 @@ LEFT JOIN LATERAL (
         {
             return 0;
         }
-        if (idsArray.Length > 1000) //Safety margin
+        if (idsArray.Length > 10000) //Safety margin
         {
             throw new ArgumentException($"Too many file transfers to delete. Total file transfers in requested hard delete: {idsArray.Length}", nameof(fileTransferIds));
         }

--- a/tests/Altinn.Broker.Tests/CleanupUseCaseTestsHandlerTests.cs
+++ b/tests/Altinn.Broker.Tests/CleanupUseCaseTestsHandlerTests.cs
@@ -16,12 +16,15 @@ public class CleanupUseCaseTestsHandlerTests
 
 	private static CleanupUseCaseTestsHandler CreateHandler(
 		Mock<IBackgroundJobClient> bgClientMock,
-		Mock<IFileTransferRepository> repoMock)
+		Mock<IFileTransferRepository> repoMock,
+		Mock<IResourceRepository>? resourceRepoMock = null,
+		Mock<IServiceOwnerRepository>? serviceOwnerRepoMock = null,
+		Mock<IBrokerStorageService>? storageMock = null)
 	{
 		var loggerMock = new Mock<ILogger<CleanupUseCaseTestsHandler>>();
-		var resourceRepoMock = new Mock<IResourceRepository>();
-		var serviceOwnerRepoMock = new Mock<IServiceOwnerRepository>();
-		var storageMock = new Mock<IBrokerStorageService>();
+		resourceRepoMock ??= new Mock<IResourceRepository>();
+		serviceOwnerRepoMock ??= new Mock<IServiceOwnerRepository>();
+		storageMock ??= new Mock<IBrokerStorageService>();
 		return new CleanupUseCaseTestsHandler(
 			bgClientMock.Object,
 			loggerMock.Object,
@@ -30,6 +33,19 @@ public class CleanupUseCaseTestsHandlerTests
 			serviceOwnerRepoMock.Object,
 			storageMock.Object);
 	}
+
+	private static FileTransferEntity CreateLightweightFileTransfer(Guid id) => new()
+	{
+		FileTransferId = id,
+		ResourceId = ResourceId,
+		UseVirusScan = true,
+		Sender = null!,
+		FileTransferStatusEntity = null!,
+		RecipientCurrentStatuses = [],
+		FileName = string.Empty,
+		Created = default,
+		ExpirationTime = default,
+	};
 
 	[Fact]
 	public async Task Process_EnqueuesDeleteJob_ReturnsResponseWithCounts()
@@ -131,5 +147,52 @@ public class CleanupUseCaseTestsHandlerTests
 
 		// Assert
 		repoMock.Verify(r => r.HardDeleteFileTransfersByIds(ids, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task DeleteFileTransfers_KeepsRowsWhoseBlobDeletionFailed()
+	{
+		// Arrange
+		var succeedId = Guid.NewGuid();
+		var failId = Guid.NewGuid();
+		var alreadyPurgedId = Guid.NewGuid();
+		var ids = new List<Guid> { succeedId, failId, alreadyPurgedId };
+
+		var repoMock = new Mock<IFileTransferRepository>();
+		repoMock.Setup(r => r.GetNonPurgedFileTransfersByResourceId(ResourceId, It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new List<FileTransferEntity>
+			{
+				CreateLightweightFileTransfer(succeedId),
+				CreateLightweightFileTransfer(failId),
+			});
+
+		List<Guid>? hardDeletedIds = null;
+		repoMock.Setup(r => r.HardDeleteFileTransfersByIds(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+			.Callback<IEnumerable<Guid>, CancellationToken>((deleted, _) => hardDeletedIds = deleted.ToList())
+			.ReturnsAsync(2);
+
+		var resourceRepoMock = new Mock<IResourceRepository>();
+		resourceRepoMock.Setup(r => r.GetResource(ResourceId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new ResourceEntity { Id = ResourceId, ServiceOwnerId = "so-1" });
+
+		var serviceOwnerRepoMock = new Mock<IServiceOwnerRepository>();
+		serviceOwnerRepoMock.Setup(s => s.GetServiceOwner("so-1"))
+			.ReturnsAsync(new ServiceOwnerEntity { Id = "so-1", Name = "Test", StorageProviders = [] });
+
+		var storageMock = new Mock<IBrokerStorageService>();
+		storageMock.Setup(s => s.DeleteFile(It.IsAny<ServiceOwnerEntity>(), It.Is<FileTransferEntity>(f => f.FileTransferId == failId), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new Exception("blob delete failed"));
+
+		var bgClientMock = new Mock<IBackgroundJobClient>();
+		var handler = CreateHandler(bgClientMock, repoMock, resourceRepoMock, serviceOwnerRepoMock, storageMock);
+
+		// Act
+		await handler.DeleteFileTransfers(ids, ResourceId, DateTimeOffset.UtcNow, CancellationToken.None);
+
+		// Assert
+		Assert.NotNull(hardDeletedIds);
+		Assert.Contains(succeedId, hardDeletedIds!);
+		Assert.Contains(alreadyPurgedId, hardDeletedIds!);
+		Assert.DoesNotContain(failId, hardDeletedIds!);
 	}
 }

--- a/tests/Altinn.Broker.Tests/CleanupUseCaseTestsHandlerTests.cs
+++ b/tests/Altinn.Broker.Tests/CleanupUseCaseTestsHandlerTests.cs
@@ -1,4 +1,5 @@
 using Altinn.Broker.Application.CleanupUseCaseTests;
+using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Repositories;
 using Hangfire;
 using Hangfire.Common;
@@ -18,7 +19,16 @@ public class CleanupUseCaseTestsHandlerTests
 		Mock<IFileTransferRepository> repoMock)
 	{
 		var loggerMock = new Mock<ILogger<CleanupUseCaseTestsHandler>>();
-		return new CleanupUseCaseTestsHandler(bgClientMock.Object, loggerMock.Object, repoMock.Object);
+		var resourceRepoMock = new Mock<IResourceRepository>();
+		var serviceOwnerRepoMock = new Mock<IServiceOwnerRepository>();
+		var storageMock = new Mock<IBrokerStorageService>();
+		return new CleanupUseCaseTestsHandler(
+			bgClientMock.Object,
+			loggerMock.Object,
+			repoMock.Object,
+			resourceRepoMock.Object,
+			serviceOwnerRepoMock.Object,
+			storageMock.Object);
 	}
 
 	[Fact]
@@ -60,10 +70,10 @@ public class CleanupUseCaseTestsHandlerTests
 		Assert.Equal(nameof(CleanupUseCaseTestsHandler.DeleteFileTransfers), capturedJob.Method.Name);
 		var argFileTransfersVal = capturedJob.Args[0] as List<Guid>;
 		var argResourceVal = capturedJob.Args[1] as string;
-		var argCancellationTokenVal = (CancellationToken)capturedJob.Args[2];
 		Assert.NotNull(argFileTransfersVal);
 		Assert.Equal(existingIds.OrderBy(x => x), argFileTransfersVal!.OrderBy(x => x));
 		Assert.Equal(ResourceId, argResourceVal);
+		Assert.IsType<DateTimeOffset>(capturedJob.Args[2]);
 	}
 
 	[Fact]
@@ -108,6 +118,8 @@ public class CleanupUseCaseTestsHandlerTests
 		// Arrange
 		var ids = new List<Guid> { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
 		var repoMock = new Mock<IFileTransferRepository>();
+		repoMock.Setup(r => r.GetNonPurgedFileTransfersByResourceId(ResourceId, It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new List<FileTransferEntity>());
 		repoMock.Setup(r => r.HardDeleteFileTransfersByIds(ids, It.IsAny<CancellationToken>()))
 			.ReturnsAsync(ids.Count);
 
@@ -115,7 +127,7 @@ public class CleanupUseCaseTestsHandlerTests
 		var handler = CreateHandler(bgClientMock, repoMock);
 
 		// Act
-		await handler.DeleteFileTransfers(ids, ResourceId, CancellationToken.None);
+		await handler.DeleteFileTransfers(ids, ResourceId, DateTimeOffset.UtcNow, CancellationToken.None);
 
 		// Assert
 		repoMock.Verify(r => r.HardDeleteFileTransfersByIds(ids, It.IsAny<CancellationToken>()), Times.Once);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In production more than 1000 file transfers to cleanup have accumulated which exceeds the safe guard configured. Also the cleanup job does not delete the blob for the use case files, which is fine since the tests also purge the file. But if a test  fails before that step it could lead to an orphaned file blob.

This PR makes the cleanup job also purge the blob for the files if the blob was not deleted by the tests. And it increases the safe guard limit to 10000.

## Related Issue(s)
- https://github.com/Altinn/altinn-correspondence/issues/2038

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cleanup now also removes related stored files when deleting old file transfers.
  * Only file transfers older than the selected cutoff are considered for cleanup.

* **Bug Fixes**
  * Prevents hard deletion when file removal fails, helping avoid orphaned files.
  * Improves cleanup logging so retained items are reported clearly.

* **Chores**
  * Increased the maximum number of file transfer IDs handled in a single delete operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->