### PR TITLE
Handle mid-upload termination

### DIFF
--- a/src/Altinn.Broker.Application/Errors.cs
+++ b/src/Altinn.Broker.Application/Errors.cs
@@ -35,6 +35,7 @@ public static class Errors
     public static Error RequiredPartyInvalidRecipientConfiguration = new Error(27, "When required party is specified and the required party is not the sender, the number of recipients can only be one.", HttpStatusCode.BadRequest);
     public static Error RecipientNotInAccessList = new Error(28, "All recipients need to be in the access list of the resource.", HttpStatusCode.BadRequest);
     public static Error InvalidByteRange = new Error(29, "The requested byte range is not satisfiable.", HttpStatusCode.RequestedRangeNotSatisfiable);
+    public static Error MalwareScanResultNotReady = new Error(30, "File transfer is not yet in UploadProcessing. Retry when upload completion has been recorded.", HttpStatusCode.ServiceUnavailable);
 }
 
 public static class StatisticsErrors

--- a/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
+++ b/src/Altinn.Broker.Application/MalwareScanResults/MalwareScanResultHandler.cs
@@ -16,6 +16,7 @@ using Altinn.Broker.Core.Services.Enums;
 
 using Hangfire;
 
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 using OneOf;
@@ -31,7 +32,8 @@ public class MalwareScanningResultHandler(
     IBrokerStorageService brokerStorageService,
     FileTransferPublishService fileTransferPublishService,
     ILogger<MalwareScanningResultHandler> logger,
-    IBackgroundJobClient backgroundJobClient) : IHandler<ScanResultData, Task>
+    IBackgroundJobClient backgroundJobClient,
+    IHostEnvironment hostEnvironment) : IHandler<ScanResultData, Task>
 {
     public async Task<OneOf<Task, Error>> Process(ScanResultData data, ClaimsPrincipal? user, CancellationToken cancellationToken)
     {
@@ -56,9 +58,31 @@ public class MalwareScanningResultHandler(
         {
             throw new Exception("Service owner not found");
         }
-        if (fileTransfer.FileTransferStatusEntity.Status == FileTransferStatus.Failed)
+
+        var status = fileTransfer.FileTransferStatusEntity.Status;
+        if (status == FileTransferStatus.Failed)
         {
-            logger.LogWarning("Received malware scan result for file transfer {fileTransferId} with status {status}, expected status UploadProcessing. Ignoring the result.", fileTransferId, fileTransfer.FileTransferStatusEntity.Status);
+            logger.LogWarning(
+                "Received malware scan result for file transfer {fileTransferId} with status {status}. Ignoring the result.",
+                fileTransferId,
+                status);
+            return Task.CompletedTask;
+        }
+
+        if (status == FileTransferStatus.UploadStarted && !hostEnvironment.IsDevelopment())
+        {
+            logger.LogInformation(
+                "Malware scan result for file transfer {fileTransferId} arrived while status is UploadStarted. Requesting retry until UploadProcessing is set.",
+                fileTransferId);
+            return Errors.MalwareScanResultNotReady;
+        }
+
+        if (status != FileTransferStatus.UploadProcessing && !hostEnvironment.IsDevelopment())
+        {
+            logger.LogWarning(
+                "Received malware scan result for file transfer {fileTransferId} with status {status}, expected status UploadProcessing. Ignoring the result.",
+                fileTransferId,
+                status);
             return Task.CompletedTask;
         }
 

--- a/tests/Altinn.Broker.Tests/MalwareScanningResultHandlerTests.cs
+++ b/tests/Altinn.Broker.Tests/MalwareScanningResultHandlerTests.cs
@@ -270,6 +270,38 @@ public class MalwareScanningResultHandlerTests
     }
 
     [Fact]
+    public async Task Process_WhenUploadStartedInDevelopment_ProcessesAndClaimsIdempotency()
+    {
+        var fileTransfer = CreateFileTransfer(FileTransferStatus.UploadStarted);
+        var (handler, idempotencyRepository, fileTransferRepository, resourceRepository, serviceOwnerRepository) =
+            CreateProcessHandler(isDevelopment: true);
+
+        fileTransferRepository
+            .Setup(r => r.GetFileTransfer(fileTransfer.FileTransferId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fileTransfer);
+        resourceRepository
+            .Setup(r => r.GetResource(fileTransfer.ResourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ResourceEntity { Id = fileTransfer.ResourceId, ServiceOwnerId = "test-owner" });
+        serviceOwnerRepository
+            .Setup(r => r.GetServiceOwner("test-owner"))
+            .ReturnsAsync(new ServiceOwnerEntity { Id = "test-owner", Name = "Test Owner", StorageProviders = [] });
+        idempotencyRepository
+            .Setup(r => r.TryAddIdempotencyEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Malicious result avoids a second TryAdd from publish, so we can assert exactly one claim.
+        var scanResult = CreateScanResult(fileTransfer.FileTransferId);
+        scanResult.ScanResultType = "Malicious";
+
+        var result = await handler.Process(scanResult, null, CancellationToken.None);
+
+        Assert.True(result.IsT0);
+        idempotencyRepository.Verify(
+            r => r.TryAddIdempotencyEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task Process_WhenFailed_IgnoresWithoutClaimingIdempotency()
     {
         var fileTransfer = CreateFileTransfer(FileTransferStatus.Failed);
@@ -369,6 +401,19 @@ public class MalwareScanningResultHandlerTests
         var serviceOwnerRepository = new Mock<IServiceOwnerRepository>();
         var brokerStorageService = new Mock<IBrokerStorageService>();
         var backgroundJobClient = new Mock<IBackgroundJobClient>();
+
+        statusRepository
+            .Setup(r => r.InsertFileTransferStatus(
+                It.IsAny<Guid>(),
+                It.IsAny<FileTransferStatus>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        backgroundJobClient
+            .Setup(c => c.Create(It.IsAny<Job>(), It.IsAny<IState>()))
+            .Returns("job-id");
 
         var handler = CreateHandler(
             statusRepository,

--- a/tests/Altinn.Broker.Tests/MalwareScanningResultHandlerTests.cs
+++ b/tests/Altinn.Broker.Tests/MalwareScanningResultHandlerTests.cs
@@ -12,6 +12,7 @@ using Hangfire;
 using Hangfire.Common;
 using Hangfire.States;
 
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 using Moq;
@@ -242,6 +243,82 @@ public class MalwareScanningResultHandlerTests
         resourceRepository.Verify(r => r.GetResource(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task Process_WhenUploadStartedOutsideDevelopment_ReturnsServiceUnavailableWithoutClaimingIdempotency()
+    {
+        var fileTransfer = CreateFileTransfer(FileTransferStatus.UploadStarted);
+        var (handler, idempotencyRepository, fileTransferRepository, resourceRepository, serviceOwnerRepository) =
+            CreateProcessHandler(isDevelopment: false);
+
+        fileTransferRepository
+            .Setup(r => r.GetFileTransfer(fileTransfer.FileTransferId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fileTransfer);
+        resourceRepository
+            .Setup(r => r.GetResource(fileTransfer.ResourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ResourceEntity { Id = fileTransfer.ResourceId, ServiceOwnerId = "test-owner" });
+        serviceOwnerRepository
+            .Setup(r => r.GetServiceOwner("test-owner"))
+            .ReturnsAsync(new ServiceOwnerEntity { Id = "test-owner", Name = "Test Owner", StorageProviders = [] });
+
+        var result = await handler.Process(CreateScanResult(fileTransfer.FileTransferId), null, CancellationToken.None);
+
+        Assert.True(result.IsT1);
+        Assert.Equal(Errors.MalwareScanResultNotReady, result.AsT1);
+        idempotencyRepository.Verify(
+            r => r.TryAddIdempotencyEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenFailed_IgnoresWithoutClaimingIdempotency()
+    {
+        var fileTransfer = CreateFileTransfer(FileTransferStatus.Failed);
+        var (handler, idempotencyRepository, fileTransferRepository, resourceRepository, serviceOwnerRepository) =
+            CreateProcessHandler(isDevelopment: false);
+
+        fileTransferRepository
+            .Setup(r => r.GetFileTransfer(fileTransfer.FileTransferId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fileTransfer);
+        resourceRepository
+            .Setup(r => r.GetResource(fileTransfer.ResourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ResourceEntity { Id = fileTransfer.ResourceId, ServiceOwnerId = "test-owner" });
+        serviceOwnerRepository
+            .Setup(r => r.GetServiceOwner("test-owner"))
+            .ReturnsAsync(new ServiceOwnerEntity { Id = "test-owner", Name = "Test Owner", StorageProviders = [] });
+
+        var result = await handler.Process(CreateScanResult(fileTransfer.FileTransferId), null, CancellationToken.None);
+
+        Assert.True(result.IsT0);
+        idempotencyRepository.Verify(
+            r => r.TryAddIdempotencyEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Process_WhenPublishedOutsideDevelopment_IgnoresWithoutClaimingIdempotency()
+    {
+        var fileTransfer = CreateFileTransfer(FileTransferStatus.Published);
+        var (handler, idempotencyRepository, fileTransferRepository, resourceRepository, serviceOwnerRepository) =
+            CreateProcessHandler(isDevelopment: false);
+
+        fileTransferRepository
+            .Setup(r => r.GetFileTransfer(fileTransfer.FileTransferId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fileTransfer);
+        resourceRepository
+            .Setup(r => r.GetResource(fileTransfer.ResourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ResourceEntity { Id = fileTransfer.ResourceId, ServiceOwnerId = "test-owner" });
+        serviceOwnerRepository
+            .Setup(r => r.GetServiceOwner("test-owner"))
+            .ReturnsAsync(new ServiceOwnerEntity { Id = "test-owner", Name = "Test Owner", StorageProviders = [] });
+
+        var result = await handler.Process(CreateScanResult(fileTransfer.FileTransferId), null, CancellationToken.None);
+
+        Assert.True(result.IsT0);
+        idempotencyRepository.Verify(
+            r => r.TryAddIdempotencyEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     private static MalwareScanningResultHandler CreateHandler(
         Mock<IFileTransferStatusRepository> statusRepository,
         Mock<IFileTransferRepository> fileTransferRepository,
@@ -249,7 +326,8 @@ public class MalwareScanningResultHandlerTests
         Mock<IResourceRepository> resourceRepository,
         Mock<IServiceOwnerRepository> serviceOwnerRepository,
         Mock<IBrokerStorageService> brokerStorageService,
-        Mock<IBackgroundJobClient> backgroundJobClient)
+        Mock<IBackgroundJobClient> backgroundJobClient,
+        bool isDevelopment = true)
     {
         var eventBus = new Mock<IEventBus>();
         var eventBusMiddleware = new EventBusMiddleware(eventBus.Object);
@@ -259,6 +337,8 @@ public class MalwareScanningResultHandlerTests
             backgroundJobClient.Object,
             eventBusMiddleware,
             new Mock<ILogger<FileTransferPublishService>>().Object);
+        var hostEnvironment = new Mock<IHostEnvironment>();
+        hostEnvironment.Setup(e => e.EnvironmentName).Returns(isDevelopment ? Environments.Development : Environments.Production);
 
         return new MalwareScanningResultHandler(
             statusRepository.Object,
@@ -270,10 +350,54 @@ public class MalwareScanningResultHandlerTests
             brokerStorageService.Object,
             publishService,
             new Mock<ILogger<MalwareScanningResultHandler>>().Object,
-            backgroundJobClient.Object);
+            backgroundJobClient.Object,
+            hostEnvironment.Object);
     }
 
-    private static FileTransferEntity CreateFileTransfer()
+    private static (
+        MalwareScanningResultHandler Handler,
+        Mock<IIdempotencyEventRepository> IdempotencyRepository,
+        Mock<IFileTransferRepository> FileTransferRepository,
+        Mock<IResourceRepository> ResourceRepository,
+        Mock<IServiceOwnerRepository> ServiceOwnerRepository)
+        CreateProcessHandler(bool isDevelopment)
+    {
+        var statusRepository = new Mock<IFileTransferStatusRepository>();
+        var fileTransferRepository = new Mock<IFileTransferRepository>();
+        var idempotencyRepository = new Mock<IIdempotencyEventRepository>();
+        var resourceRepository = new Mock<IResourceRepository>();
+        var serviceOwnerRepository = new Mock<IServiceOwnerRepository>();
+        var brokerStorageService = new Mock<IBrokerStorageService>();
+        var backgroundJobClient = new Mock<IBackgroundJobClient>();
+
+        var handler = CreateHandler(
+            statusRepository,
+            fileTransferRepository,
+            idempotencyRepository,
+            resourceRepository,
+            serviceOwnerRepository,
+            brokerStorageService,
+            backgroundJobClient,
+            isDevelopment);
+
+        return (handler, idempotencyRepository, fileTransferRepository, resourceRepository, serviceOwnerRepository);
+    }
+
+    private static ScanResultData CreateScanResult(Guid fileTransferId) => new()
+    {
+        BlobUri = $"https://storage.blob.core.windows.net/brokerfiles/{fileTransferId}",
+        CorrelationId = Guid.NewGuid(),
+        ETag = "etag",
+        ScanFinishedTimeUtc = DateTime.UtcNow,
+        ScanResultDetails = new ScanResultDetails
+        {
+            MalwareNamesFound = [],
+            Sha256 = "sha256"
+        },
+        ScanResultType = "No threats found"
+    };
+
+    private static FileTransferEntity CreateFileTransfer(FileTransferStatus status = FileTransferStatus.Published)
     {
         var fileTransferId = Guid.NewGuid();
         return new FileTransferEntity
@@ -298,7 +422,7 @@ public class MalwareScanningResultHandlerTests
             {
                 FileTransferId = fileTransferId,
                 Date = DateTime.UtcNow,
-                Status = FileTransferStatus.Published
+                Status = status
             }
         };
     }


### PR DESCRIPTION
## Description
Malwarescan may arrive sooner than UploadProcessing code, or upload may be terminated before UploadProcessing can be set. Do not accept these as UploadProcessing events have not been published.

## Related Issue(s)
- #935 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malware scan results when uploads are still starting or have already failed.
  * Added a temporary-unavailable response for scan results that are not yet ready, allowing processing to be retried.
  * Prevented processing of scan results for transfers in unsupported states.
* **Tests**
  * Added coverage for scan results across starting, failed, and completed transfer states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->