### PR TITLE
Return bad request for invalid recipients (#975)

### DIFF
--- a/src/Altinn.Broker.API/Controllers/FileTransferController.cs
+++ b/src/Altinn.Broker.API/Controllers/FileTransferController.cs
@@ -37,6 +37,7 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
     /// <response code="400"><ul>
     /// <li>Service owner needs to be configured to use the broker API</li>
     /// <li>In order to use file transfers without virus scan the service resource needs to be approved by Altinn. Please contact us @ Slack</li>
+    /// <li>One or more recipients are invalid or could not be found</li>
     /// </ul></response>
     /// <response code="401">You must use a bearer token that represents a system user with access to the resource in the Resource Rights Registry</response>
     /// <response code="403">The resource needs to be registered as an Altinn 3 resource and it has to be associated with a service owner</response>
@@ -131,6 +132,7 @@ public class FileTransferController(ILogger<FileTransferController> logger) : Co
     /// <response code="400"><ul>
     /// <li>Service owner needs to be configured to use the broker API</li>
     /// <li>In order to use file transfers without virus scan the service resource needs to be approved by Altinn. Please contact us @ Slack</li>
+    /// <li>One or more recipients are invalid or could not be found</li>
     /// </ul></response>
     /// <response code="401">You must use a bearer token that represents a system user with access to the resource in the Resource Rights Registry</response>
     /// <response code="403">The resource needs to be registered as an Altinn 3 resource and it has to be associated with a service owner</response>

--- a/src/Altinn.Broker.Application/Errors.cs
+++ b/src/Altinn.Broker.Application/Errors.cs
@@ -36,6 +36,7 @@ public static class Errors
     public static Error RecipientNotInAccessList = new Error(28, "All recipients need to be in the access list of the resource.", HttpStatusCode.BadRequest);
     public static Error InvalidByteRange = new Error(29, "The requested byte range is not satisfiable.", HttpStatusCode.RequestedRangeNotSatisfiable);
     public static Error MalwareScanResultNotReady = new Error(30, "File transfer is not yet in UploadProcessing. Retry when upload completion has been recorded.", HttpStatusCode.ServiceUnavailable);
+    public static Error InvalidRecipient = new Error(31, "One or more recipients are invalid or could not be found.", HttpStatusCode.BadRequest);
 }
 
 public static class StatisticsErrors

--- a/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
+++ b/src/Altinn.Broker.Application/InitializeFileTransfer/InitializeFileTransferHandler.cs
@@ -95,7 +95,12 @@ public class InitializeFileTransferHandler(
             foreach (var recipient in request.RecipientExternalIds)
             {
                 var accessList = await altinnResourceRepository.GetAccessListOfResource(request.ResourceId, recipient.WithoutPrefix(), cancellationToken);
-                if (accessList is null || accessList.Count == 0)
+                if (accessList is null)
+                {
+                    return Errors.InvalidRecipient;
+                }
+
+                if (accessList.Count == 0)
                 {
                     return Errors.RecipientNotInAccessList;
                 }
@@ -156,4 +161,3 @@ public class InitializeFileTransferHandler(
         }, logger, cancellationToken);
     }
 }
-

--- a/src/Altinn.Broker.Core/Repositories/IAltinnResourceRepoistory.cs
+++ b/src/Altinn.Broker.Core/Repositories/IAltinnResourceRepoistory.cs
@@ -11,5 +11,12 @@ public interface IAltinnResourceRepository
     /// </summary>
     Task<string?> GetServiceOwnerNameOfResource(string resourceId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Gets access-list memberships for a party and resource.
+    /// </summary>
+    /// <returns>
+    /// The memberships, an empty list when the party has no membership, or <see langword="null"/>
+    /// when the party is invalid or cannot be found.
+    /// </returns>
     Task<List<string>?> GetAccessListOfResource(string resourceId, string party, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.Broker.Integrations/Altinn/ResourceRegistry/AltinnResourceRegistryRepository.cs
+++ b/src/Altinn.Broker.Integrations/Altinn/ResourceRegistry/AltinnResourceRegistryRepository.cs
@@ -92,7 +92,8 @@ public class AltinnResourceRegistryRepository : IAltinnResourceRepository
         var response = await _client.GetAsync(url, cancellationToken);
         return response.StatusCode switch
         {
-            HttpStatusCode.NotFound or HttpStatusCode.NoContent => null,
+            // Resource Registry returns 400 when the party URN is invalid or cannot be resolved.
+            HttpStatusCode.BadRequest or HttpStatusCode.NotFound or HttpStatusCode.NoContent => null,
             HttpStatusCode.OK => (await response.Content.ReadFromJsonAsync<AccessListMembershipResponse>(cancellationToken: cancellationToken))
                 ?.Data
                 ?.Select(m => m.Party?.Split(":").Last())

--- a/tests/Altinn.Broker.Tests/AltinnResourceRegistryRepositoryTests.cs
+++ b/tests/Altinn.Broker.Tests/AltinnResourceRegistryRepositoryTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Altinn.Broker.Core.Options;
+using Altinn.Broker.Integrations.Altinn.ResourceRegistry;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Xunit;
+
+namespace Altinn.Broker.Tests;
+
+public class AltinnResourceRegistryRepositoryTests
+{
+    [Fact]
+    public async Task GetAccessListOfResource_ValidPartyWithoutMembership_ReturnsEmptyList()
+    {
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new { data = Array.Empty<object>() })
+            }));
+        var repository = CreateRepository(httpClient);
+
+        var result = await repository.GetAccessListOfResource("test-resource", "986252932");
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAccessListOfResource_InvalidParty_ReturnsNull()
+    {
+        Uri? requestUri = null;
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(request =>
+        {
+            requestUri = request.RequestUri;
+            return new HttpResponseMessage(HttpStatusCode.BadRequest);
+        }));
+        var repository = CreateRepository(httpClient);
+
+        var result = await repository.GetAccessListOfResource("test-resource", "111111111");
+
+        Assert.Null(result);
+        Assert.Equal(
+            "/resourceregistry/api/v1/access-lists/memberships?resource=urn:altinn:resource:test-resource&party=urn:altinn:organization:identifier-no:111111111",
+            requestUri?.PathAndQuery);
+    }
+
+    [Fact]
+    public async Task GetAccessListOfResource_UpstreamFailure_Throws()
+    {
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.InternalServerError)));
+        var repository = CreateRepository(httpClient);
+
+        await Assert.ThrowsAsync<BadHttpRequestException>(() =>
+            repository.GetAccessListOfResource("test-resource", "991825827"));
+    }
+
+    private static AltinnResourceRegistryRepository CreateRepository(HttpClient httpClient)
+    {
+        var options = Options.Create(new AltinnOptions
+        {
+            PlatformGatewayUrl = "https://platform.example/"
+        });
+
+        return new AltinnResourceRegistryRepository(
+            httpClient,
+            options,
+            NullLogger<AltinnResourceRegistryRepository>.Instance);
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(handler(request));
+        }
+    }
+}

--- a/tests/Altinn.Broker.Tests/FileTransferControllerTests.cs
+++ b/tests/Altinn.Broker.Tests/FileTransferControllerTests.cs
@@ -1423,8 +1423,8 @@ public class FileTransferControllerTests : IClassFixture<CustomWebApplicationFac
     }
 
     [Theory]
-    [InlineData("0192:999999999")]
-    [InlineData(UrnConstants.OrganizationNumberAttribute + ":999999999")]
+    [InlineData("0192:986252932")]
+    [InlineData(UrnConstants.OrganizationNumberAttribute + ":986252932")]
     public async Task InitializeFileTransfer_WithRecipientNotInAccessList_ReturnsBadRequest(string recipient)
     {
         // Arrange
@@ -1439,6 +1439,50 @@ public class FileTransferControllerTests : IClassFixture<CustomWebApplicationFac
         var parsedError = await initializeFileTransferResponse.Content.ReadFromJsonAsync<ProblemDetails>();
         Assert.NotNull(parsedError);
         Assert.Equal(Errors.RecipientNotInAccessList.Message, parsedError.Detail);
+    }
+
+    [Theory]
+    [InlineData("0192:111111111")]
+    [InlineData(UrnConstants.OrganizationNumberAttribute + ":111111111")]
+    public async Task InitializeFileTransfer_WithInvalidRecipient_ReturnsBadRequest(string recipient)
+    {
+        // Arrange
+        var file = FileTransferInitializeExtTestFactory.BasicFileTransfer_With_AccessList_Resource_And_No_Recipients();
+        file.Recipients.Add(recipient);
+
+        // Act
+        var initializeFileTransferResponse = await _senderClient.PostAsJsonAsync("broker/api/v1/filetransfer", file);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, initializeFileTransferResponse.StatusCode);
+        var parsedError = await initializeFileTransferResponse.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(parsedError);
+        Assert.Equal((int)HttpStatusCode.BadRequest, parsedError.Status);
+        Assert.Equal("Bad Request", parsedError.Title);
+        Assert.Equal(Errors.InvalidRecipient.Message, parsedError.Detail);
+        Assert.Equal("BRO-00031", parsedError.Extensions["code"]?.ToString());
+        Assert.False(parsedError.Extensions.ContainsKey("exceptionType"));
+        Assert.False(parsedError.Extensions.ContainsKey("stackTrace"));
+    }
+
+    [Theory]
+    [InlineData("0192:311764837", "0192:111111111")]
+    [InlineData(UrnConstants.OrganizationNumberAttribute + ":311764837", UrnConstants.OrganizationNumberAttribute + ":111111111")]
+    public async Task InitializeFileTransfer_WithInvalidRecipientAmongMultipleRecipients_ReturnsBadRequest(string validRecipient, string invalidRecipient)
+    {
+        // Arrange
+        var file = FileTransferInitializeExtTestFactory.BasicFileTransfer_With_AccessList_Resource_And_No_Recipients();
+        file.Recipients.Add(validRecipient);
+        file.Recipients.Add(invalidRecipient);
+
+        // Act
+        var initializeFileTransferResponse = await _senderClient.PostAsJsonAsync("broker/api/v1/filetransfer", file);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, initializeFileTransferResponse.StatusCode);
+        var parsedError = await initializeFileTransferResponse.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(parsedError);
+        Assert.Equal(Errors.InvalidRecipient.Message, parsedError.Detail);
     }
 
     [Theory]
@@ -1462,8 +1506,8 @@ public class FileTransferControllerTests : IClassFixture<CustomWebApplicationFac
     }
 
     [Theory]
-    [InlineData("0192:311764837", "0192:999999999")]
-    [InlineData(UrnConstants.OrganizationNumberAttribute + ":311764837", UrnConstants.OrganizationNumberAttribute + ":999999999")]
+    [InlineData("0192:311764837", "0192:986252932")]
+    [InlineData(UrnConstants.OrganizationNumberAttribute + ":311764837", UrnConstants.OrganizationNumberAttribute + ":986252932")]
     public async Task InitializeFileTransfer_WithNotAllRecipientsInAccessList_ReturnsBadRequest(string recipientInAccessList, string recipientNotInAccessList)
     {
         // Arrange

--- a/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
+++ b/tests/Altinn.Broker.Tests/Helpers/CustomWebApplicationFactory.cs
@@ -52,6 +52,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
             configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 { "GeneralSettings:SimulateMalwareScan", EnableMalwareScanSimulation.ToString().ToLower() },
+                { "GeneralSettings:SlackUrl", string.Empty },
                 { "DistributedCacheOptions:RedisConnectionString", string.Empty },
             });
         });
@@ -195,6 +196,8 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                 });
             altinnResourceRepository.Setup(x => x.GetAccessListOfResource(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((List<string>?)null);
+            altinnResourceRepository.Setup(x => x.GetAccessListOfResource(It.Is(TestConstants.RESOURCE_WITH_ACCESS_LIST, StringComparer.Ordinal), It.Is("986252932", StringComparer.Ordinal), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<string>());
             altinnResourceRepository.Setup(x => x.GetAccessListOfResource(It.Is(TestConstants.RESOURCE_WITH_ACCESS_LIST, StringComparer.Ordinal), It.Is("311764837", StringComparer.Ordinal), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<string> { "gl908ae2-ci9f-481m-9700-1t7brok12345" });
             services.AddSingleton(altinnResourceRepository.Object);

--- a/tests/Altinn.Broker.Tests/InitializeAndUploadFormDataTests.cs
+++ b/tests/Altinn.Broker.Tests/InitializeAndUploadFormDataTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 
 using Altinn.Broker.API.Models;
+using Altinn.Broker.Application;
 using Altinn.Broker.Enums;
 using Altinn.Broker.Models;
 using Altinn.Broker.Tests.Helpers;
@@ -96,6 +97,29 @@ public class InitializeAndUploadFormDataTests : IClassFixture<CustomWebApplicati
     }
 
     [Fact]
+    public async Task InitializeAndUpload_InvalidRecipient_Returns400()
+    {
+        var metadata = new FileTransferInitalizeExt
+        {
+            FileName = "test.txt",
+            ResourceId = TestConstants.RESOURCE_WITH_ACCESS_LIST,
+            Sender = "0192:991825827",
+            Recipients = new List<string> { "0192:111111111" },
+            SendersFileTransferReference = "123",
+            PropertyList = new Dictionary<string, string>()
+        };
+
+        var multipart = CreateMultipartFormData(metadata, "hello world");
+
+        var response = await _senderClient.PostAsync("broker/api/v1/filetransfer/upload", multipart);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>(_jsonOptions);
+        Assert.NotNull(problem);
+        Assert.Equal(Errors.InvalidRecipient.Message, problem.Detail);
+    }
+
+    [Fact]
     public async Task InitializeAndUpload_MissingFile_Returns400()
     {
         var metadata = new FileTransferInitalizeExt
@@ -173,5 +197,4 @@ public class InitializeAndUploadFormDataTests : IClassFixture<CustomWebApplicati
         return multipart;
     }
 }
-
 

--- a/tests/Altinn.Broker.Tests/InitializeFileTransferHandlerTests.cs
+++ b/tests/Altinn.Broker.Tests/InitializeFileTransferHandlerTests.cs
@@ -1,0 +1,120 @@
+using Altinn.Broker.Application;
+using Altinn.Broker.Application.InitializeFileTransfer;
+using Altinn.Broker.Application.Middlewares;
+using Altinn.Broker.Core.Domain;
+using Altinn.Broker.Core.Repositories;
+using Altinn.Broker.Core.Services;
+
+using Hangfire;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using Xunit;
+
+namespace Altinn.Broker.Tests;
+
+public class InitializeFileTransferHandlerTests
+{
+    [Fact]
+    public async Task Process_InvalidRecipient_ReturnsBadRequestError()
+    {
+        const string resourceId = "access-list-resource";
+        var resource = new ResourceEntity
+        {
+            Id = resourceId,
+            ServiceOwnerId = "0192:991825827"
+        };
+        var altinnResource = new ResourceEntity
+        {
+            Id = resourceId,
+            ServiceOwnerId = "0192:991825827",
+            AccessListEnabled = true
+        };
+
+        var resourceRepository = new Mock<IResourceRepository>();
+        resourceRepository
+            .Setup(repository => repository.GetResource(resourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resource);
+
+        var altinnResourceRepository = new Mock<IAltinnResourceRepository>();
+        altinnResourceRepository
+            .Setup(repository => repository.GetResource(resourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(altinnResource);
+        altinnResourceRepository
+            .Setup(repository => repository.GetAccessListOfResource(resourceId, "111111111", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<string>?)null);
+
+        var serviceOwnerRepository = new Mock<IServiceOwnerRepository>();
+        serviceOwnerRepository
+            .Setup(repository => repository.GetServiceOwner(resource.ServiceOwnerId))
+            .ReturnsAsync(new ServiceOwnerEntity
+            {
+                Id = resource.ServiceOwnerId,
+                Name = "Test owner",
+                StorageProviders =
+                [
+                    new StorageProviderEntity
+                    {
+                        Type = StorageProviderType.Altinn3Azure,
+                        ResourceName = "test-storage",
+                        ServiceOwnerId = resource.ServiceOwnerId,
+                        Active = true
+                    }
+                ]
+            });
+
+        var authorizationService = new Mock<IAuthorizationService>();
+        authorizationService
+            .Setup(service => service.CheckAccessAsSender(null, resourceId, "0192:991825827", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var hostEnvironment = new Mock<IHostEnvironment>();
+        hostEnvironment.SetupGet(environment => environment.EnvironmentName).Returns(Environments.Development);
+
+        var fileTransferRepository = new Mock<IFileTransferRepository>();
+        var eventBus = new EventBusMiddleware(new Mock<IEventBus>().Object);
+        var handler = new InitializeFileTransferHandler(
+            resourceRepository.Object,
+            altinnResourceRepository.Object,
+            serviceOwnerRepository.Object,
+            authorizationService.Object,
+            fileTransferRepository.Object,
+            new Mock<IFileTransferStatusRepository>().Object,
+            new Mock<IActorFileTransferStatusRepository>().Object,
+            new Mock<IBackgroundJobClient>().Object,
+            eventBus,
+            hostEnvironment.Object,
+            new Mock<IAltinnRegisterService>().Object,
+            NullLogger<InitializeFileTransferHandler>.Instance);
+
+        var result = await handler.Process(new InitializeFileTransferRequest
+        {
+            ResourceId = resourceId,
+            FileName = "test.txt",
+            SendersFileTransferReference = "reference",
+            SenderExternalId = "0192:991825827",
+            RecipientExternalIds = ["0192:111111111"],
+            PropertyList = new Dictionary<string, string>()
+        }, null, CancellationToken.None);
+
+        Assert.True(result.IsT1);
+        Assert.Equal(Errors.InvalidRecipient, result.AsT1);
+        fileTransferRepository.Verify(
+            repository => repository.AddFileTransfer(
+                It.IsAny<ResourceEntity>(),
+                It.IsAny<StorageProviderEntity>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<List<string>>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<string?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #975 by returning 400 Bad Request with BRO-00031 when a recipient is invalid or cannot be found, instead of returning 500 Internal Server Error.
Valid recipients without access-list membership continue to return BRO-00028.

## Related Issue(s)
- #975 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [x] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)