### PR TITLE
Always set file length

### DIFF
--- a/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
@@ -206,13 +206,15 @@ public class CompleteFileUploadHandler(
                                 AltinnEventSubjectRole.Recipient));
                         }
                     }
-
-                    await fileTransferRepository.SetStorageDetails(
-                        request.FileTransferId,
-                        storageProvider.Id,
-                        request.FileTransferId.ToString(),
-                        request.UploadLength,
-                        ct);
+                    if (fileTransfer.FileTransferSize == 0) 
+                    { 
+                        await fileTransferRepository.SetStorageDetails(
+                            request.FileTransferId,
+                            storageProvider.Id,
+                            request.FileTransferId.ToString(),
+                            request.UploadLength,
+                            ct);
+                    }
                 }
 
                 return Task.CompletedTask;

--- a/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
@@ -155,11 +155,11 @@ public class CompleteFileUploadHandler(
                     }
 
                     await fileTransferRepository.SetStorageDetails(
-                        request.FileTransferId,
-                        storageProvider.Id,
-                        request.FileTransferId.ToString(),
-                        request.UploadLength,
-                        ct);
+                    request.FileTransferId,
+                    storageProvider.Id,
+                    request.FileTransferId.ToString(),
+                    request.UploadLength,
+                    ct);
 
                     backgroundJobClient.Enqueue<TusChecksumProcessingHandler>(handler =>
                         handler.Process(request.FileTransferId, CancellationToken.None));
@@ -218,15 +218,13 @@ public class CompleteFileUploadHandler(
                                 AltinnEventSubjectRole.Recipient));
                         }
                     }
-                    if (fileTransfer.FileTransferSize == 0) 
-                    { 
-                        await fileTransferRepository.SetStorageDetails(
-                            request.FileTransferId,
-                            storageProvider.Id,
-                            request.FileTransferId.ToString(),
-                            request.UploadLength,
-                            ct);
-                    }
+
+                    await fileTransferRepository.SetStorageDetails(
+                        request.FileTransferId,
+                        storageProvider.Id,
+                        request.FileTransferId.ToString(),
+                        request.UploadLength,
+                        ct);
                 }
 
                 return Task.CompletedTask;

--- a/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
@@ -52,8 +52,6 @@ public class CompleteFileUploadHandler(
             return request.FileTransferId;
         }
 
-        var alreadyUploadProcessing = fileTransfer.FileTransferStatusEntity.Status == FileTransferStatus.UploadProcessing;
-
         var resource = await resourceRepository.GetResource(fileTransfer.ResourceId, cancellationToken);
         if (resource is null)
         {
@@ -106,7 +104,13 @@ public class CompleteFileUploadHandler(
                 {
                     if (userProvidedChecksum || requiresVirusScan)
                     {
-                        if (!alreadyUploadProcessing)
+                        var currentFileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, ct);
+                        if (currentFileTransfer is null)
+                        {
+                            throw new InvalidOperationException(
+                                $"File transfer {request.FileTransferId} not found when trying to set status to UploadProcessing");
+                        }
+                        if (currentFileTransfer.FileTransferStatusEntity.Status == FileTransferStatus.UploadStarted)
                         {
                             logger.LogInformation(
                                 "CompleteFileUpload setting status UploadProcessing for file transfer {FileTransferId} (defer checksum, virus scan or user checksum)",

--- a/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
@@ -155,11 +155,11 @@ public class CompleteFileUploadHandler(
                     }
 
                     await fileTransferRepository.SetStorageDetails(
-                    request.FileTransferId,
-                    storageProvider.Id,
-                    request.FileTransferId.ToString(),
-                    request.UploadLength,
-                    ct);
+                        request.FileTransferId,
+                        storageProvider.Id,
+                        request.FileTransferId.ToString(),
+                        request.UploadLength,
+                        ct);
 
                     backgroundJobClient.Enqueue<TusChecksumProcessingHandler>(handler =>
                         handler.Process(request.FileTransferId, CancellationToken.None));

--- a/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
@@ -168,18 +168,30 @@ public class CompleteFileUploadHandler(
                 {
                     if (requiresVirusScan)
                     {
-                        await fileTransferStatusRepository.InsertFileTransferStatus(
-                            request.FileTransferId,
-                            FileTransferStatus.UploadProcessing,
-                            timestamp: finishedUploadTimestamp,
-                            cancellationToken: ct);
-                        backgroundJobClient.Enqueue(() => eventBus.Publish(
-                            AltinnEventType.UploadProcessing,
-                            fileTransfer.ResourceId,
-                            request.FileTransferId.ToString(),
-                            fileTransfer.Sender.ActorExternalId,
-                            Guid.NewGuid(),
-                            AltinnEventSubjectRole.Sender));
+                        var currentFileTransfer = await fileTransferRepository.GetFileTransfer(request.FileTransferId, ct);
+                        if (currentFileTransfer is null)
+                        {
+                            throw new InvalidOperationException(
+                                $"File transfer {request.FileTransferId} not found when trying to set status to UploadProcessing");
+                        } 
+                        if (currentFileTransfer.FileTransferStatusEntity.Status == FileTransferStatus.UploadStarted)
+                        {
+                            logger.LogInformation(
+                                "CompleteFileUpload setting status UploadProcessing for file transfer {FileTransferId} (requires virus scan)",
+                                request.FileTransferId);
+                            await fileTransferStatusRepository.InsertFileTransferStatus(
+                                request.FileTransferId,
+                                FileTransferStatus.UploadProcessing,
+                                timestamp: finishedUploadTimestamp,
+                                cancellationToken: ct);
+                            backgroundJobClient.Enqueue(() => eventBus.Publish(
+                                AltinnEventType.UploadProcessing,
+                                fileTransfer.ResourceId,
+                                request.FileTransferId.ToString(),
+                                fileTransfer.Sender.ActorExternalId,
+                                Guid.NewGuid(),
+                                AltinnEventSubjectRole.Sender));
+                        }
                     }
                     else if (!generalSettings.Value.SimulateMalwareScan)
                     {

--- a/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
@@ -1,14 +1,12 @@
 using System.Security.Claims;
 
 using Altinn.Broker.Application.Middlewares;
-using Altinn.Broker.Application.Settings;
 using Altinn.Broker.Common;
 using Altinn.Broker.Core;
 using Altinn.Broker.Core.Application;
 using Altinn.Broker.Core.Domain.Enums;
 using Altinn.Broker.Core.Helpers;
 using Altinn.Broker.Core.Repositories;
-using Altinn.Broker.Core.Services;
 using Altinn.Broker.Core.Services.Enums;
 
 using Hangfire;
@@ -22,6 +20,7 @@ namespace Altinn.Broker.Application.UploadFile;
 public class UploadFileHandler(
     TusUploadValidationService tusUploadValidationService,
     IFileTransferStatusRepository fileTransferStatusRepository,
+    IFileTransferRepository fileTransferRepository,
     IBrokerStorageService brokerStorageService,
     CompleteFileUploadHandler completeFileUploadHandler,
     IResourceRepository resourceRepository,
@@ -96,6 +95,17 @@ public class UploadFileHandler(
             }
 
             var (checksum, uploadLength) = result.Value;
+            var storageProvider = serviceOwner.GetStorageProvider(fileTransfer.UseVirusScan);
+            if (storageProvider is null)
+            {
+                throw new InvalidOperationException(Errors.StorageProviderNotReady.Message);
+            }
+            await fileTransferRepository.SetStorageDetails(
+                request.FileTransferId,
+                storageProvider.Id,
+                request.FileTransferId.ToString(),
+                uploadLength,
+                CancellationToken.None);
             return await completeFileUploadHandler.Process(
                 new CompleteFileUploadRequest
                 {

--- a/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -7,11 +7,13 @@ using Altinn.Broker.Application.UploadFile;
 using Altinn.Broker.Core.Domain;
 using Altinn.Broker.Core.Repositories;
 using Altinn.Broker.Core.Services;
+using Altinn.Broker.Integrations.Hangfire;
 using Altinn.Broker.Tests.Helpers;
 
 using Hangfire;
 using Hangfire.MemoryStorage;
 using Hangfire.Logging;
+using Hangfire.PostgreSql;
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -23,14 +25,13 @@ using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
 using Moq;
-
-using Polly;
 
 using StackExchange.Redis;
 
@@ -67,10 +68,6 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
         // Overwrite registrations from Program.cs
         builder.ConfigureTestServices((services) =>
         {
-            // Hangfire keeps the log provider globally. Set the test-safe provider before
-            // any test service provider resolves Hangfire services.
-            LogProvider.SetCurrentLogProvider(new HangfireNoOpLogProvider());
-
             services.RemoveAll<IConnectionMultiplexer>();
             services.RemoveAll<IConfigureOptions<RedisCacheOptions>>();
             services.RemoveAll<IDistributedCache>();
@@ -121,7 +118,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                         }
                     };
                 });
-            services.AddHangfire(c => c.UseMemoryStorage());
+            ReplaceHangfireForTests(services);
             services.RemoveAll<ITusFinalizeUploadEnqueuer>();
             services.AddSingleton<ITusFinalizeUploadEnqueuer, InlineTusFinalizeUploadEnqueuer>();
 
@@ -220,21 +217,40 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
             var eventBus = new Mock<IEventBus>();
             services.AddSingleton(eventBus.Object);
 
-            // Ensure Hangfire for tests uses in-memory storage and a test-safe log provider,
-            // overriding any AspNetCoreLogProvider that depends on a scoped LoggerFactory.
-            services.AddHangfire(config => config.UseMemoryStorage());
-
-            var sp = services.BuildServiceProvider();
-            var backgroundJobClient = sp.GetRequiredService<IBackgroundJobClient>();
-            var policy = Policy.Handle<Exception>().WaitAndRetry(10, _ => TimeSpan.FromSeconds(1));
-            var result = policy.ExecuteAndCapture(() => backgroundJobClient.Enqueue(() => Console.WriteLine("Hello World!")));
-
             services.RemoveAll<IRecurringJobManager>();
             services.AddSingleton(new Mock<IRecurringJobManager>().Object);
-            if (result.Outcome == OutcomeType.Failure)
-            {
-                throw new InvalidOperationException("Hangfire could not be installed");
-            }
+        });
+    }
+
+    private static void ReplaceHangfireForTests(IServiceCollection services)
+    {
+        // Production ConfigureHangfire() registers first and wires AspNetCoreLogProvider to
+        // ILoggerFactory. Hangfire uses TryAddSingleton, so a later AddHangfire() does not
+        // replace those registrations. AspNetCoreLogProvider is also process-global static
+        // state, so a disposed test host can cause intermittent ObjectDisposedException.
+        var descriptorsToRemove = services
+            .Where(d =>
+                (d.ServiceType.FullName?.StartsWith("Hangfire.", StringComparison.Ordinal) ?? false) ||
+                (d.ImplementationType?.FullName?.StartsWith("Hangfire.", StringComparison.Ordinal) ?? false) ||
+                d.ImplementationType == typeof(HangfireQueueMetricsService) ||
+                (d.ServiceType == typeof(IHostedService) &&
+                 (d.ImplementationType?.FullName?.Contains("Hangfire", StringComparison.Ordinal) ?? false)))
+            .ToList();
+
+        foreach (var descriptor in descriptorsToRemove)
+        {
+            services.Remove(descriptor);
+        }
+
+        services.RemoveAll<IConnectionFactory>();
+
+        var noOpLogProvider = new HangfireNoOpLogProvider();
+        LogProvider.SetCurrentLogProvider(noOpLogProvider);
+
+        services.AddHangfire(config =>
+        {
+            config.UseMemoryStorage();
+            config.UseLogProvider(noOpLogProvider);
         });
     }
 


### PR DESCRIPTION
## Description
Solves a couple of race conditions and made tests less flaky.

## Related Issue(s)
- #935 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Uploads now record storage-provider information and upload size after a successful transfer.
  - If storage-provider details cannot be saved, the upload is marked as failed and the corresponding failure event is triggered.
  - Virus-scan completion now only triggers upload-processing updates when the file transfer is in the expected “started” state, preventing duplicate processing updates.
  - If the transfer cannot be reloaded during virus-scan completion, processing fails clearly instead of applying an incorrect update.

- **Tests**
  - Updated the test host’s Hangfire setup to use a dedicated replacement helper with no-op logging and safer in-memory configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->