### PR TITLE
Fixed naming of IdPortenDirectAuthSettings

### DIFF
--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -72,10 +72,10 @@ var containerAppEnvVars = concat([
   { name: 'AltinnOptions__PlatformSubscriptionKey', secretRef: 'platform-subscription-key' }
   { name: 'MaskinportenSettings__Environment', value: maskinporten_environment } 
   { name: 'MaskinportenSettings__ClientId', secretRef: 'maskinporten-client-id' }
-  { name: 'IdPortenSettings__ClientId', secretRef: 'idporten-client-id' }
-  { name: 'IdPortenSettings__ClientSecret', secretRef: 'idporten-client-secret' }
-  { name: 'IdPortenSettings__Authority', value: idporten_authority }
-  { name: 'IdPortenSettings__SpaBaseUrl', value: frontend_base_url }
+  { name: 'IdPortenDirectAuthSettings__ClientId', secretRef: 'idporten-client-id' }
+  { name: 'IdPortenDirectAuthSettings__ClientSecret', secretRef: 'idporten-client-secret' }
+  { name: 'IdPortenDirectAuthSettings__Authority', value: idporten_authority }
+  { name: 'IdPortenDirectAuthSettings__SpaBaseUrl', value: frontend_base_url }
   {
     name: 'MaskinportenSettings__Scope'
     value: 'altinn:events.publish altinn:events.publish.admin altinn:register/partylookup.admin altinn:serviceowner altinn:authorization/authorize.admin altinn:resourceregistry/resource.admin'

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -87,7 +87,7 @@ This mirrors how other `*.ui.altinn.no` apps reuse the shared Altinn session.
 
 Settings live in the Broker API (`appsettings.json`, `appsettings.Development.json`, or environment variables).
 
-### `IdPortenSettings` (IdPortenDirectAuth)
+### `IdPortenDirectAuthSettings` (IdPortenDirectAuth)
 
 Used for direct ID-Porten login. Section name is unchanged for existing deployments.
 
@@ -104,15 +104,15 @@ Fixed in code (not configurable): callback `/broker/api/v1/authentication/callba
 
 **Deploy environment variables** (Container App):
 
-- `IdPortenSettings__Authority` ← `IDPORTEN_AUTHORITY`
-- `IdPortenSettings__ClientId` ← Key Vault
-- `IdPortenSettings__ClientSecret` ← Key Vault
-- `IdPortenSettings__SpaBaseUrl` ← `FRONTEND_BASE_URL`
+- `IdPortenDirectAuthSettings__Authority` ← `IDPORTEN_AUTHORITY`
+- `IdPortenDirectAuthSettings__ClientId` ← Key Vault
+- `IdPortenDirectAuthSettings__ClientSecret` ← Key Vault
+- `IdPortenDirectAuthSettings__SpaBaseUrl` ← `FRONTEND_BASE_URL`
 
 **Local Development example** (`appsettings.local.json`):
 
 ```json
-"IdPortenSettings": {
+"IdPortenDirectAuthSettings": {
   "Authority": "https://test.idporten.no",
   "ClientId": "<from Samarbeidsportalen>",
   "ClientSecret": "<from Samarbeidsportalen>",
@@ -160,7 +160,7 @@ In Azure, Front Door can proxy API and SPA on one origin:
 
 1. Set GitHub secret `API_ORIGIN_HOST_NAME` to the APIM host (e.g. `altinn-dev-api.azure-api.net`)
 2. Leave `VITE_API_BASE_URL` empty so the SPA uses same-origin `/broker/...` URLs
-3. Set `FRONTEND_BASE_URL` → `IdPortenSettings__SpaBaseUrl` (Front Door URL from the deploy log)
+3. Set `FRONTEND_BASE_URL` → `IdPortenDirectAuthSettings__SpaBaseUrl` (Front Door URL from the deploy log)
 4. Register ID-Porten redirect URI: `https://<front-door-host>/broker/api/v1/authentication/callback`
 
 Front Door endpoint names are globally unique. The name is derived from `AZURE_NAME_PREFIX`. After deploy, use the hostname printed in the workflow log for `FRONTEND_BASE_URL` and ID-Porten.

--- a/src/Altinn.Broker.API/Altinn.Broker.API.csproj
+++ b/src/Altinn.Broker.API/Altinn.Broker.API.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.7.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.10" />

--- a/src/Altinn.Broker.API/IdPortenDirectAuth/DependencyInjection.cs
+++ b/src/Altinn.Broker.API/IdPortenDirectAuth/DependencyInjection.cs
@@ -20,9 +20,9 @@ public static class DependencyInjection
         IConfiguration configuration)
     {
         var services = builder.Services;
-        services.Configure<IdPortenDirectAuthSettings>(configuration.GetSection(ConfigurationSectionName));
+        services.Configure<IdPortenDirectAuthSettings>(configuration.GetSection(nameof(IdPortenDirectAuthSettings)));
 
-        var settings = configuration.GetSection("IdPortenDirectAuthSettings").Get<IdPortenDirectAuthSettings>()
+        var settings = configuration.GetSection(nameof(IdPortenDirectAuthSettings)).Get<IdPortenDirectAuthSettings>()
             ?? new IdPortenDirectAuthSettings();
 
         services.AddHttpClient<IAltinnTokenExchangeService, AltinnTokenExchangeService>();

--- a/src/Altinn.Broker.API/IdPortenDirectAuth/DependencyInjection.cs
+++ b/src/Altinn.Broker.API/IdPortenDirectAuth/DependencyInjection.cs
@@ -15,11 +15,6 @@ namespace Altinn.Broker.API.IdPortenDirectAuth;
 
 public static class DependencyInjection
 {
-    /// <summary>
-    /// Configuration section name (kept as <c>IdPortenSettings</c> for existing deployments).
-    /// </summary>
-    public const string ConfigurationSectionName = "IdPortenSettings";
-
     public static AuthenticationBuilder AddIdPortenDirectAuth(
         this AuthenticationBuilder builder,
         IConfiguration configuration)
@@ -27,14 +22,14 @@ public static class DependencyInjection
         var services = builder.Services;
         services.Configure<IdPortenDirectAuthSettings>(configuration.GetSection(ConfigurationSectionName));
 
-        var settings = configuration.GetSection(ConfigurationSectionName).Get<IdPortenDirectAuthSettings>()
+        var settings = configuration.GetSection("IdPortenDirectAuthSettings").Get<IdPortenDirectAuthSettings>()
             ?? new IdPortenDirectAuthSettings();
 
         services.AddHttpClient<IAltinnTokenExchangeService, AltinnTokenExchangeService>();
         services.AddSingleton<IConfigurationManager<OpenIdConnectConfiguration>>(sp =>
         {
-            var idPortenSettings = sp.GetRequiredService<IOptions<IdPortenDirectAuthSettings>>().Value;
-            var metadataAddress = $"{idPortenSettings.Authority.TrimEnd('/')}/.well-known/openid-configuration";
+            var idPortenDirectAuthSettings = sp.GetRequiredService<IOptions<IdPortenDirectAuthSettings>>().Value;
+            var metadataAddress = $"{idPortenDirectAuthSettings.Authority.TrimEnd('/')}/.well-known/openid-configuration";
             return new ConfigurationManager<OpenIdConnectConfiguration>(
                 metadataAddress,
                 new OpenIdConnectConfigurationRetriever(),

--- a/src/Altinn.Broker.API/IdPortenDirectAuth/Options/IdPortenDirectAuthSettings.cs
+++ b/src/Altinn.Broker.API/IdPortenDirectAuth/Options/IdPortenDirectAuthSettings.cs
@@ -4,8 +4,6 @@ using Altinn.Broker.API.IdPortenDirectAuth;
 
 /// <summary>
 /// Configuration for direct ID-Porten OIDC login (Broker as confidential client + session cookie).
-/// Bound from the <c>IdPortenSettings</c> configuration section for deployment compatibility.
-/// Paths, ACR, and session lifetime are fixed — see <see cref="IdPortenDirectAuthDefaults"/>.
 /// </summary>
 public class IdPortenDirectAuthSettings
 {

--- a/src/Altinn.Broker.API/Program.cs
+++ b/src/Altinn.Broker.API/Program.cs
@@ -26,6 +26,7 @@ using Hangfire;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -148,16 +149,20 @@ static void ConfigureServices(IServiceCollection services, IConfiguration config
         }
     });
 
-    // Add distributed cache for rate limiting and TUS upload expiration tracking.
+    // Shared Redis for distributed cache, TUS, and ASP.NET Data Protection keys
+    // (OIDC state/correlation cookies must decrypt on any Container App replica).
     var distributedCacheOptions = config.GetSection(DistributedCacheOptions.SectionName).Get<DistributedCacheOptions>();
     if (!string.IsNullOrWhiteSpace(distributedCacheOptions?.RedisConnectionString))
     {
+        var redis = ConnectionMultiplexer.Connect(distributedCacheOptions.RedisConnectionString);
+        services.AddSingleton<IConnectionMultiplexer>(redis);
         services.AddStackExchangeRedisCache(options =>
         {
             options.Configuration = distributedCacheOptions.RedisConnectionString;
         });
-        services.AddSingleton<IConnectionMultiplexer>(_ =>
-            ConnectionMultiplexer.Connect(distributedCacheOptions.RedisConnectionString));
+        services.AddDataProtection()
+            .SetApplicationName("Altinn.Broker.API")
+            .PersistKeysToStackExchangeRedis(redis, "Altinn.Broker.API-DataProtection-Keys");
     }
     else
     {

--- a/src/Altinn.Broker.API/appsettings.Development.json
+++ b/src/Altinn.Broker.API/appsettings.Development.json
@@ -44,11 +44,10 @@
   "DistributedCacheOptions": {
     "RedisConnectionString": "localhost:6379"
   },
-  "IdPortenSettings": {
+  "IdPortenDirectAuthSettings": {
     "Authority": "https://test.idporten.no",
     "ClientId": "",
     "ClientSecret": "",
-    "Scopes": ["openid", "profile", "altinn:portal/enduser"],
     "SpaBaseUrl": "https://localhost:5173"
   },
   "AltinnPlatformAuth": {


### PR DESCRIPTION
## Description
Fixed naming of Settings class and updated it to work with multireplica as in staging.

## Related Issue(s)
- #978 

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [X] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [X] All tests run green
- [X] If pre- or post-deploy actions (including database migrations) are needed, add a description, include a "Pre/Post-deploy actions" section below, and mark the PR title with ⚠️

## Documentation
- [X] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sign-in reliability when requests are handled by different application instances by securely sharing authentication protection keys through Redis.

- **Configuration**
  - Renamed the IdPorten configuration section to `IdPortenDirectAuthSettings` across deployment and development settings.
  - Existing configuration values and secret references remain unchanged; existing deployments are unaffected.

- **Documentation**
  - Updated setup and deployment guidance to reflect the new configuration section name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->