### PR TITLE
Set UploadProcessing timestamp immediately after file has been uploaded to avoid timing issue

### DIFF
--- a/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadHandler.cs
@@ -72,7 +72,6 @@ public class CompleteFileUploadHandler(
             return Errors.StorageProviderNotReady;
         }
 
-        var finishedUploadTimestamp = DateTime.UtcNow;
         var userProvidedChecksum = !string.IsNullOrWhiteSpace(fileTransfer.Checksum);
         var requiresVirusScan = storageProvider.Type == StorageProviderType.Altinn3Azure;
 
@@ -90,7 +89,7 @@ public class CompleteFileUploadHandler(
             await fileTransferStatusRepository.InsertFileTransferStatus(
                 request.FileTransferId,
                 FileTransferStatus.Failed,
-                timestamp: finishedUploadTimestamp,
+                timestamp: request.UploadFinishedTimestamp,
                 detailedFileTransferStatus: "Checksum mismatch",
                 cancellationToken: cancellationToken);
             backgroundJobClient.Enqueue<IBrokerStorageService>(service =>
@@ -120,7 +119,7 @@ public class CompleteFileUploadHandler(
                             await fileTransferStatusRepository.InsertFileTransferStatus(
                                 request.FileTransferId,
                                 FileTransferStatus.UploadProcessing,
-                                timestamp: finishedUploadTimestamp,
+                                timestamp: request.UploadFinishedTimestamp,
                                 cancellationToken: ct);
                             backgroundJobClient.Enqueue(() => eventBus.Publish(
                                 AltinnEventType.UploadProcessing,
@@ -138,7 +137,7 @@ public class CompleteFileUploadHandler(
                             request.FileTransferId);
                         await fileTransferPublishService.TryPublishAsync(
                             fileTransfer,
-                            finishedUploadTimestamp,
+                            DateTimeOffset.UtcNow,
                             ct);
                     }
 
@@ -170,7 +169,7 @@ public class CompleteFileUploadHandler(
                             await fileTransferStatusRepository.InsertFileTransferStatus(
                                 request.FileTransferId,
                                 FileTransferStatus.UploadProcessing,
-                                timestamp: finishedUploadTimestamp,
+                                timestamp: request.UploadFinishedTimestamp,
                                 cancellationToken: ct);
                             backgroundJobClient.Enqueue(() => eventBus.Publish(
                                 AltinnEventType.UploadProcessing,
@@ -185,7 +184,7 @@ public class CompleteFileUploadHandler(
                     {
                         await fileTransferPublishService.TryPublishAsync(
                             fileTransfer,
-                            finishedUploadTimestamp,
+                            DateTimeOffset.UtcNow,
                             ct);
                     }
 

--- a/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadRequest.cs
+++ b/src/Altinn.Broker.Application/UploadFile/CompleteFileUploadRequest.cs
@@ -6,4 +6,5 @@ public class CompleteFileUploadRequest
     public string? Checksum { get; set; }
     public long UploadLength { get; set; }
     public bool DeferChecksumValidation { get; set; }
+    public DateTimeOffset UploadFinishedTimestamp { get; set; }
 }

--- a/src/Altinn.Broker.Application/UploadFile/Tus/TusUploadCompleteHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/Tus/TusUploadCompleteHandler.cs
@@ -76,6 +76,7 @@ public class TusUploadCompleteHandler(
         }
 
         var (checksum, uploadLength) = finalizeResult.Value;
+        var uploadFinishedTimeStamp = DateTime.UtcNow;
         logger.LogInformation(
             "TUS storage finalized for file transfer {FileTransferId}. UploadLength={UploadLength} ChecksumPresent={ChecksumPresent}",
             fileTransferId,
@@ -88,7 +89,8 @@ public class TusUploadCompleteHandler(
                 FileTransferId = fileTransferId,
                 Checksum = checksum,
                 UploadLength = uploadLength,
-                DeferChecksumValidation = true
+                DeferChecksumValidation = true,
+                UploadFinishedTimestamp = uploadFinishedTimeStamp
             },
             user,
             cancellationToken);

--- a/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
+++ b/src/Altinn.Broker.Application/UploadFile/UploadFileHandler.cs
@@ -68,6 +68,7 @@ public class UploadFileHandler(
         try
         {
             var result = await brokerStorageService.UploadFile(serviceOwner, fileTransfer, request.UploadStream, cancellationToken);
+            var finishedUploadTimestamp = DateTime.UtcNow;
             if (result is null)
             {
                 return await TransactionWithRetriesPolicy.Execute(async ct =>
@@ -106,7 +107,8 @@ public class UploadFileHandler(
                 {
                     FileTransferId = request.FileTransferId,
                     Checksum = checksum,
-                    UploadLength = uploadLength
+                    UploadLength = uploadLength,
+                    UploadFinishedTimestamp = finishedUploadTimestamp,
                 },
                 user,
                 cancellationToken);


### PR DESCRIPTION
## Description
Set UploadProcessing timestamp immediately after file has been uploaded to avoid timing issue.

## Related Issue(s)
- #873 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Upload completion times are now recorded immediately after successful file storage.
  * Completion and status updates consistently use the recorded upload-finished timestamp.
  * Publication events continue to use the current UTC time.
  * TUS uploads retain deferred checksum validation while providing more accurate completion timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->