### PR TITLE
push checksumProcessing enqueue outside of original transaction

### DIFF
--- a/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
@@ -100,6 +100,7 @@ public class CompleteFileUploadHandler(
 
         try
         {
+            var enqueueChecksumProcessing = false;
             await TransactionWithRetriesPolicy.Execute<Task>(async ct =>
             {
                 if (request.DeferChecksumValidation)
@@ -161,8 +162,7 @@ public class CompleteFileUploadHandler(
                         request.UploadLength,
                         ct);
 
-                    backgroundJobClient.Enqueue<TusChecksumProcessingHandler>(handler =>
-                        handler.Process(request.FileTransferId, CancellationToken.None));
+                    enqueueChecksumProcessing = true;
                 }
                 else
                 {
@@ -217,6 +217,12 @@ public class CompleteFileUploadHandler(
 
                 return Task.CompletedTask;
             }, logger, cancellationToken);
+
+            if (enqueueChecksumProcessing)
+            {
+                backgroundJobClient.Enqueue<TusChecksumProcessingHandler>(handler =>
+                    handler.Process(request.FileTransferId, CancellationToken.None));
+            }
         }
         catch (Exception e)
         {


### PR DESCRIPTION
## Description


## Related Issue(s)
- #959 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
- [ ] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deferred checksum processing during file uploads.
  * Checksum validation jobs are now queued only after the upload transaction completes successfully, preventing unnecessary processing when the transaction fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->