### PR TITLE
Idempotency key can be max 80 characters. Exceeded when using URN.

### DIFF
--- a/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
+++ b/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
@@ -20,6 +20,7 @@ using Hangfire;
 using Microsoft.Extensions.Logging;
 
 using OneOf;
+using Altinn.Broker.Common;
 
 namespace Altinn.Broker.Application;
 public class MalwareScanningResultHandler(
@@ -181,7 +182,7 @@ public class MalwareScanningResultHandler(
         string actorExternalId,
         AltinnEventSubjectRole subjectRole)
     {
-        var idempotencyKey = $"{fileTransferId}_cleanscan_published_{subjectRole}_{actorExternalId}";
+        var idempotencyKey = $"{fileTransferId}_okscan_published_{subjectRole}_{actorExternalId.WithoutPrefix()}";
         if (await idempotencyEventRepository.ExistsAsync(idempotencyKey, CancellationToken.None))
         {
             logger.LogInformation(


### PR DESCRIPTION
## Description
Idempotency key can be max 80 characters. Exceeded when using URN. Also with shorter prefix for recipients.

## Related Issue(s)
- #947 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-event handling for malware scan results by standardizing event identifiers.
  * Ensured actor identifiers are consistently normalized when processing published events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->